### PR TITLE
WHISQ-18: add ref<T>() primitive helper and export Ref type

### DIFF
--- a/packages/core/src/__tests__/ref.test.ts
+++ b/packages/core/src/__tests__/ref.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { signal } from "../reactive.js";
+import { signal, isSignal } from "../reactive.js";
 import { div, input, button, mount } from "../elements.js";
+import { ref } from "../ref.js";
 
 let container: HTMLElement;
 let dispose: () => void;
@@ -90,5 +91,47 @@ describe("ref prop", () => {
         "Click me",
       );
     });
+  });
+});
+
+describe("ref() helper", () => {
+  it("returns a Signal", () => {
+    const r = ref<HTMLInputElement>();
+    expect(isSignal(r)).toBe(true);
+  });
+
+  it("initializes to null", () => {
+    const r = ref<HTMLInputElement>();
+    expect(r.value).toBeNull();
+  });
+
+  it("populates on mount when used as an element ref", () => {
+    const inputRef = ref<HTMLInputElement>();
+    dispose = mount(input({ ref: inputRef, type: "text" }), container);
+    expect(inputRef.value).toBeInstanceOf(HTMLInputElement);
+    expect(inputRef.value!.type).toBe("text");
+  });
+
+  it("resets to null on dispose", () => {
+    const inputRef = ref<HTMLInputElement>();
+    dispose = mount(input({ ref: inputRef }), container);
+    expect(inputRef.value).toBeInstanceOf(HTMLInputElement);
+    dispose();
+    expect(inputRef.value).toBeNull();
+  });
+
+  it("is typed to the requested element", () => {
+    // Compile-time assertion: ref<HTMLInputElement>() typed as Signal<HTMLInputElement | null>
+    const r = ref<HTMLInputElement>();
+    dispose = mount(input({ ref: r }), container);
+    // .focus is HTMLInputElement-specific; this line only typechecks if r.value narrows correctly.
+    r.value?.focus();
+    expect(document.activeElement).toBe(r.value);
+  });
+
+  it("defaults element type to HTMLElement when unspecified", () => {
+    const r = ref();
+    dispose = mount(div({ ref: r }), container);
+    expect(r.value).toBeInstanceOf(HTMLDivElement);
   });
 });

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -11,19 +11,11 @@
 // AI generates this correctly because it's just function calls.
 // ============================================================================
 
-import {
-  effect,
-  isSignal,
-  setEffectErrorHandler,
-  type Signal,
-} from "./reactive.js";
+import { effect, isSignal, setEffectErrorHandler } from "./reactive.js";
 import { reconcileKeyed, type KeyedEntry } from "./reconcile.js";
+import type { Ref } from "./ref.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
-
-type Ref<T extends HTMLElement = HTMLElement> =
-  | Signal<T | null>
-  | ((el: T | null) => void);
 
 type Child =
   | string

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,6 +93,10 @@ export {
 } from "./component.js";
 export type { ComponentDef, Resource, InjectionKey } from "./component.js";
 
+// Refs
+export { ref } from "./ref.js";
+export type { Ref } from "./ref.js";
+
 // Styling
 export { sheet, styles, cx, rcx, theme } from "./styling.js";
 

--- a/packages/core/src/ref.ts
+++ b/packages/core/src/ref.ts
@@ -1,0 +1,30 @@
+// ============================================================================
+// Whisq Core — DOM element ref
+// Signal-based and callback-based refs for imperative DOM access.
+// ============================================================================
+
+import { signal, type Signal } from "./reactive.js";
+
+/**
+ * A ref accepts either a Signal that will be populated with the element,
+ * or a callback invoked with the element (and later with null on unmount).
+ */
+export type Ref<T extends HTMLElement = HTMLElement> =
+  | Signal<T | null>
+  | ((el: T | null) => void);
+
+/**
+ * Create a typed signal ref for a DOM element.
+ *
+ * The signal starts at `null` and is populated with the element after mount;
+ * it is reset to `null` on unmount.
+ *
+ * ```ts
+ * const inputEl = ref<HTMLInputElement>();
+ * input({ ref: inputEl });
+ * onMount(() => inputEl.value?.focus());
+ * ```
+ */
+export function ref<T extends HTMLElement = HTMLElement>(): Signal<T | null> {
+  return signal<T | null>(null);
+}


### PR DESCRIPTION
## Summary
The `ref` prop on elements (signal-ref and callback-ref) was already wired up and tested, but the **public API was incomplete**: no `ref<T>()` primitive and no exported `Ref` type.

This PR closes that gap with minimal churn.

### Before
```ts
// users had to know to use signal<T | null>(null) manually
const inputEl = signal<HTMLInputElement | null>(null);
input({ ref: inputEl });
```

### After
```ts
import { ref } from "@whisq/core";

const inputEl = ref<HTMLInputElement>();
input({ ref: inputEl });
onMount(() => inputEl.value?.focus());
```

## Changes
- New `packages/core/src/ref.ts` — exports `ref<T>()` and the `Ref<T>` type (moved from `elements.ts`).
- `packages/core/src/elements.ts` — imports `Ref` from `./ref.js`, behavior unchanged.
- `packages/core/src/index.ts` — adds `ref` and type `Ref` to the public surface.
- `packages/core/src/__tests__/ref.test.ts` — +6 tests covering primitive creation, initial `null`, mount population, dispose reset, type narrowing, and default `HTMLElement` generic.

## Test plan
- [x] 12 tests in `ref.test.ts` pass (6 existing + 6 new)
- [x] `pnpm --filter @whisq/core test` → 213 pass (up from 207)
- [x] `pnpm -r test` → all workspace tests green
- [x] `pnpm -r build` clean
- [x] `npx tsc --noEmit` in `packages/core` clean
- [x] `prettier --check` clean on changed files
- [ ] CI (lint, typecheck, test, audit, license-check, build, CodeQL) all green

## Out of scope
- Component-level refs (only elements)
- forwardRef / ref forwarding
- Docs-site update about mount-vs-`onMount` firing order (docs repo)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)