### PR TITLE
WHISQ-22: add object form to style prop + sx() helper

### DIFF
--- a/packages/core/src/__tests__/style-object.test.ts
+++ b/packages/core/src/__tests__/style-object.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { signal } from "../reactive.js";
+import { div, mount } from "../elements.js";
+import { sx } from "../styling.js";
+
+let container: HTMLElement;
+let dispose: () => void;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+});
+
+describe("style prop — object form", () => {
+  it("applies static properties on mount", () => {
+    const node = div({ style: { color: "red", padding: "1rem" } });
+    dispose = mount(node, container);
+
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.color).toBe("red");
+    expect(el.style.padding).toBe("1rem");
+  });
+
+  it("reactively updates a property when its signal changes", () => {
+    const color = signal("red");
+    const node = div({ style: { color: () => color.value } });
+    dispose = mount(node, container);
+
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.color).toBe("red");
+
+    color.value = "blue";
+    expect(el.style.color).toBe("blue");
+  });
+
+  it("updates only the changed property, not others", () => {
+    const color = signal("red");
+    const padding = signal("1rem");
+    const node = div({
+      style: {
+        color: () => color.value,
+        padding: () => padding.value,
+      },
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    color.value = "blue";
+    expect(el.style.color).toBe("blue");
+    expect(el.style.padding).toBe("1rem");
+  });
+
+  it("mixes static and reactive properties", () => {
+    const x = signal(10);
+    const node = div({
+      style: {
+        color: "red",
+        transform: () => `translateX(${x.value}px)`,
+      },
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.color).toBe("red");
+    expect(el.style.transform).toBe("translateX(10px)");
+    x.value = 20;
+    expect(el.style.transform).toBe("translateX(20px)");
+  });
+
+  it("converts camelCase keys to kebab-case", () => {
+    const node = div({
+      style: { backgroundColor: "yellow", borderRadius: "4px" },
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.backgroundColor).toBe("yellow");
+    expect(el.style.borderRadius).toBe("4px");
+  });
+
+  it("accepts kebab-case keys directly", () => {
+    const node = div({ style: { "background-color": "yellow" } });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.backgroundColor).toBe("yellow");
+  });
+
+  it("passes CSS custom properties through unchanged", () => {
+    const accent = signal("#5ce0f2");
+    const node = div({ style: { "--accent": () => accent.value } });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.getPropertyValue("--accent")).toBe("#5ce0f2");
+    accent.value = "#4F46E5";
+    expect(el.style.getPropertyValue("--accent")).toBe("#4F46E5");
+  });
+
+  it("removes the property when the getter returns undefined", () => {
+    const color = signal<string | undefined>("red");
+    const node = div({ style: { color: () => color.value } });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.color).toBe("red");
+    color.value = undefined;
+    expect(el.style.color).toBe("");
+  });
+
+  it("removes the property when the getter returns empty string", () => {
+    const pad = signal("1rem");
+    const node = div({ style: { padding: () => pad.value } });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    pad.value = "";
+    expect(el.style.padding).toBe("");
+  });
+
+  it("coerces numeric values to string", () => {
+    const op = signal(1);
+    const node = div({
+      style: {
+        opacity: () => op.value,
+        zIndex: 5,
+      },
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.opacity).toBe("1");
+    expect(el.style.zIndex).toBe("5");
+    op.value = 0;
+    expect(el.style.opacity).toBe("0");
+  });
+
+  it("skips null and empty-string static entries without error", () => {
+    const node = div({
+      style: {
+        color: "red",
+        padding: null,
+        margin: "",
+      },
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.color).toBe("red");
+    expect(el.style.padding).toBe("");
+    expect(el.style.margin).toBe("");
+  });
+
+  // Regression checks — make sure the existing forms still work.
+
+  it("regression — static string form still sets cssText", () => {
+    const node = div({ style: "color: red; padding: 1rem" });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.color).toBe("red");
+    expect(el.style.padding).toBe("1rem");
+  });
+
+  it("regression — reactive string form still updates", () => {
+    const c = signal("red");
+    const node = div({ style: () => `color: ${c.value}` });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.color).toBe("red");
+    c.value = "blue";
+    expect(el.style.color).toBe("blue");
+  });
+});
+
+describe("sx() — style composition", () => {
+  it("merges multiple objects, later wins", () => {
+    expect(sx({ a: "1", b: "2" }, { b: "3", c: "4" })).toEqual({
+      a: "1",
+      b: "3",
+      c: "4",
+    });
+  });
+
+  it("ignores false / null / undefined args", () => {
+    expect(sx({ a: "1" }, false, null, undefined, { b: "2" })).toEqual({
+      a: "1",
+      b: "2",
+    });
+  });
+
+  it("preserves function values without invoking them", () => {
+    const getter = () => "red";
+    const merged = sx({ color: getter });
+    expect(merged.color).toBe(getter);
+  });
+
+  it("supports the conditional `cond && {...}` pattern", () => {
+    const active = true;
+    const merged = sx({ color: "red" }, active && { borderColor: "blue" }, {
+      padding: "1rem",
+    });
+    expect(merged).toEqual({
+      color: "red",
+      borderColor: "blue",
+      padding: "1rem",
+    });
+  });
+
+  it("integrates with the style prop (composition end-to-end)", () => {
+    const active = signal(true);
+    const node = div({
+      style: sx({ color: "red" }, active.value && { borderColor: "blue" }, {
+        padding: () => (active.value ? "1rem" : "0"),
+      }),
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.color).toBe("red");
+    expect(el.style.borderColor).toBe("blue");
+    expect(el.style.padding).toBe("1rem");
+  });
+});

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -32,11 +32,14 @@ type EventHandler<E extends Event = Event> = (event: E) => void;
 
 type ReactiveProp<T> = T | (() => T);
 
+type StyleValue = string | number | null | undefined;
+export type StyleObject = Record<string, StyleValue | (() => StyleValue)>;
+
 interface BaseProps {
   ref?: Ref;
   class?: ReactiveProp<string | undefined>;
   id?: ReactiveProp<string | undefined>;
-  style?: ReactiveProp<string | undefined>;
+  style?: ReactiveProp<string | undefined> | StyleObject;
   hidden?: ReactiveProp<boolean>;
   title?: ReactiveProp<string | undefined>;
   [key: `data-${string}`]: ReactiveProp<string | undefined>;
@@ -156,6 +159,11 @@ export function h(
             (value as (el: HTMLElement | null) => void)(null);
           });
         }
