### PR TITLE
chore: enforce version consistency across @whisq/* and scaffold templates

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@whisq/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "develop",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,15 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm format --check
 
+  version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/check-versions.mjs
+
   typecheck:
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +86,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test]
+    needs: [lint, version-consistency, typecheck, test]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Lint
         run: pnpm format --check
 
+      - name: Version consistency
+        run: node scripts/check-versions.mjs
+
       - name: Typecheck
         run: pnpm build && pnpm -r exec tsc --noEmit
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "clean": "turbo run clean",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
+    "check:versions": "node scripts/check-versions.mjs",
+    "sync:template-versions": "node scripts/sync-template-versions.mjs",
     "changeset": "changeset",
-    "version": "changeset version",
-    "release": "pnpm build && pnpm test && changeset publish"
+    "version": "changeset version && node scripts/sync-template-versions.mjs",
+    "release": "pnpm build && pnpm test && pnpm check:versions && changeset publish"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Verifies version consistency across the monorepo:
+//   1. Every `@whisq/*` package in `packages/*` shares the same version.
+//   2. Every `@whisq/*` reference inside `packages/create-whisq/src/templates/**/package.json.tmpl`
+//      resolves to that same version. Allowed forms: "X.Y.Z", "^X.Y.Z", "~X.Y.Z", "workspace:*".
+//
+// Exits non-zero on any drift. Run in CI and as a gate inside /release.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const errors = [];
+
+const whisqPackages = readdirSync(join(root, "packages"))
+  .map((dir) => {
+    const pkgPath = join(root, "packages", dir, "package.json");
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+      return { dir, pkgPath, name: pkg.name, version: pkg.version };
+    } catch {
+      return null;
+    }
+  })
+  .filter((p) => p && p.name?.startsWith("@whisq/"));
+
+if (whisqPackages.length === 0) {
+  errors.push("No @whisq/* packages found in packages/*");
+}
+
+const referenceVersion = whisqPackages[0]?.version;
+for (const pkg of whisqPackages) {
+  if (pkg.version !== referenceVersion) {
+    errors.push(
+      `${pkg.name} is ${pkg.version}, expected ${referenceVersion} (matching ${whisqPackages[0].name})`,
+    );
+  }
+}
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) walk(full, out);
+    else if (entry === "package.json.tmpl") out.push(full);
+  }
+  return out;
+}
+
+const templatesDir = join(root, "packages", "create-whisq", "src", "templates");
+let templateFiles = [];
+try {
+  templateFiles = walk(templatesDir);
+} catch {
+  errors.push(`Templates directory not found at ${relative(root, templatesDir)}`);
+}
+
+const validSpec = (spec) => {
+  if (spec === "workspace:*") return true;
+  const stripped = spec.replace(/^[\^~]/, "");
+  return stripped === referenceVersion;
+};
+
+for (const file of templateFiles) {
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(file, "utf8"));
+  } catch (e) {
+    errors.push(`${relative(root, file)} is not valid JSON: ${e.message}`);
+    continue;
+  }
+  for (const section of ["dependencies", "devDependencies", "peerDependencies"]) {
+    const deps = pkg[section] ?? {};
+    for (const [name, spec] of Object.entries(deps)) {
+      if (!name.startsWith("@whisq/")) continue;
+      if (!validSpec(spec)) {
+        errors.push(
+          `${relative(root, file)} ${section}["${name}"] is "${spec}", expected "^${referenceVersion}" or "${referenceVersion}"`,
+        );
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Version consistency check failed:");
+  for (const err of errors) console.error(`  - ${err}`);
+  process.exit(1);
+}
+
+console.log(
+  `Version consistency OK — ${whisqPackages.length} @whisq/* packages at ${referenceVersion}, ${templateFiles.length} template(s) aligned.`,
+);

--- a/scripts/sync-template-versions.mjs
+++ b/scripts/sync-template-versions.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Rewrites every `@whisq/*` dep inside
+// `packages/create-whisq/src/templates/**/package.json.tmpl`
+// to match the current workspace version (the one in `packages/core/package.json`).
+//
+// Caret range is preserved. `workspace:*` specs are left alone.
+// Run after version bumps so scaffolded apps pick up the new release.
+
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+const corePkg = JSON.parse(
+  readFileSync(join(root, "packages", "core", "package.json"), "utf8"),
+);
+const targetVersion = corePkg.version;
+if (!targetVersion) {
+  console.error("Could not read version from packages/core/package.json");
+  process.exit(1);
+}
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) walk(full, out);
+    else if (entry === "package.json.tmpl") out.push(full);
+  }
+  return out;
+}
+
+const templatesDir = join(root, "packages", "create-whisq", "src", "templates");
+const files = walk(templatesDir);
+let changed = 0;
+
+for (const file of files) {
+  const original = readFileSync(file, "utf8");
+  const pkg = JSON.parse(original);
+  let mutated = false;
+
+  for (const section of ["dependencies", "devDependencies", "peerDependencies"]) {
+    const deps = pkg[section];
+    if (!deps) continue;
+    for (const [name, spec] of Object.entries(deps)) {
+      if (!name.startsWith("@whisq/")) continue;
+      if (spec === "workspace:*") continue;
+      const prefix = spec.startsWith("^") || spec.startsWith("~") ? spec[0] : "^";
+      const next = `${prefix}${targetVersion}`;
+      if (next !== spec) {
+        deps[name] = next;
+        mutated = true;
+      }
+    }
+  }
+
+  if (mutated) {
+    const trailingNewline = original.endsWith("\n") ? "\n" : "";
+    writeFileSync(file, JSON.stringify(pkg, null, 2) + trailingNewline);
+    console.log(`updated ${relative(root, file)}`);
+    changed++;
+  }
+}
+
+console.log(`Synced ${changed}/${files.length} template(s) to @whisq/*@${targetVersion}.`);


### PR DESCRIPTION
## Summary

Adds a version-consistency gate so `create-whisq` scaffold templates never pin a stale `@whisq/*` version after a release.

- **`scripts/check-versions.mjs`** — asserts every `@whisq/*` package in `packages/*` shares the same version, and every `@whisq/*` dep inside `packages/create-whisq/src/templates/**/package.json.tmpl` matches that version. Allowed specs: `"X.Y.Z"`, `"^X.Y.Z"`, `"~X.Y.Z"`, `"workspace:*"`.
- **`scripts/sync-template-versions.mjs`** — rewrites the template `.tmpl` pins to the current `packages/core/package.json` version. Hooked into `pnpm version` so Changesets' bump and template sync happen in the same step.
- **`.changeset/config.json`** — adds `"@whisq/*"` to `"fixed"` so workspace packages bump together.
- **CI** — new `version-consistency` job; added to `build`'s `needs`.
- **Release workflow** — runs the check before publish.
- **`package.json`** — `check:versions`, `sync:template-versions` scripts; `version` script now runs sync; `release` script runs the check before publish.

## Why

Currently `create-whisq/src/templates/**/package.json.tmpl` hardcodes `"@whisq/core": "^0.1.0-alpha.1"`. Changesets bumps workspace packages via `workspace:*` but has no visibility into these `.tmpl` files, so after the next core bump scaffolded apps would resolve a stale version — and pre-release caret ranges are strict in npm semver, which can fail resolution outright.

## Test plan

- [x] `node scripts/check-versions.mjs` passes on `develop` state (8 packages at `0.1.0-alpha.1`, 4 templates aligned).
- [x] `node scripts/sync-template-versions.mjs` is a no-op against current state.
- [x] Simulated drift (`@whisq/core` → `^0.0.99` in minimal template) is caught by the check and reports the offending file/key.
- [ ] CI `version-consistency` job goes green on this PR.