### PR TITLE
WHISQ-21: add match() multi-branch conditional primitive

### DIFF
--- a/packages/core/src/__tests__/match.test.ts
+++ b/packages/core/src/__tests__/match.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { signal } from "../reactive.js";
+import { div, p, span, match, mount } from "../elements.js";
+
+let container: HTMLElement;
+let dispose: () => void;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+});
+
+describe("match()", () => {
+  it("renders the first branch whose predicate is true", () => {
+    const node = div(
+      match([() => true, () => p("first")], [() => true, () => p("second")]),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelectorAll("p")).toHaveLength(1);
+    expect(container.querySelector("p")!.textContent).toBe("first");
+  });
+
+  it("renders a later branch when earlier predicates are false", () => {
+    const node = div(
+      match(
+        [() => false, () => p("skipped")],
+        [() => false, () => p("also skipped")],
+        [() => true, () => p("winner")],
+      ),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelector("p")!.textContent).toBe("winner");
+  });
+
+  it("renders the fallback when no branch matches", () => {
+    const node = div(
+      match([() => false, () => p("a")], [() => false, () => p("b")], () =>
+        p("fallback"),
+      ),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelector("p")!.textContent).toBe("fallback");
+  });
+
+  it("renders nothing when no branch matches and no fallback is given", () => {
+    const node = div(
+      match([() => false, () => p("a")], [() => false, () => p("b")]),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelector("p")).toBeNull();
+  });
+
+  it("is reactive — predicate changes swap the rendered branch", () => {
+    const status = signal<"loading" | "error" | "ready">("loading");
+    const node = div(
+      match(
+        [() => status.value === "loading", () => p("Loading...")],
+        [() => status.value === "error", () => p({ class: "error" }, "Oops")],
+        [() => status.value === "ready", () => p("Done")],
+      ),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelector("p")!.textContent).toBe("Loading...");
+
+    status.value = "error";
+    expect(container.querySelector("p")!.textContent).toBe("Oops");
+    expect(container.querySelector("p")!.className).toBe("error");
+
+    status.value = "ready";
+    expect(container.querySelector("p")!.textContent).toBe("Done");
+  });
+
+  it("renders the fallback when all predicates turn false reactively", () => {
+    const active = signal(true);
+    const node = div(
+      match([() => active.value, () => p("on")], () => p("off")),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelector("p")!.textContent).toBe("on");
+    active.value = false;
+    expect(container.querySelector("p")!.textContent).toBe("off");
+  });
+
+  it("supports complex children (nested hyperscript)", () => {
+    const node = div(
+      match([
+        () => true,
+        () => div({ class: "card" }, p("title"), span("subtitle")),
+      ]),
+    );
+    dispose = mount(node, container);
+
+    const card = container.querySelector(".card");
+    expect(card).not.toBeNull();
+    expect(card!.querySelector("p")!.textContent).toBe("title");
+    expect(card!.querySelector("span")!.textContent).toBe("subtitle");
+  });
+
+  it("returns null when called with no arguments", () => {
+    const node = div(match());
+    dispose = mount(node, container);
+    expect(container.querySelector("p")).toBeNull();
+  });
+
+  it("renders the fallback when branches is empty but fallback is provided", () => {
+    const node = div(match(() => p("only the fallback")));
+    dispose = mount(node, container);
+    expect(container.querySelector("p")!.textContent).toBe("only the fallback");
+  });
+});

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -490,6 +490,46 @@ export function when(
   return () => (condition() ? then() : otherwise ? otherwise() : null);
 }
 
+// ── match() — Multi-branch conditional rendering ───────────────────────────
+
+type MatchRender = () => WhisqNode | string | null;
+type MatchBranch = readonly [() => boolean, MatchRender];
+
+/**
+ * Multi-branch conditional renderer. Evaluates branches in order and renders
+ * the first whose predicate returns truthy. An optional trailing fallback
+ * (a bare render function, not wrapped in a tuple) renders when no branch
+ * matches. Re-evaluates reactively like other children.
+ *
+ * ```ts
+ * div(
+ *   match(
+ *     [() => users.loading(),    () => p("Loading...")],
+ *     [() => !!users.error(),    () => p({ class: "error" }, users.error()!.message)],
+ *     [() => !!users.data(),     () => List({ items: users.data()! })],
+ *     () => p("No data yet."), // fallback
+ *   ),
+ * )
+ * ```
+ *
+ * First-true-wins: if two predicates are true, only the earlier branch renders.
+ */
+export function match(...branches: MatchBranch[]): () => Child;
+export function match(...args: [...MatchBranch[], MatchRender]): () => Child;
+export function match(...args: Array<MatchBranch | MatchRender>): () => Child {
+  const last = args[args.length - 1];
+  const hasFallback = typeof last === "function";
+  const fallback = hasFallback ? (last as MatchRender) : undefined;
+  const branches = (hasFallback ? args.slice(0, -1) : args) as MatchBranch[];
+
+  return () => {
+    for (const [predicate, render] of branches) {
+      if (predicate()) return render();
+    }
+    return fallback ? fallback() : null;
+  };
+}
+
 // ── each() — List rendering ────────────────────────────────────────────────
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export {
   h,
   raw,
   when,
+  match,
   each,
   errorBoundary,
   portal,


### PR DESCRIPTION
## Summary
`match()` is the multi-branch sibling of `when()`. It collapses the tri-state loading/error/data pattern `resource()` produces from three chained `when()` calls into one readable declarative block:

```ts
div(
  match(
    [() => users.loading(), () => p("Loading...")],
    [() => !!users.error(), () => p({ class: "error" }, users.error()!.message)],
    [() => !!users.data(),  () => List({ items: users.data()! })],
    () => p("No data yet."),  // optional fallback (bare function, no tuple)
  ),
)
```

## Semantics
- Evaluates predicates in order; renders the first branch whose predicate is truthy.
- **First-true-wins** — later branches don't render even if their predicates are also true.
- Final trailing bare `() => Child` is the fallback; absent + no match → `null`.
- Reactive: evaluates through the same child-rendering path as `when()`.

## API
```ts
match(...branches: [() => boolean, () => Child][]): () => Child
match(...branches: [...[() => boolean, () => Child][], () => Child]): () => Child
```

TypeScript distinguishes branch tuples from a bare fallback function at the call site — the implementation inspects the final arg at runtime.

## Changes
- `packages/core/src/elements.ts` — `match()` added right after `when()`
- `packages/core/src/index.ts` — export `match`
- `packages/core/src/__tests__/match.test.ts` — 9 new tests

## Test plan
- [x] `pnpm --filter @whisq/core test` → 247 pass (up from 238)
- [x] Tests cover: first-match, order-preserving, fallback (static + reactive), no-match-no-fallback, predicate flipping, complex children, empty args, fallback-only
- [x] `pnpm -r test` all green
- [x] `pnpm -r build` clean, `tsc --noEmit` clean, `prettier --check` clean
- [ ] CI (10 checks) all green

## Out of scope
- `switchOn()` discriminator-style — `match()` alone handles the same patterns; follow-up if desired.
- TypeScript narrowing across branches

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)