### PR TITLE
chore: sync v0.1.0-alpha.4 release into develop

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@whisq/*"]],
+  "fixed": [["@whisq/*", "create-whisq"]],
   "linked": [],
   "access": "public",
   "baseBranch": "develop",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1",
-    "@whisq/router": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4",
+    "@whisq/router": "^0.1.0-alpha.4"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1",
-    "@whisq/ssr": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4",
+    "@whisq/ssr": "^0.1.0-alpha.4"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1",
-    "@whisq/router": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4",
+    "@whisq/router": "^0.1.0-alpha.4"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.1",
+    "@whisq/vite-plugin": "^0.1.0-alpha.4",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 // Verifies version consistency across the monorepo:
-//   1. Every `@whisq/*` package in `packages/*` shares the same version.
+//   1. Every `@whisq/*` package AND `create-whisq` in `packages/*` share the same version.
 //   2. Every `@whisq/*` reference inside `packages/create-whisq/src/templates/**/package.json.tmpl`
 //      resolves to that same version. Allowed forms: "X.Y.Z", "^X.Y.Z", "~X.Y.Z", "workspace:*".
+//
+// `create-whisq` is included so the scaffolder and the runtime packages
+// always release together. Enforced by the `fixed` group in
+// `.changeset/config.json` and by this check in CI + /release.
 //
 // Exits non-zero on any drift. Run in CI and as a gate inside /release.
 
@@ -13,7 +17,11 @@ import { fileURLToPath } from "node:url";
 const root = fileURLToPath(new URL("..", import.meta.url));
 const errors = [];
 
-const whisqPackages = readdirSync(join(root, "packages"))
+const RELEASED_PACKAGE_NAMES = new Set(["create-whisq"]);
+const isReleasedPackage = (name) =>
+  Boolean(name) && (name.startsWith("@whisq/") || RELEASED_PACKAGE_NAMES.has(name));
+
+const releasedPackages = readdirSync(join(root, "packages"))
   .map((dir) => {
     const pkgPath = join(root, "packages", dir, "package.json");
     try {
@@ -23,17 +31,17 @@ const whisqPackages = readdirSync(join(root, "packages"))
       return null;
     }
   })
-  .filter((p) => p && p.name?.startsWith("@whisq/"));
+  .filter((p) => p && isReleasedPackage(p.name));
 
-if (whisqPackages.length === 0) {
-  errors.push("No @whisq/* packages found in packages/*");
+if (releasedPackages.length === 0) {
+  errors.push("No released packages found in packages/*");
 }
 
-const referenceVersion = whisqPackages[0]?.version;
-for (const pkg of whisqPackages) {
+const referenceVersion = releasedPackages[0]?.version;
+for (const pkg of releasedPackages) {
   if (pkg.version !== referenceVersion) {
     errors.push(
-      `${pkg.name} is ${pkg.version}, expected ${referenceVersion} (matching ${whisqPackages[0].name})`,
+      `${pkg.name} is ${pkg.version}, expected ${referenceVersion} (matching ${releasedPackages[0].name})`,
     );
   }
 }
@@ -90,5 +98,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `Version consistency OK — ${whisqPackages.length} @whisq/* packages at ${referenceVersion}, ${templateFiles.length} template(s) aligned.`,
+  `Version consistency OK — ${releasedPackages.length} released packages at ${referenceVersion}, ${templateFiles.length} template(s) aligned.`,
 );


### PR DESCRIPTION
Back-merges the v0.1.0-alpha.4 release commit into develop. Squash-merge this so develop stays free of merge commits per branch protection rules.

Mirrors the content of #14 (which was merged to main via `--merge` to preserve release history) without pulling the merge commit itself into develop.