+        continue;
+      }
+      if (key === "style" && isPlainStyleObject(value)) {
+        // Style object — per-property reactive subscriptions
+        applyStyleObject(el as HTMLElement, value, disposers);
         continue;
       }
       if (key.startsWith("on") && typeof value === "function") {
@@ -818,6 +826,42 @@ export function mount(node: WhisqNode, container: Element): () => void {
 }
 
 // ── Internal ────────────────────────────────────────────────────────────────
+
+function isPlainStyleObject(value: unknown): value is StyleObject {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function camelToKebab(str: string): string {
+  return str.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+}
+
+function applyStyleObject(
+  el: HTMLElement,
+  style: StyleObject,
+  disposers: (() => void)[],
+): void {
+  for (const [prop, raw] of Object.entries(style)) {
+    const cssProp = prop.startsWith("--") ? prop : camelToKebab(prop);
+    if (typeof raw === "function") {
+      const getter = raw as () => StyleValue;
+      const dispose = effect(() => {
+        const v = getter();
+        if (v == null || v === "") {
+          el.style.removeProperty(cssProp);
+        } else {
+          el.style.setProperty(cssProp, String(v));
+        }
+      });
+      disposers.push(dispose);
+    } else if (raw != null && raw !== "") {
+      el.style.setProperty(cssProp, String(raw));
+    }
+  }
+}
 
 function applyProp(el: Element, key: string, value: unknown): void {
   if (key === "class") {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,7 +105,8 @@ export { ref } from "./ref.js";
 export type { Ref } from "./ref.js";
 
 // Styling
-export { sheet, styles, cx, rcx, theme } from "./styling.js";
+export { sheet, styles, cx, rcx, sx, theme } from "./styling.js";
+export type { StyleObject } from "./elements.js";
 
 // Forms
 export { bind } from "./bind.js";

--- a/packages/core/src/styling.ts
+++ b/packages/core/src/styling.ts
@@ -245,6 +245,46 @@ export function rcx(
   };
 }
 
+// ── sx() — Style object composition ────────────────────────────────────────
+
+type SxStyleValue = string | number | null | undefined;
+type SxStyleSource =
+  | Record<string, SxStyleValue | (() => SxStyleValue)>
+  | false
+  | null
+  | undefined;
+
+/**
+ * Merge style objects into a single object suitable for the element `style`
+ * prop. Later sources override earlier ones. Falsy sources (false / null /
+ * undefined) are skipped — useful for conditionals.
+ *
+ * ```ts
+ * div({
+ *   style: sx(
+ *     { color: "red", padding: "1rem" },           // base
+ *     active.value && { borderColor: "blue" },     // conditional
+ *     { transform: () => `translateX(${x.value}px)` }, // reactive
+ *   ),
+ * })
+ * ```
+ *
+ * Function values are preserved (not eagerly invoked), so the reactive
+ * per-property subscription in the `style` prop still sees them.
+ */
+export function sx(
+  ...sources: SxStyleSource[]
+): Record<string, SxStyleValue | (() => SxStyleValue)> {
+  const merged: Record<string, SxStyleValue | (() => SxStyleValue)> = {};
+  for (const source of sources) {
+    if (!source) continue;
+    for (const [key, value] of Object.entries(source)) {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
 // ── theme() — Design Tokens ────────────────────────────────────────────────
 
 type ThemeTokens = Record<


### PR DESCRIPTION
## Summary
Two additive style-prop improvements with full backward compat.

### 1. Object form for the element `style` prop

```ts
div({ style: {
  color: "red",
  opacity: () => visible.value ? 1 : 0,
  transform: () => `translateX(${x.value}px)`,
  "--accent": () => theme.value,
}})
```

Each property with a function gets its **own** `effect()` subscription, so changing one signal triggers exactly one `el.style.setProperty` call. Fixes the "coarse reactivity" of the string form (which re-stringifies the whole declaration on any change).

- camelCase keys → kebab-case; kebab works directly
- CSS custom properties (`--*`) pass through unchanged
- Getter returning `undefined` / `null` / `""` removes the property
- Numeric values coerced to string

### 2. `sx()` helper in `styling.ts`

```ts
div({ style: sx(
  { color: "red" },
  active.value && { borderColor: "blue" },   // conditional
  { padding: () => `${px.value}px` },        // reactive
)})
```

Later sources override earlier; falsy sources skipped; function values preserved (not eagerly invoked).

## Changes
- `packages/core/src/elements.ts` — new `StyleObject` type, early style-object branch in prop loop, `applyStyleObject()` + `camelToKebab()` helpers, `BaseProps.style` widened.
- `packages/core/src/styling.ts` — `sx()`.
- `packages/core/src/index.ts` — export `sx` + type `StyleObject`.
- `packages/core/src/__tests__/style-object.test.ts` — 18 new tests.

## Test plan
- [x] `pnpm --filter @whisq/core test` → 265 pass (up from 247)
- [x] Covers: static/reactive/mixed/camelCase/kebab/custom-props/undefined-removal/numeric-coercion + both regression paths (string form, `() => string`) + `sx()` merging/conditionals/composition/end-to-end
- [x] `pnpm -r test` all green
- [x] `pnpm -r build` clean, `tsc --noEmit` clean, `prettier --check` clean
- [ ] CI (10 checks) all green

## Backward compat
100%. `string` and `() => string` forms still work via their original paths; the new handling is a narrow early-return branch before them.

## Out of scope
Type-safe CSS property names, vendor prefixes, `!important`, deprecation of the string form.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)