### PR TITLE
chore: pin CI workflow permissions to contents:read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [develop, main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Defense-in-depth hardening ahead of making the repo public: explicitly scope the CI workflow's `GITHUB_TOKEN` to `contents: read` at the workflow level.

- Repo default is already `read` — this just pins it so any future default change won't silently grant CI more power than it needs.
- `release.yml` already declares broader permissions (`contents: write`, `id-token: write`) at its own workflow level, so it's unaffected.

## Test plan
- [ ] CI workflow still runs successfully on this PR
- [ ] No new permission errors in lint/typecheck/test/audit/license-check/build jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)