### PR TITLE
Release v0.1.0-alpha.4

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@whisq/*"]],
+  "fixed": [["@whisq/*", "create-whisq"]],
   "linked": [],
   "access": "public",
   "baseBranch": "develop",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@whisq/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "develop",

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# CODEOWNERS — https://docs.github.com/articles/about-code-owners
+# Each line maps a path pattern to one or more owners. Last matching line wins.
+# Owners are auto-requested for review on PRs that touch matching paths.
+
+# Default: everything needs mkotulac-markot review
+*                                   @mkotulac-markot
+
+# Workflows, Dependabot, and repo config
+/.github/                           @mkotulac-markot
+
+# Release tooling
+/.changeset/                        @mkotulac-markot
+/package.json                       @mkotulac-markot
+/pnpm-lock.yaml                     @mkotulac-markot
+/turbo.json                         @mkotulac-markot
+
+# Packages
+/packages/core/                     @mkotulac-markot
+/packages/router/                   @mkotulac-markot
+/packages/ssr/                      @mkotulac-markot
+/packages/vite-plugin/              @mkotulac-markot
+/packages/testing/                  @mkotulac-markot
+/packages/devtools/                 @mkotulac-markot
+/packages/sandbox/                  @mkotulac-markot
+/packages/mcp-server/               @mkotulac-markot
+/packages/create-whisq/             @mkotulac-markot
+
+# Docs & brand
+/docs/                              @mkotulac-markot
+/README.md                          @mkotulac-markot
+/CLAUDE.md                          @mkotulac-markot

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+<!--
+Thanks for contributing to Whisq!
+
+Commit/PR title format: `WHISQ-<issue#>: <short description>`
+Target branch: almost always `develop` (release PRs go to `main`).
+-->
+
+## Summary
+
+<!-- One or two sentences explaining WHAT changed and WHY. -->
+
+## Linked issue
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change
+- [ ] Docs / chore / tooling
+- [ ] Security fix
+
+## Affected packages
+
+<!-- Check all that apply. -->
+
+- [ ] `@whisq/core`
+- [ ] `@whisq/router`
+- [ ] `@whisq/ssr`
+- [ ] `@whisq/vite-plugin`
+- [ ] `@whisq/testing`
+- [ ] `@whisq/devtools`
+- [ ] `@whisq/sandbox`
+- [ ] `@whisq/mcp-server`
+- [ ] `create-whisq`
+- [ ] Repo tooling / CI / docs
+
+## Changeset
+
+- [ ] Added a changeset (`pnpm changeset`) — *required for any change to a published package*
+- [ ] Not applicable (docs, CI, tooling only)
+
+## Test plan
+
+<!-- How did you verify this? Commands, browser checks, screenshots, etc. -->
+
+- [ ] `pnpm test` passes
+- [ ] `pnpm build` passes
+- [ ] Manual verification (describe below)
+
+## Checklist
+
+- [ ] PR targets `develop` (or `main` only for release PRs)
+- [ ] Title follows `WHISQ-<issue#>: ...` format
+- [ ] No new TypeScript errors (`pnpm -r typecheck`)
+- [ ] Docs updated if public API changed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# Dependabot configuration — https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# All update PRs target `develop` (the integration branch). Release PRs from
+# develop to main are handled manually.
+
+version: 2
+updates:
+  # npm / pnpm workspace root
+  - package-ecosystem: npm
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Bratislava
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      prod-patch:
+        dependency-type: production
+        update-types:
+          - patch
+    ignore:
+      # Don't churn on major bumps — open those manually with a migration plan.
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+
+  # GitHub Actions workflow pins
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Bratislava
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,3 +51,10 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      # pnpm/action-setup@v6 installs a newer pnpm whose lockfile parser
+      # rejects lockfiles written by pnpm@9.x (ERR_PNPM_BROKEN_LOCKFILE).
+      # Revisit after we regenerate the lockfile on pnpm@10 or @11.
+      - dependency-name: "pnpm/action-setup"
+        update-types:
+          - version-update:semver-major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - run: node scripts/check-versions.mjs
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -90,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,15 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm format --check
 
+  version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/check-versions.mjs
+
   typecheck:
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +86,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test]
+    needs: [lint, version-consistency, typecheck, test]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -25,7 +25,7 @@ jobs:
   version-consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -34,7 +34,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -47,7 +47,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -59,7 +59,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -73,7 +73,7 @@ jobs:
   license-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, version-consistency, typecheck, test]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [develop, main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const tag = context.ref.replace('refs/tags/', '');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Lint
         run: pnpm format --check
 
+      - name: Version consistency
+        run: node scripts/check-versions.mjs
+
       - name: Typecheck
         run: pnpm build && pnpm -r exec tsc --noEmit
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,12 @@ Whisq is designed for AI-assisted development:
 
 ## Documentation
 
-Full documentation at [whisq.dev](https://whisq.dev) (coming soon).
+- [Getting Started](https://whisq.dev/getting-started/introduction/) — installation, quick start, first component
+- [Core Concepts](https://whisq.dev/core-concepts/signals/) — signals, elements, components, styling
+- [API Reference](https://whisq.dev/api/signal/) — complete API docs
+- [Guides](https://whisq.dev/guides/routing/) — routing, SSR, forms, testing, data fetching
+- [Examples](https://whisq.dev/examples/counter/) — counter, todo, dashboard, forms
+- [Playground](https://whisq.dev/playground/) — try Whisq in the browser
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "clean": "turbo run clean",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
+    "check:versions": "node scripts/check-versions.mjs",
+    "sync:template-versions": "node scripts/sync-template-versions.mjs",
     "changeset": "changeset",
-    "version": "changeset version",
-    "release": "pnpm build && pnpm test && changeset publish"
+    "version": "changeset version && node scripts/sync-template-versions.mjs",
+    "release": "pnpm build && pnpm test && pnpm check:versions && changeset publish"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
     "esbuild": "^0.28.0",
-    "prettier": "^3.4.0",
-    "turbo": "^2.3.0",
+    "prettier": "^3.8.3",
+    "turbo": "^2.9.6",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -26,5 +26,10 @@
   "packageManager": "pnpm@9.15.0",
   "engines": {
     "node": ">=20"
+  },
+  "pnpm": {
+    "overrides": {
+      "hono@<4.12.14": ">=4.12.14"
+    }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,10 +54,10 @@
     }
   ],
   "devDependencies": {
-    "@size-limit/preset-small-lib": "^11.0.0",
+    "@size-limit/preset-small-lib": "^11.2.0",
     "jsdom": "^29.0.2",
-    "size-limit": "^11.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "size-limit": "^11.2.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -26,9 +26,9 @@
   "author": "Markot s. r. o.",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "@types/node": "^22.19.17",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   },
   "repository": {
     "type": "git",

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1",
-    "@whisq/router": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4",
+    "@whisq/router": "^0.1.0-alpha.4"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1",
-    "@whisq/ssr": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4",
+    "@whisq/ssr": "^0.1.0-alpha.4"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1",
-    "@whisq/router": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4",
+    "@whisq/router": "^0.1.0-alpha.4"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.1",
+    "@whisq/vite-plugin": "^0.1.0-alpha.4",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -36,8 +36,8 @@
   },
   "devDependencies": {
     "jsdom": "^29.0.2",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   },
   "repository": {
     "type": "git",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -34,13 +34,13 @@
   "author": "Markot s. r. o.",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.11.0",
-    "zod": "^3.23.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "@types/node": "^22.19.17",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   },
   "repository": {
     "type": "git",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -43,11 +43,11 @@
     "@whisq/core": "workspace:*"
   },
   "devDependencies": {
-    "@size-limit/preset-small-lib": "^11.0.0",
+    "@size-limit/preset-small-lib": "^11.2.0",
     "jsdom": "^29.0.2",
-    "size-limit": "^11.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "size-limit": "^11.2.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   },
   "repository": {
     "type": "git",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -32,9 +32,9 @@
   "author": "Markot s. r. o.",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "@types/node": "^22.19.17",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   },
   "repository": {
     "type": "git",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -36,8 +36,8 @@
   },
   "devDependencies": {
     "jsdom": "^29.0.2",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   },
   "repository": {
     "type": "git",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,31 +36,31 @@ importers:
   packages/core:
     devDependencies:
       '@size-limit/preset-small-lib':
-        specifier: ^11.0.0
+        specifier: ^11.2.0
         version: 11.2.0(size-limit@11.2.0)
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2
       size-limit:
-        specifier: ^11.0.0
+        specifier: ^11.2.0
         version: 11.2.0
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@29.0.2)(lightningcss@1.32.0)(yaml@2.8.3)
 
   packages/create-whisq:
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
+        specifier: ^22.19.17
         version: 22.19.17
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@29.0.2)(lightningcss@1.32.0)(yaml@2.8.3)
 
   packages/devtools:
@@ -73,29 +73,29 @@ importers:
         specifier: ^29.0.2
         version: 29.0.2
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@29.0.2)(lightningcss@1.32.0)(yaml@2.8.3)
 
   packages/mcp-server:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.11.0
+        specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
       zod:
-        specifier: ^3.23.0
+        specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
+        specifier: ^22.19.17
         version: 22.19.17
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@29.0.2)(lightningcss@1.32.0)(yaml@2.8.3)
 
   packages/router:
@@ -105,31 +105,31 @@ importers:
         version: link:../core
     devDependencies:
       '@size-limit/preset-small-lib':
-        specifier: ^11.0.0
+        specifier: ^11.2.0
         version: 11.2.0(size-limit@11.2.0)
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2
       size-limit:
-        specifier: ^11.0.0
+        specifier: ^11.2.0
         version: 11.2.0
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@29.0.2)(lightningcss@1.32.0)(yaml@2.8.3)
 
   packages/sandbox:
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
+        specifier: ^22.19.17
         version: 22.19.17
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)(jsdom@29.0.2)(lightningcss@1.32.0)(yaml@2.8.3)
 
   packages/ssr:
@@ -164,10 +164,10 @@ importers:
         specifier: ^29.0.2
         version: 29.0.2
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@29.0.2)(lightningcss@1.32.0)(yaml@2.8.3)
 
   packages/vite-plugin:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  hono@<4.12.14: '>=4.12.14'
+
 importers:
 
   .:
@@ -781,7 +784,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.14'
 
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
@@ -1384,8 +1387,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -2594,9 +2597,9 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.13(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
   '@inquirer/external-editor@1.0.3(@types/node@24.12.2)':
     dependencies:
@@ -2625,7 +2628,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
+      '@hono/node-server': 1.19.13(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -2635,7 +2638,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
+      hono: 4.12.14
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -2801,14 +2804,6 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
     dependencies:
@@ -3260,7 +3255,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -3907,7 +3902,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
         specifier: ^0.28.0
         version: 0.28.0
       prettier:
-        specifier: ^3.4.0
-        version: 3.8.1
+        specifier: ^3.8.3
+        version: 3.8.3
       turbo:
-        specifier: ^2.3.0
-        version: 2.9.5
+        specifier: ^2.9.6
+        version: 2.9.6
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -968,33 +968,33 @@ packages:
     peerDependencies:
       size-limit: 11.2.0
 
-  '@turbo/darwin-64@2.9.5':
-    resolution: {integrity: sha512-qPxhKsLMQP+9+dsmPgAGidi5uNifD4AoAOnEnljab3Qgn0QZRR31Hp+/CgW3Ia5AanWj6JuLLTBYvuQj4mqTWg==}
+  '@turbo/darwin-64@2.9.6':
+    resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.5':
-    resolution: {integrity: sha512-vkF/9F/l3aWd4bHxTui5Hh0F5xrTZ4e3rbBsc57zA6O8gNbmHN3B6eZ5psAIP2CnJRZ8ZxRjV3WZHeNXMXkPBw==}
+  '@turbo/darwin-arm64@2.9.6':
+    resolution: {integrity: sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.5':
-    resolution: {integrity: sha512-z/Get5NUaUxm5HSGFqVMICDRjFNsCUhSc4wnFa/PP1QD0NXCjr7bu9a2EM6md/KMCBW0Qe393Ac+UM7/ryDDTw==}
+  '@turbo/linux-64@2.9.6':
+    resolution: {integrity: sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.5':
-    resolution: {integrity: sha512-jyBifaNoI5/NheyswomiZXJvjdAdvT7hDRYzQ4meP0DKGvpXUjnqsD+4/J2YSDQ34OHxFkL30FnSCUIVOh2PHw==}
+  '@turbo/linux-arm64@2.9.6':
+    resolution: {integrity: sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.5':
-    resolution: {integrity: sha512-ph24K5uPtvo7UfuyDXnBiB/8XvrO+RQWbbw5zkA/bVNoy9HDiNoIJJj3s62MxT9tjEb6DnPje5PXSz1UR7QAyg==}
+  '@turbo/windows-64@2.9.6':
+    resolution: {integrity: sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.5':
-    resolution: {integrity: sha512-6c5RccT/+iR39SdT1G5HyZaD2n57W77o+l0TTfxG/cVlhV94Acyg2gTQW7zUOhW1BeQpBjHzu9x8yVBZwrHh7g==}
+  '@turbo/windows-arm64@2.9.6':
+    resolution: {integrity: sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==}
     cpu: [arm64]
     os: [win32]
 
@@ -1740,8 +1740,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1952,8 +1952,8 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
-  turbo@2.9.5:
-    resolution: {integrity: sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA==}
+  turbo@2.9.6:
+    resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
     hasBin: true
 
   type-is@2.0.1:
@@ -2751,22 +2751,22 @@ snapshots:
       '@size-limit/file': 11.2.0(size-limit@11.2.0)
       size-limit: 11.2.0
 
-  '@turbo/darwin-64@2.9.5':
+  '@turbo/darwin-64@2.9.6':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.5':
+  '@turbo/darwin-arm64@2.9.6':
     optional: true
 
-  '@turbo/linux-64@2.9.5':
+  '@turbo/linux-64@2.9.6':
     optional: true
 
-  '@turbo/linux-arm64@2.9.5':
+  '@turbo/linux-arm64@2.9.6':
     optional: true
 
-  '@turbo/windows-64@2.9.5':
+  '@turbo/windows-64@2.9.6':
     optional: true
 
-  '@turbo/windows-arm64@2.9.5':
+  '@turbo/windows-arm64@2.9.6':
     optional: true
 
   '@types/chai@5.2.3':
@@ -2804,6 +2804,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
     dependencies:
@@ -3529,7 +3537,7 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  prettier@3.8.1: {}
+  prettier@3.8.3: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -3766,14 +3774,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  turbo@2.9.5:
+  turbo@2.9.6:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.5
-      '@turbo/darwin-arm64': 2.9.5
-      '@turbo/linux-64': 2.9.5
-      '@turbo/linux-arm64': 2.9.5
-      '@turbo/windows-64': 2.9.5
-      '@turbo/windows-arm64': 2.9.5
+      '@turbo/darwin-64': 2.9.6
+      '@turbo/darwin-arm64': 2.9.6
+      '@turbo/linux-64': 2.9.6
+      '@turbo/linux-arm64': 2.9.6
+      '@turbo/windows-64': 2.9.6
+      '@turbo/windows-arm64': 2.9.6
 
   type-is@2.0.1:
     dependencies:
@@ -3902,7 +3910,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 // Verifies version consistency across the monorepo:
-//   1. Every `@whisq/*` package in `packages/*` shares the same version.
+//   1. Every `@whisq/*` package AND `create-whisq` in `packages/*` share the same version.
 //   2. Every `@whisq/*` reference inside `packages/create-whisq/src/templates/**/package.json.tmpl`
 //      resolves to that same version. Allowed forms: "X.Y.Z", "^X.Y.Z", "~X.Y.Z", "workspace:*".
+//
+// `create-whisq` is included so the scaffolder and the runtime packages
+// always release together. Enforced by the `fixed` group in
+// `.changeset/config.json` and by this check in CI + /release.
 //
 // Exits non-zero on any drift. Run in CI and as a gate inside /release.
 
@@ -13,7 +17,11 @@ import { fileURLToPath } from "node:url";
 const root = fileURLToPath(new URL("..", import.meta.url));
 const errors = [];
 
-const whisqPackages = readdirSync(join(root, "packages"))
+const RELEASED_PACKAGE_NAMES = new Set(["create-whisq"]);
+const isReleasedPackage = (name) =>
+  Boolean(name) && (name.startsWith("@whisq/") || RELEASED_PACKAGE_NAMES.has(name));
+
+const releasedPackages = readdirSync(join(root, "packages"))
   .map((dir) => {
     const pkgPath = join(root, "packages", dir, "package.json");
     try {
@@ -23,17 +31,17 @@ const whisqPackages = readdirSync(join(root, "packages"))
       return null;
     }
   })
-  .filter((p) => p && p.name?.startsWith("@whisq/"));
+  .filter((p) => p && isReleasedPackage(p.name));
 
-if (whisqPackages.length === 0) {
-  errors.push("No @whisq/* packages found in packages/*");
+if (releasedPackages.length === 0) {
+  errors.push("No released packages found in packages/*");
 }
 
-const referenceVersion = whisqPackages[0]?.version;
-for (const pkg of whisqPackages) {
+const referenceVersion = releasedPackages[0]?.version;
+for (const pkg of releasedPackages) {
   if (pkg.version !== referenceVersion) {
     errors.push(
-      `${pkg.name} is ${pkg.version}, expected ${referenceVersion} (matching ${whisqPackages[0].name})`,
+      `${pkg.name} is ${pkg.version}, expected ${referenceVersion} (matching ${releasedPackages[0].name})`,
     );
   }
 }
@@ -90,5 +98,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `Version consistency OK — ${whisqPackages.length} @whisq/* packages at ${referenceVersion}, ${templateFiles.length} template(s) aligned.`,
+  `Version consistency OK — ${releasedPackages.length} released packages at ${referenceVersion}, ${templateFiles.length} template(s) aligned.`,
 );

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Verifies version consistency across the monorepo:
+//   1. Every `@whisq/*` package in `packages/*` shares the same version.
+//   2. Every `@whisq/*` reference inside `packages/create-whisq/src/templates/**/package.json.tmpl`
+//      resolves to that same version. Allowed forms: "X.Y.Z", "^X.Y.Z", "~X.Y.Z", "workspace:*".
+//
+// Exits non-zero on any drift. Run in CI and as a gate inside /release.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const errors = [];
+
+const whisqPackages = readdirSync(join(root, "packages"))
+  .map((dir) => {
+    const pkgPath = join(root, "packages", dir, "package.json");
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+      return { dir, pkgPath, name: pkg.name, version: pkg.version };
+    } catch {
+      return null;
+    }
+  })
+  .filter((p) => p && p.name?.startsWith("@whisq/"));
+
+if (whisqPackages.length === 0) {
+  errors.push("No @whisq/* packages found in packages/*");
+}
+
+const referenceVersion = whisqPackages[0]?.version;
+for (const pkg of whisqPackages) {
+  if (pkg.version !== referenceVersion) {
+    errors.push(
+      `${pkg.name} is ${pkg.version}, expected ${referenceVersion} (matching ${whisqPackages[0].name})`,
+    );
+  }
+}
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) walk(full, out);
+    else if (entry === "package.json.tmpl") out.push(full);
+  }
+  return out;
+}
+
+const templatesDir = join(root, "packages", "create-whisq", "src", "templates");
+let templateFiles = [];
+try {
+  templateFiles = walk(templatesDir);
+} catch {
+  errors.push(`Templates directory not found at ${relative(root, templatesDir)}`);
+}
+
+const validSpec = (spec) => {
+  if (spec === "workspace:*") return true;
+  const stripped = spec.replace(/^[\^~]/, "");
+  return stripped === referenceVersion;
+};
+
+for (const file of templateFiles) {
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(file, "utf8"));
+  } catch (e) {
+    errors.push(`${relative(root, file)} is not valid JSON: ${e.message}`);
+    continue;
+  }
+  for (const section of ["dependencies", "devDependencies", "peerDependencies"]) {
+    const deps = pkg[section] ?? {};
+    for (const [name, spec] of Object.entries(deps)) {
+      if (!name.startsWith("@whisq/")) continue;
+      if (!validSpec(spec)) {
+        errors.push(
+          `${relative(root, file)} ${section}["${name}"] is "${spec}", expected "^${referenceVersion}" or "${referenceVersion}"`,
+        );
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Version consistency check failed:");
+  for (const err of errors) console.error(`  - ${err}`);
+  process.exit(1);
+}
+
+console.log(
+  `Version consistency OK — ${whisqPackages.length} @whisq/* packages at ${referenceVersion}, ${templateFiles.length} template(s) aligned.`,
+);

--- a/scripts/sync-template-versions.mjs
+++ b/scripts/sync-template-versions.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Rewrites every `@whisq/*` dep inside
+// `packages/create-whisq/src/templates/**/package.json.tmpl`
+// to match the current workspace version (the one in `packages/core/package.json`).
+//
+// Caret range is preserved. `workspace:*` specs are left alone.
+// Run after version bumps so scaffolded apps pick up the new release.
+
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+const corePkg = JSON.parse(
+  readFileSync(join(root, "packages", "core", "package.json"), "utf8"),
+);
+const targetVersion = corePkg.version;
+if (!targetVersion) {
+  console.error("Could not read version from packages/core/package.json");
+  process.exit(1);
+}
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) walk(full, out);
+    else if (entry === "package.json.tmpl") out.push(full);
+  }
+  return out;
+}
+
+const templatesDir = join(root, "packages", "create-whisq", "src", "templates");
+const files = walk(templatesDir);
+let changed = 0;
+
+for (const file of files) {
+  const original = readFileSync(file, "utf8");
+  const pkg = JSON.parse(original);
+  let mutated = false;
+
+  for (const section of ["dependencies", "devDependencies", "peerDependencies"]) {
+    const deps = pkg[section];
+    if (!deps) continue;
+    for (const [name, spec] of Object.entries(deps)) {
+      if (!name.startsWith("@whisq/")) continue;
+      if (spec === "workspace:*") continue;
+      const prefix = spec.startsWith("^") || spec.startsWith("~") ? spec[0] : "^";
+      const next = `${prefix}${targetVersion}`;
+      if (next !== spec) {
+        deps[name] = next;
+        mutated = true;
+      }
+    }
+  }
+
+  if (mutated) {
+    const trailingNewline = original.endsWith("\n") ? "\n" : "";
+    writeFileSync(file, JSON.stringify(pkg, null, 2) + trailingNewline);
+    console.log(`updated ${relative(root, file)}`);
+    changed++;
+  }
+}
+
+console.log(`Synced ${changed}/${files.length} template(s) to @whisq/*@${targetVersion}.`);


### PR DESCRIPTION
## Summary

First fully-aligned release across the whisq monorepo. Every `@whisq/*` package and `create-whisq` move to **`0.1.0-alpha.4`** in one commit.

### Why alpha.4

The smallest bump that clears every already-published npm version:

| Package | Was | Now |
|---|---|---|
| `@whisq/core` + 7 siblings | `0.1.0-alpha.1` | `0.1.0-alpha.4` |
| `create-whisq` | `0.1.0-alpha.3` | `0.1.0-alpha.4` |

### Structural changes (one-time)

- `.changeset/config.json` — `create-whisq` added to the `fixed` group so it always bumps in lockstep with `@whisq/*` going forward.
- `scripts/check-versions.mjs` — now requires `create-whisq` to match the `@whisq/*` version. CI will fail on drift.
- Template `.tmpl` pins synced automatically via `pnpm sync:template-versions`.
- `pnpm-lock.yaml` refreshed.

### What happens after merge

1. Tag `v0.1.0-alpha.4` on the merge commit (annotated).
2. Tag push triggers `release.yml` which runs the full verify pipeline, then `pnpm -r publish --provenance` for all 9 packages.
3. A GitHub Release is created automatically (flagged as pre-release due to `alpha`).
4. Back-merge `main` into `develop` so develop stays ahead.

## Test plan

- [x] `pnpm check:versions` — 9 released packages at 0.1.0-alpha.4, 4 templates aligned.
- [x] `pnpm build` — 9/9 tasks.
- [x] `pnpm test` — 18/18 tasks.
- [ ] CI green on this PR.
- [ ] After merge: `v0.1.0-alpha.4` tag push publishes all packages to npm without collision.