### PR TITLE
WHISQ-19: add bind() two-way input binding helper

### DIFF
--- a/packages/core/src/__tests__/bind.test.ts
+++ b/packages/core/src/__tests__/bind.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { signal } from "../reactive.js";
+import { input, textarea, select, option, mount } from "../elements.js";
+import { bind } from "../bind.js";
+
+let container: HTMLElement;
+let dispose: () => void;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+});
+
+describe("bind() — text input", () => {
+  it("reflects initial signal value into DOM", () => {
+    const name = signal("ada");
+    dispose = mount(input({ ...bind(name) }), container);
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("ada");
+  });
+
+  it("updates signal when user types into the input", () => {
+    const name = signal("");
+    dispose = mount(input({ ...bind(name) }), container);
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "grace";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(name.value).toBe("grace");
+  });
+
+  it("propagates programmatic signal updates to DOM", () => {
+    const name = signal("ada");
+    dispose = mount(input({ ...bind(name) }), container);
+    const el = container.querySelector("input") as HTMLInputElement;
+    name.value = "grace";
+    expect(el.value).toBe("grace");
+  });
+});
+
+describe("bind() — number input", () => {
+  it("parses numeric input via valueAsNumber", () => {
+    const age = signal(0);
+    dispose = mount(
+      input({ type: "number", ...bind(age, { as: "number" }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "42";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(age.value).toBe(42);
+  });
+
+  it("ignores NaN (e.g. empty string) keeping signal at previous value", () => {
+    const age = signal(7);
+    dispose = mount(
+      input({ type: "number", ...bind(age, { as: "number" }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(age.value).toBe(7);
+  });
+
+  it("reflects signal value as DOM string", () => {
+    const age = signal(21);
+    dispose = mount(
+      input({ type: "number", ...bind(age, { as: "number" }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("21");
+    age.value = 99;
+    expect(el.value).toBe("99");
+  });
+});
+
+describe("bind() — checkbox", () => {
+  it("reflects signal as checked", () => {
+    const agreed = signal(true);
+    dispose = mount(
+      input({ type: "checkbox", ...bind(agreed, { as: "checkbox" }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(true);
+    agreed.value = false;
+    expect(el.checked).toBe(false);
+  });
+
+  it("toggles signal on change", () => {
+    const agreed = signal(false);
+    dispose = mount(
+      input({ type: "checkbox", ...bind(agreed, { as: "checkbox" }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(agreed.value).toBe(true);
+    el.checked = false;
+    el.dispatchEvent(new Event("change"));
+    expect(agreed.value).toBe(false);
+  });
+});
+
+describe("bind() — radio", () => {
+  it("sets checked only when signal equals the radio's value", () => {
+    const role = signal<"admin" | "user">("user");
+    dispose = mount(
+      input({
+        type: "radio",
+        name: "role",
+        ...bind(role, { as: "radio", value: "admin" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(false);
+    role.value = "admin";
+    expect(el.checked).toBe(true);
+  });
+
+  it("sets signal to the radio's value on change", () => {
+    const role = signal<"admin" | "user">("user");
+    dispose = mount(
+      input({
+        type: "radio",
+        name: "role",
+        ...bind(role, { as: "radio", value: "admin" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(role.value).toBe("admin");
+  });
+});
+
+describe("bind() — textarea and select", () => {
+  it("works with textarea (string signal)", () => {
+    const notes = signal("hi");
+    dispose = mount(textarea({ ...bind(notes) }), container);
+    const el = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(el.value).toBe("hi");
+    el.value = "updated";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(notes.value).toBe("updated");
+  });
+
+  it("works with select (string signal)", () => {
+    const role = signal("user");
+    dispose = mount(
+      select(
+        { ...bind(role) },
+        option({ value: "user" }, "User"),
+        option({ value: "admin" }, "Admin"),
+      ),
+      container,
+    );
+    const el = container.querySelector("select") as HTMLSelectElement;
+    expect(el.value).toBe("user");
+    el.value = "admin";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(role.value).toBe("admin");
+  });
+});
+
+describe("bind() — input validation", () => {
+  it("throws TypeError when first argument is not a signal", () => {
+    expect(() => bind({} as never)).toThrow(TypeError);
+    expect(() => bind(null as never)).toThrow(TypeError);
+    expect(() => bind("not a signal" as never)).toThrow(TypeError);
+  });
+});

--- a/packages/core/src/bind.ts
+++ b/packages/core/src/bind.ts
@@ -1,0 +1,109 @@
+// ============================================================================
+// Whisq Core — Two-way input binding helper
+// bind(signal, options?) returns a prop object to spread into input/select/textarea.
+// ============================================================================
+
+import { type Signal, isSignal } from "./reactive.js";
+
+export interface TextBind {
+  value: () => string;
+  oninput: (e: Event) => void;
+}
+
+export interface NumberBind {
+  value: () => string;
+  oninput: (e: Event) => void;
+}
+
+export interface CheckboxBind {
+  checked: () => boolean;
+  onchange: (e: Event) => void;
+}
+
+export interface RadioBind<V extends string> {
+  value: V;
+  checked: () => boolean;
+  onchange: (e: Event) => void;
+}
+
+export type BindOptions =
+  | { as: "number" }
+  | { as: "checkbox" }
+  | { as: "radio"; value: string };
+
+/**
+ * Two-way binding helper for form inputs.
+ *
+ * ```ts
+ * input({ ...bind(name) })                              // text
+ * input({ type: "number", ...bind(age, { as: "number" }) })
+ * input({ type: "checkbox", ...bind(agreed, { as: "checkbox" }) })
+ * input({ type: "radio", ...bind(role, { as: "radio", value: "admin" }) })
+ * ```
+ */
+export function bind(signal: Signal<string>): TextBind;
+export function bind(
+  signal: Signal<number>,
+  options: { as: "number" },
+): NumberBind;
+export function bind(
+  signal: Signal<boolean>,
+  options: { as: "checkbox" },
+): CheckboxBind;
+export function bind<V extends string>(
+  signal: Signal<V>,
+  options: { as: "radio"; value: V },
+): RadioBind<V>;
+export function bind(
+  signal: Signal<string | number | boolean>,
+  options?: BindOptions,
+): TextBind | NumberBind | CheckboxBind | RadioBind<string> {
+  if (!isSignal(signal)) {
+    throw new TypeError("bind() expects a Signal as its first argument");
+  }
+
+  if (options?.as === "checkbox") {
+    const sig = signal as Signal<boolean>;
+    return {
+      checked: () => sig.value,
+      onchange: (e: Event) => {
+        sig.value = (e.target as HTMLInputElement).checked;
+      },
+    };
+  }
+
+  if (options?.as === "radio") {
+    const sig = signal as Signal<string>;
+    const target = options.value;
+    return {
+      value: target,
+      checked: () => sig.value === target,
+      onchange: (e: Event) => {
+        if ((e.target as HTMLInputElement).checked) {
+          sig.value = target;
+        }
+      },
+    };
+  }
+
+  if (options?.as === "number") {
+    const sig = signal as Signal<number>;
+    return {
+      value: () => String(sig.value),
+      oninput: (e: Event) => {
+        const n = (e.target as HTMLInputElement).valueAsNumber;
+        if (!Number.isNaN(n)) sig.value = n;
+      },
+    };
+  }
+
+  const sig = signal as Signal<string>;
+  return {
+    value: () => sig.value,
+    oninput: (e: Event) => {
+      sig.value = (
+        e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+      ).value;
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,3 +95,13 @@ export type { ComponentDef, Resource, InjectionKey } from "./component.js";
 
 // Styling
 export { sheet, styles, cx, rcx, theme } from "./styling.js";
+
+// Forms
+export { bind } from "./bind.js";
+export type {
+  TextBind,
+  NumberBind,
+  CheckboxBind,
+  RadioBind,
+  BindOptions,
+} from "./bind.js";


### PR DESCRIPTION
## Summary
Adds a `bind()` helper that returns a prop-object to spread into `input`/`textarea`/`select`, collapsing controlled-input boilerplate from ~3 lines to 1.

```ts
input({ ...bind(email) })                                  // text
input({ type: "number", ...bind(age, { as: "number" }) })
input({ type: "checkbox", ...bind(agreed, { as: "checkbox" }) })
input({ type: "radio", ...bind(role, { as: "radio", value: "admin" }) })
textarea({ ...bind(notes) })
select({ ...bind(role) }, option({ value: "admin" }, "Admin"), ...)
```

Purely additive. No changes to `elements.ts` or `reconcile.ts`.

## Design notes
- **Overloads** narrow the return type by `options.as` so `input({...bind(age, {as:"number"})})` keeps full type safety.
- **Number inputs** use `valueAsNumber` and keep the previous signal value on `NaN` (empty / non-numeric input) — cleaner than treating empty as 0, and matches how most users reason about numeric field state.
- **Radio `onchange`** only writes when the radio becomes checked — multiple radios on the same signal compose correctly.
- **Input validation**: `bind()` throws `TypeError` when the first argument isn't a Signal, catching common mistakes early.

## Test plan
- [x] 13 new tests in `bind.test.ts` covering text / number / checkbox / radio / textarea / select / reactivity / type-guard
- [x] `pnpm -r --filter @whisq/core test` → 207 pass (up from 194)
- [x] `pnpm build` passes
- [x] `npx tsc --noEmit` clean
- [x] `prettier --check` clean on changed files
- [ ] CI (lint, typecheck, test, audit, license-check, build) all green

## Out of scope
- `model` prop alternative (would require `elements.ts` + per-element type changes — future issue)
- `<select multiple>` (follow-up)
- Modifiers (`.trim`, `.lazy`, `.number` a la Vue — only `as: "number"` for now)
- File inputs

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)