### PR TITLE
WHISQ-27: emit public-api.json manifest at build time

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,6 +27,32 @@ mount(App, document.getElementById("app"));
 
 Full documentation at [whisq.dev](https://whisq.dev).
 
+## Public API manifest
+
+Every published release ships a machine-readable list of exports at
+`dist/public-api.json` inside the npm package. It's the source of truth
+for "what `@whisq/core` exposes at this version" and is used by the
+docs site to guard against silent drift in the AI reference card.
+
+Shape:
+
+```json
+{
+  "version": "0.1.0-alpha.4",
+  "exports": ["Signal", "bind", "component", "mount", "..."]
+}
+```
+
+Fetch it via any CDN that mirrors npm:
+
+```
+https://unpkg.com/@whisq/core@<version>/dist/public-api.json
+https://cdn.jsdelivr.net/npm/@whisq/core@<version>/dist/public-api.json
+```
+
+Regenerated on every build by `scripts/generate-public-api.mjs` reading
+`src/index.ts`.
+
 ## License
 
 MIT

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/generate-public-api.mjs",
     "dev": "tsc --watch",
     "test": "vitest run --passWithNoTests",
     "size": "size-limit",

--- a/packages/core/scripts/generate-public-api.mjs
+++ b/packages/core/scripts/generate-public-api.mjs
@@ -1,0 +1,89 @@
+// ============================================================================
+// Whisq Core — Public API manifest generator
+//
+// Reads src/index.ts, extracts every named export (values + types),
+// and writes dist/public-api.json with { version, exports[] }.
+//
+// The manifest ships with the npm package, so consumers (e.g. the docs
+// repo's drift check) can fetch it from:
+//
+//   https://unpkg.com/@whisq/core@<version>/dist/public-api.json
+//
+// Pure extraction logic is exported so tests can exercise it without disk IO.
+// ============================================================================
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const RE_REEXPORT =
+  /export\s+(?:type\s+)?\{([\s\S]*?)\}\s+from\s+["'][^"']+["']/g;
+
+/**
+ * Extract every named export from an `index.ts` re-export file.
+ * Handles value re-exports, `type` re-exports, `as` aliases, and multi-line
+ * export blocks. Returns sorted unique names.
+ */
+export function extractExports(source) {
+  // Strip whole-line and end-of-line single-line comments so commented-out
+  // re-export statements don't leak into the manifest.
+  const cleaned = source.replace(/\/\/[^\n]*/g, "");
+  const names = new Set();
+  for (const match of cleaned.matchAll(RE_REEXPORT)) {
+    // Strip single-line // comments that live inside the re-export block so
+    // they don't leak into the extracted names.
+    const inner = match[1].replace(/\/\/[^\n]*/g, "");
+    for (const raw of inner.split(",")) {
+      const part = raw.trim();
+      if (!part) continue;
+      const aliasMatch = part.match(/\s+as\s+(\w+)$/);
+      const name = aliasMatch
+        ? aliasMatch[1]
+        : part.replace(/^type\s+/, "").trim();
+      // Only keep clean identifiers — reject anything that still contains
+      // whitespace or punctuation (defensive against odd formatting).
+      if (/^\w+$/.test(name)) {
+        names.add(name);
+      }
+    }
+  }
+  return [...names].sort();
+}
+
+/**
+ * Build the manifest object from a version string and the source file content.
+ */
+export function generateManifest(version, source) {
+  return {
+    version,
+    exports: extractExports(source),
+  };
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+const isDirectRun =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url === `file:///${process.argv[1].replace(/\\/g, "/")}`;
+
+if (isDirectRun) {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const pkgRoot = resolve(__dirname, "..");
+
+  const pkg = JSON.parse(
+    readFileSync(resolve(pkgRoot, "package.json"), "utf8"),
+  );
+  const src = readFileSync(resolve(pkgRoot, "src/index.ts"), "utf8");
+
+  const manifest = generateManifest(pkg.version, src);
+
+  const outDir = resolve(pkgRoot, "dist");
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+
+  const outPath = resolve(outDir, "public-api.json");
+  writeFileSync(outPath, JSON.stringify(manifest, null, 2) + "\n");
+
+  console.log(
+    `Wrote ${outPath}: ${manifest.exports.length} exports, version ${manifest.version}`,
+  );
+}

--- a/packages/core/src/__tests__/public-api.test.ts
+++ b/packages/core/src/__tests__/public-api.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+// @ts-expect-error — .mjs module without type declarations
+import {
+  extractExports,
+  generateManifest,
+} from "../../scripts/generate-public-api.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(__dirname, "../..");
+
+describe("extractExports()", () => {
+  it("extracts value re-exports", () => {
+    const src = `export { signal, computed } from "./reactive.js";`;
+    expect(extractExports(src)).toEqual(["computed", "signal"]);
+  });
+
+  it("extracts type re-exports", () => {
+    const src = `export type { Signal, ReadonlySignal } from "./reactive.js";`;
+    expect(extractExports(src)).toEqual(["ReadonlySignal", "Signal"]);
+  });
+
+  it("resolves `as` aliases to the exported name", () => {
+    const src = `export { internal as publicName } from "./x.js";`;
+    expect(extractExports(src)).toEqual(["publicName"]);
+  });
+
+  it("handles multi-line export blocks", () => {
+    const src = `
+      export {
+        h,
+        raw,
+        when,
+        each,
+      } from "./elements.js";
+    `;
+    expect(extractExports(src)).toEqual(["each", "h", "raw", "when"]);
+  });
+
+  it("deduplicates names that appear more than once", () => {
+    const src = `
+      export { foo } from "./a.js";
+      export type { foo } from "./b.js";
+    `;
+    expect(extractExports(src)).toEqual(["foo"]);
+  });
+
+  it("ignores commented-out re-export statements", () => {
+    const src = `
+      // export { ghost } from "./nope.js";
+      export { real } from "./x.js";
+    `;
+    expect(extractExports(src)).toEqual(["real"]);
+  });
+
+  it("ignores in-block // comments without swallowing the following name", () => {
+    const src = `
+      export {
+        // Core
+        h,
+        raw,
+      } from "./elements.js";
+    `;
+    expect(extractExports(src)).toEqual(["h", "raw"]);
+  });
+
+  it("extracts canonical exports from the real src/index.ts", () => {
+    const src = readFileSync(resolve(pkgRoot, "src/index.ts"), "utf8");
+    const exports = extractExports(src);
+
+    // Sanity: substantial surface
+    expect(exports.length).toBeGreaterThan(30);
+
+    // Sorted
+    expect(exports).toEqual([...exports].sort());
+
+    // Key public surface must be present
+    for (const name of [
+      "signal",
+      "computed",
+      "effect",
+      "batch",
+      "component",
+      "mount",
+      "resource",
+      "ref",
+      "bind",
+      "Resource",
+      "Signal",
+    ]) {
+      expect(exports).toContain(name);
+    }
+  });
+});
+
+describe("generateManifest()", () => {
+  it("returns version and sorted exports", () => {
+    const manifest = generateManifest(
+      "1.2.3",
+      `export { b, a } from "./x.js"; export type { C } from "./y.js";`,
+    );
+    expect(manifest).toEqual({
+      version: "1.2.3",
+      exports: ["C", "a", "b"],
+    });
+  });
+});
+
+describe("generate-public-api.mjs CLI", () => {
+  const outPath = resolve(pkgRoot, "dist/public-api.json");
+
+  beforeAll(() => {
+    execFileSync(
+      "node",
+      [resolve(pkgRoot, "scripts/generate-public-api.mjs")],
+      { stdio: "pipe" },
+    );
+  });
+
+  it("writes dist/public-api.json", () => {
+    expect(existsSync(outPath)).toBe(true);
+  });
+
+  it("writes valid JSON with version and exports fields", () => {
+    const manifest = JSON.parse(readFileSync(outPath, "utf8"));
+    expect(manifest).toHaveProperty("version");
+    expect(typeof manifest.version).toBe("string");
+    expect(manifest).toHaveProperty("exports");
+    expect(Array.isArray(manifest.exports)).toBe(true);
+    expect(manifest.exports.length).toBeGreaterThan(30);
+  });
+
+  it("version matches package.json", () => {
+    const manifest = JSON.parse(readFileSync(outPath, "utf8"));
+    const pkg = JSON.parse(
+      readFileSync(resolve(pkgRoot, "package.json"), "utf8"),
+    );
+    expect(manifest.version).toBe(pkg.version);
+  });
+
+  it("exports are sorted and unique", () => {
+    const manifest = JSON.parse(readFileSync(outPath, "utf8"));
+    const sorted = [...manifest.exports].sort();
+    expect(manifest.exports).toEqual(sorted);
+    expect(new Set(manifest.exports).size).toBe(manifest.exports.length);
+  });
+});


### PR DESCRIPTION
## Summary
Build-time generator that writes `dist/public-api.json` with the version + the full list of `@whisq/core`'s named exports. The docs repo's drift-check CI (`whisqjs/whisq.dev#15`) fetches this manifest and fails its build if the AI reference card's imports block diverges — no more silent drift.

Publication path is the [pinned decision](https://github.com/whisqjs/whisq/issues/27#issuecomment-4275682658): the manifest ships inside the npm package at `dist/public-api.json`, reachable via any npm CDN:

```
https://unpkg.com/@whisq/core@<version>/dist/public-api.json
https://cdn.jsdelivr.net/npm/@whisq/core@<version>/dist/public-api.json
```

## Shape
```json
{
  "version": "0.1.0-alpha.4",
  "exports": ["BindOptions", "CheckboxBind", "Signal", "bind", "component", "mount", "...", "when"]
}
```

Sorted alphabetically, unique. Currently 85 entries (11 types + 74 values).

## Changes
- **New:** `packages/core/scripts/generate-public-api.mjs` — exports pure `extractExports()` and `generateManifest()` functions + a CLI. Parses `src/index.ts`, strips `//` comments (whole-line and in-block), handles value exports, `type` exports, `as` aliases, and multi-line re-export blocks.
- **Edit:** `packages/core/package.json` — build script becomes `"tsc && node scripts/generate-public-api.mjs"`. No `files[]` change needed (`dist/**` already covers the manifest).
- **New:** `packages/core/src/__tests__/public-api.test.ts` — 13 tests:
  - Extractor: value, type, alias, multi-line, dedup, comment handling
  - Real-file sanity: >30 exports, sorted, canonical names present (`signal`, `component`, `mount`, `bind`, `ref`, `Signal`, `Resource`, ...)
  - Manifest builder: shape + sorting
  - CLI smoke: executes the script, reads the output, validates JSON shape, version match, sorted/unique invariants
- **Edit:** `packages/core/README.md` — short section on the manifest (location, shape, CDN URLs, how it's regenerated).

## Test plan
- [x] `pnpm --filter @whisq/core test` → 238 pass (up from 225)
- [x] `pnpm --filter @whisq/core build` writes `dist/public-api.json` with 85 exports
- [x] `pnpm -r test` / `pnpm -r build` / `tsc --noEmit` clean
- [x] `prettier --check` clean on changed files
- [ ] CI (10 checks) all green

## Backward compat
100%. No existing API changed. The added build step runs after `tsc` and only writes a new file.

## Out of scope
- GitHub release-asset upload (npm path is the decision)
- Docs-repo consumer CI check (`whisqjs/whisq.dev#15`)
- Committed snapshot file — unnecessary; the generator output IS the truth and runs at build.
- `onCleanup`-style lifecycle integration for the generator (it's a CLI, not runtime code)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)