### PR TITLE
chore: ignore pnpm/action-setup majors until lockfile is regenerated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,3 +51,10 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      # pnpm/action-setup@v6 installs a newer pnpm whose lockfile parser
+      # rejects lockfiles written by pnpm@9.x (ERR_PNPM_BROKEN_LOCKFILE).
+      # Revisit after we regenerate the lockfile on pnpm@10 or @11.
+      - dependency-name: "pnpm/action-setup"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## Summary

Dependabot opened #8 to bump `pnpm/action-setup` from v4 to v6. v6 installs a newer pnpm (likely 10/11) whose lockfile parser rejects our pnpm@9.15.0-generated lockfile with `ERR_PNPM_BROKEN_LOCKFILE`. Attempted fixes:

- Leaving `version:` unset → action reads `packageManager` but still installs something incompatible with the lockfile (same error).
- Pinning `version: 9` on every step → v6 errors out with `ERR_PNPM_BAD_PM_VERSION: Multiple versions of pnpm specified` because it refuses to accept both `version:` input and the `packageManager` field.

The cleanest fix requires regenerating the lockfile on pnpm@10 or @11, which is a separate, intentional project. Until then, stay on v4 and keep Dependabot from reopening the same PR.

## Changes

- `.github/dependabot.yml`: add `dependency-name: "pnpm/action-setup"` with `version-update:semver-major` to the github-actions `ignore` list.
- #8 will be closed once this lands.

## Test plan

- [x] No workflow changes — all pipelines continue on `pnpm/action-setup@v4` exactly as before.
- [ ] CI green on this PR (only touches `.github/dependabot.yml`).