### PR TITLE
chore: add CODEOWNERS and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# CODEOWNERS — https://docs.github.com/articles/about-code-owners
+# Each line maps a path pattern to one or more owners. Last matching line wins.
+# Owners are auto-requested for review on PRs that touch matching paths.
+
+# Default: everything needs mkotulac-markot review
+*                                   @mkotulac-markot
+
+# Workflows, Dependabot, and repo config
+/.github/                           @mkotulac-markot
+
+# Release tooling
+/.changeset/                        @mkotulac-markot
+/package.json                       @mkotulac-markot
+/pnpm-lock.yaml                     @mkotulac-markot
+/turbo.json                         @mkotulac-markot
+
+# Packages
+/packages/core/                     @mkotulac-markot
+/packages/router/                   @mkotulac-markot
+/packages/ssr/                      @mkotulac-markot
+/packages/vite-plugin/              @mkotulac-markot
+/packages/testing/                  @mkotulac-markot
+/packages/devtools/                 @mkotulac-markot
+/packages/sandbox/                  @mkotulac-markot
+/packages/mcp-server/               @mkotulac-markot
+/packages/create-whisq/             @mkotulac-markot
+
+# Docs & brand
+/docs/                              @mkotulac-markot
+/README.md                          @mkotulac-markot
+/CLAUDE.md                          @mkotulac-markot

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+<!--
+Thanks for contributing to Whisq!
+
+Commit/PR title format: `WHISQ-<issue#>: <short description>`
+Target branch: almost always `develop` (release PRs go to `main`).
+-->
+
+## Summary
+
+<!-- One or two sentences explaining WHAT changed and WHY. -->
+
+## Linked issue
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change
+- [ ] Docs / chore / tooling
+- [ ] Security fix
+
+## Affected packages
+
+<!-- Check all that apply. -->
+
+- [ ] `@whisq/core`
+- [ ] `@whisq/router`
+- [ ] `@whisq/ssr`
+- [ ] `@whisq/vite-plugin`
+- [ ] `@whisq/testing`
+- [ ] `@whisq/devtools`
+- [ ] `@whisq/sandbox`
+- [ ] `@whisq/mcp-server`
+- [ ] `create-whisq`
+- [ ] Repo tooling / CI / docs
+
+## Changeset
+
+- [ ] Added a changeset (`pnpm changeset`) — *required for any change to a published package*
+- [ ] Not applicable (docs, CI, tooling only)
+
+## Test plan
+
+<!-- How did you verify this? Commands, browser checks, screenshots, etc. -->
+
+- [ ] `pnpm test` passes
+- [ ] `pnpm build` passes
+- [ ] Manual verification (describe below)
+
+## Checklist
+
+- [ ] PR targets `develop` (or `main` only for release PRs)
+- [ ] Title follows `WHISQ-<issue#>: ...` format
+- [ ] No new TypeScript errors (`pnpm -r typecheck`)
+- [ ] Docs updated if public API changed


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` so review requests on any PR auto-route to @mkotulac-markot. Includes explicit per-package, workflows, docs, and release-tooling entries.
- Adds `.github/PULL_REQUEST_TEMPLATE.md` to standardize PR descriptions (summary, linked issue, type, affected packages, changeset confirmation, test plan, checklist).

## Verification notes (related tasks from this session)
- **Dependabot target branch** — verified ✅. No `.github/dependabot.yml` exists, so only security updates run; they auto-target the repo default branch, which is `develop`. No change needed.
- **README badges** — npm badge resolves correctly; the **CI badge currently shows "repo or workflow not found"** because the repo is still private and shields.io is unauthenticated. It will auto-resolve when the repo goes public. No code change needed now.

## Test plan
- [ ] PR shows @mkotulac-markot auto-requested for review once CODEOWNERS lands on `develop`
- [ ] Opening a new PR pre-fills the template
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)