### PR TITLE
fix(release): split publish so create-whisq failure does not block @whisq/*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,20 @@ jobs:
       - name: Check bundle size
         run: cd packages/core && pnpm size
 
-      - name: Publish to npm
+      # Publish is split so a failure on the unscoped `create-whisq` package
+      # (which has its own token permissions on npm) does not block the
+      # @whisq/* scope. The whisq scope must stay internally consistent;
+      # create-whisq can lag until its token is wired up.
+      - name: Publish @whisq/* to npm
         if: inputs.dry_run != 'true' && startsWith(github.ref, 'refs/tags/v')
-        run: pnpm -r publish --access public --no-git-checks --provenance
+        run: pnpm --filter "@whisq/*" publish --access public --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish create-whisq to npm
+        if: inputs.dry_run != 'true' && startsWith(github.ref, 'refs/tags/v')
+        continue-on-error: true
+        run: pnpm --filter create-whisq publish --access public --no-git-checks --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

The v0.1.0-alpha.4 release tag push hit \`E403\` on \`create-whisq\` (unscoped package, separate npm token permissions). \`pnpm -r publish\` is fail-fast, so only \`@whisq/core\` published before the run halted. Seven other \`@whisq/*\` siblings and \`create-whisq\` stayed behind.

Split publish into two filter-scoped steps:

1. \`pnpm --filter "@whisq/*" publish --provenance\` — must succeed; keeps the scoped release atomic.
2. \`pnpm --filter create-whisq publish --provenance\` with \`continue-on-error: true\` — publishes create-whisq when the token permits, does not block the scope otherwise.

Once this is on main, the v0.1.0-alpha.4 tag will be force-moved to the new HEAD so the release workflow can run with the fix.

## Test plan

- [x] Workflow syntax still valid.
- [ ] CI green on this PR.
- [ ] After re-tag, all 7 remaining \`@whisq/*\` packages publish at alpha.4; create-whisq step logs E403 but the workflow completes and the GitHub Release is created.