### PR TITLE
chore: add dependabot.yml (weekly updates, target develop)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# Dependabot configuration — https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# All update PRs target `develop` (the integration branch). Release PRs from
+# develop to main are handled manually.
+
+version: 2
+updates:
+  # npm / pnpm workspace root
+  - package-ecosystem: npm
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Bratislava
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      prod-patch:
+        dependency-type: production
+        update-types:
+          - patch
+    ignore:
+      # Don't churn on major bumps — open those manually with a migration plan.
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+
+  # GitHub Actions workflow pins
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Bratislava
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: chore
+      include: scope


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` enabling weekly version updates (previously only security updates ran via the implicit Dependabot Updates workflow).
- All update PRs explicitly target `develop`, not `main`.
- Groups dev-deps and prod-patch updates to reduce PR churn; ignores major bumps (handle manually with migration plans).
- Covers both `npm` (repo root) and `github-actions` ecosystems.

## Test plan
- [ ] Dependabot picks up the config on next scheduled run (Monday 06:00 Europe/Bratislava)
- [ ] Any PRs it opens target `develop`
- [ ] PRs are labeled `dependencies` (+ `ci` for workflow bumps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)