### PR TITLE
WHISQ-23: add signalMap and signalSet reactive collections

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./collections": {
+      "types": "./dist/collections.d.ts",
+      "import": "./dist/collections.js"
     }
   },
   "files": [

--- a/packages/core/src/__tests__/collections.test.ts
+++ b/packages/core/src/__tests__/collections.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi } from "vitest";
+import { effect } from "../reactive.js";
+import { signalMap, signalSet } from "../collections.js";
+
+describe("signalMap()", () => {
+  it("accepts initial entries", () => {
+    const m = signalMap<string, number>([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    expect(m.get("a")).toBe(1);
+    expect(m.get("b")).toBe(2);
+    expect(m.size).toBe(2);
+  });
+
+  it("set / get / has / delete round-trip", () => {
+    const m = signalMap<string, number>();
+    expect(m.has("x")).toBe(false);
+
+    m.set("x", 42);
+    expect(m.has("x")).toBe(true);
+    expect(m.get("x")).toBe(42);
+
+    expect(m.delete("x")).toBe(true);
+    expect(m.delete("x")).toBe(false);
+    expect(m.has("x")).toBe(false);
+    expect(m.get("x")).toBeUndefined();
+  });
+
+  it("get() subscription fires only when that key changes", () => {
+    const m = signalMap<string, number>();
+    m.set("a", 1);
+    m.set("b", 2);
+
+    const spy = vi.fn(() => {
+      m.get("a");
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.set("b", 99); // different key
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.set("a", 5);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("has() subscription fires only on add/delete of that key", () => {
+    const m = signalMap<string, number>();
+
+    const spy = vi.fn(() => {
+      m.has("a");
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.set("b", 1);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.set("a", 1);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    m.delete("a");
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it("size is reactive on add/delete/clear", () => {
+    const m = signalMap<string, number>();
+
+    let seen: number[] = [];
+    effect(() => {
+      seen.push(m.size);
+    });
+    expect(seen).toEqual([0]);
+
+    m.set("a", 1);
+    m.set("b", 2);
+    expect(seen).toEqual([0, 1, 2]);
+
+    m.delete("a");
+    expect(seen).toEqual([0, 1, 2, 1]);
+
+    m.clear();
+    expect(seen).toEqual([0, 1, 2, 1, 0]);
+  });
+
+  it("iteration subscribes to structural changes", () => {
+    const m = signalMap<string, number>([["a", 1]]);
+    let snapshots: string[][] = [];
+
+    effect(() => {
+      snapshots.push([...m.keys()]);
+    });
+    expect(snapshots).toEqual([["a"]]);
+
+    m.set("b", 2);
+    expect(snapshots).toEqual([["a"], ["a", "b"]]);
+
+    m.delete("a");
+    expect(snapshots).toEqual([["a"], ["a", "b"], ["b"]]);
+  });
+
+  it("setting the same value twice on an existing key still triggers (no Object.is skip)", () => {
+    // Matches Map's semantics — set always emits, consistent with how other
+    // reactive libs behave for collections. Users can check before setting.
+    const m = signalMap<string, number>([["a", 1]]);
+    const spy = vi.fn(() => {
+      m.get("a");
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.set("a", 1);
+    m.set("a", 1);
+    // Each set notifies. The underlying signal() dedup's via Object.is, so
+    // identical values should NOT re-fire.
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves undefined as a valid stored value (distinct from absent)", () => {
+    const m = signalMap<string, number | undefined>();
+    m.set("x", undefined);
+    expect(m.has("x")).toBe(true);
+    expect(m.get("x")).toBeUndefined();
+
+    m.delete("x");
+    expect(m.has("x")).toBe(false);
+  });
+
+  it("forEach passes (value, key, map)", () => {
+    const m = signalMap<string, number>([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    const seen: Array<[number, string]> = [];
+    m.forEach((v, k) => seen.push([v, k]));
+    expect(seen).toEqual([
+      [1, "a"],
+      [2, "b"],
+    ]);
+  });
+
+  it("set returns the map (chainable)", () => {
+    const m = signalMap<string, number>();
+    const res = m.set("a", 1).set("b", 2);
+    expect(res).toBe(m);
+    expect(m.size).toBe(2);
+  });
+
+  it("clear on an empty map is a no-op (no subscriber re-runs)", () => {
+    const m = signalMap<string, number>();
+    const spy = vi.fn(() => {
+      m.size;
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.clear();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("signalSet()", () => {
+  it("accepts initial values", () => {
+    const s = signalSet<string>(["a", "b"]);
+    expect(s.has("a")).toBe(true);
+    expect(s.has("b")).toBe(true);
+    expect(s.size).toBe(2);
+  });
+
+  it("add / has / delete round-trip", () => {
+    const s = signalSet<string>();
+    expect(s.has("x")).toBe(false);
+
+    s.add("x");
+    expect(s.has("x")).toBe(true);
+
+    expect(s.delete("x")).toBe(true);
+    expect(s.delete("x")).toBe(false);
+    expect(s.has("x")).toBe(false);
+  });
+
+  it("has() subscription fires only for that value", () => {
+    const s = signalSet<string>();
+
+    const spy = vi.fn(() => {
+      s.has("admin");
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    s.add("user"); // different value
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    s.add("admin");
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    s.delete("admin");
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it("size is reactive", () => {
+    const s = signalSet<string>();
+    let seen: number[] = [];
+    effect(() => {
+      seen.push(s.size);
+    });
+    expect(seen).toEqual([0]);
+
+    s.add("a");
+    s.add("b");
+    expect(seen).toEqual([0, 1, 2]);
+
+    s.delete("a");
+    expect(seen).toEqual([0, 1, 2, 1]);
+
+    s.clear();
+    expect(seen).toEqual([0, 1, 2, 1, 0]);
+  });
+
+  it("duplicate add() is a no-op", () => {
+    const s = signalSet<string>(["a"]);
+    const spy = vi.fn(() => {
+      s.size;
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    s.add("a"); // already present
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("iteration subscribes to structural changes", () => {
+    const s = signalSet<string>(["a"]);
+    const snapshots: string[][] = [];
+
+    effect(() => {
+      snapshots.push([...s]);
+    });
+    expect(snapshots).toEqual([["a"]]);
+
+    s.add("b");
+    expect(snapshots).toEqual([["a"], ["a", "b"]]);
+  });
+
+  it("forEach passes (value, value, set)", () => {
+    const s = signalSet<string>(["a", "b"]);
+    const seen: string[] = [];
+    s.forEach((v, v2, setArg) => {
+      expect(v).toBe(v2);
+      expect(setArg).toBe(s);
+      seen.push(v);
+    });
+    expect(seen).toEqual(["a", "b"]);
+  });
+
+  it("add returns the set (chainable)", () => {
+    const s = signalSet<string>();
+    const res = s.add("a").add("b");
+    expect(res).toBe(s);
+    expect(s.size).toBe(2);
+  });
+});

--- a/packages/core/src/__tests__/collections.test.ts
+++ b/packages/core/src/__tests__/collections.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { effect } from "../reactive.js";
+// Imported from the internal module path. Public API is
+// `@whisq/core/collections` (see packages/core/package.json exports).
 import { signalMap, signalSet } from "../collections.js";
 
 describe("signalMap()", () => {

--- a/packages/core/src/collections.ts
+++ b/packages/core/src/collections.ts
@@ -1,0 +1,243 @@
+// ============================================================================
+// Whisq Core — Reactive Collections
+//
+// signalMap<K, V> and signalSet<T> — Map/Set with per-key reactivity so
+// effects only re-run when the keys they actually read change. Built on
+// top of signal() so they participate in the same tracking/batching system
+// as the rest of the reactive core.
+// ============================================================================
+
+import { signal, type Signal } from "./reactive.js";
+
+const MISSING: unique symbol = Symbol("whisq.collections.missing");
+type Missing = typeof MISSING;
+
+// ── signalMap ──────────────────────────────────────────────────────────────
+
+export interface SignalMap<K, V> {
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  set(key: K, value: V): SignalMap<K, V>;
+  delete(key: K): boolean;
+  clear(): void;
+  readonly size: number;
+  keys(): IterableIterator<K>;
+  values(): IterableIterator<V>;
+  entries(): IterableIterator<[K, V]>;
+  [Symbol.iterator](): IterableIterator<[K, V]>;
+  forEach(fn: (value: V, key: K, map: SignalMap<K, V>) => void): void;
+}
+
+/**
+ * A reactive Map where each key has its own subscriber set. Effects that read
+ * a specific key via `.get()` or `.has()` re-run only when that key changes;
+ * effects that iterate or read `.size` re-run on any structural change.
+ *
+ * ```ts
+ * const users = signalMap<string, User>();
+ * users.set("u1", alice);
+ * effect(() => console.log(users.get("u1")?.name));  // tracks "u1" only
+ * users.set("u2", bob);   // effect does NOT re-run
+ * users.set("u1", carol); // effect re-runs
+ * ```
+ */
+export function signalMap<K, V>(
+  initial?: Iterable<readonly [K, V]>,
+): SignalMap<K, V> {
+  const data = new Map<K, V>(initial as Iterable<[K, V]> | undefined);
+  const keySignals = new Map<K, Signal<V | Missing>>();
+  const structure = signal(0);
+
+  function keySig(key: K): Signal<V | Missing> {
+    let s = keySignals.get(key);
+    if (!s) {
+      s = signal<V | Missing>(data.has(key) ? (data.get(key) as V) : MISSING);
+      keySignals.set(key, s);
+    }
+    return s;
+  }
+
+  function bumpStructure(): void {
+    structure.value = structure.value + 1;
+  }
+
+  const map: SignalMap<K, V> = {
+    get(key: K): V | undefined {
+      const v = keySig(key).value;
+      return v === MISSING ? undefined : v;
+    },
+
+    has(key: K): boolean {
+      return keySig(key).value !== MISSING;
+    },
+
+    set(key: K, value: V): SignalMap<K, V> {
+      const existed = data.has(key);
+      data.set(key, value);
+      keySig(key).value = value;
+      if (!existed) bumpStructure();
+      return map;
+    },
+
+    delete(key: K): boolean {
+      if (!data.has(key)) return false;
+      data.delete(key);
+      const sig = keySignals.get(key);
+      if (sig) sig.value = MISSING;
+      bumpStructure();
+      return true;
+    },
+
+    clear(): void {
+      if (data.size === 0) return;
+      for (const k of [...data.keys()]) {
+        data.delete(k);
+        const sig = keySignals.get(k);
+        if (sig) sig.value = MISSING;
+      }
+      bumpStructure();
+    },
+
+    get size(): number {
+      structure.value; // track structural changes
+      return data.size;
+    },
+
+    keys(): IterableIterator<K> {
+      structure.value; // track
+      return data.keys();
+    },
+
+    values(): IterableIterator<V> {
+      structure.value;
+      return data.values();
+    },
+
+    entries(): IterableIterator<[K, V]> {
+      structure.value;
+      return data.entries();
+    },
+
+    [Symbol.iterator](): IterableIterator<[K, V]> {
+      structure.value;
+      return data.entries();
+    },
+
+    forEach(fn: (value: V, key: K, m: SignalMap<K, V>) => void): void {
+      structure.value;
+      data.forEach((v, k) => fn(v, k, map));
+    },
+  };
+
+  return map;
+}
+
+// ── signalSet ──────────────────────────────────────────────────────────────
+
+export interface SignalSet<T> {
+  has(value: T): boolean;
+  add(value: T): SignalSet<T>;
+  delete(value: T): boolean;
+  clear(): void;
+  readonly size: number;
+  keys(): IterableIterator<T>;
+  values(): IterableIterator<T>;
+  entries(): IterableIterator<[T, T]>;
+  [Symbol.iterator](): IterableIterator<T>;
+  forEach(fn: (value: T, value2: T, set: SignalSet<T>) => void): void;
+}
+
+/**
+ * A reactive Set with per-value membership signals — effects that read
+ * `.has(x)` re-run only when `x` is added or removed, not on other changes.
+ *
+ * ```ts
+ * const selected = signalSet<string>();
+ * effect(() => console.log(selected.has("admin")));  // tracks "admin" only
+ * selected.add("user");   // effect does NOT re-run
+ * selected.add("admin");  // effect re-runs
+ * ```
+ */
+export function signalSet<T>(initial?: Iterable<T>): SignalSet<T> {
+  const data = new Set<T>(initial);
+  const memberSignals = new Map<T, Signal<boolean>>();
+  const structure = signal(0);
+
+  function memberSig(value: T): Signal<boolean> {
+    let s = memberSignals.get(value);
+    if (!s) {
+      s = signal<boolean>(data.has(value));
+      memberSignals.set(value, s);
+    }
+    return s;
+  }
+
+  function bumpStructure(): void {
+    structure.value = structure.value + 1;
+  }
+
+  const set: SignalSet<T> = {
+    has(value: T): boolean {
+      return memberSig(value).value;
+    },
+
+    add(value: T): SignalSet<T> {
+      if (data.has(value)) return set;
+      data.add(value);
+      memberSig(value).value = true;
+      bumpStructure();
+      return set;
+    },
+
+    delete(value: T): boolean {
+      if (!data.has(value)) return false;
+      data.delete(value);
+      const sig = memberSignals.get(value);
+      if (sig) sig.value = false;
+      bumpStructure();
+      return true;
+    },
+
+    clear(): void {
+      if (data.size === 0) return;
+      for (const v of [...data]) {
+        data.delete(v);
+        const sig = memberSignals.get(v);
+        if (sig) sig.value = false;
+      }
+      bumpStructure();
+    },
+
+    get size(): number {
+      structure.value;
+      return data.size;
+    },
+
+    keys(): IterableIterator<T> {
+      structure.value;
+      return data.values();
+    },
+
+    values(): IterableIterator<T> {
+      structure.value;
+      return data.values();
+    },
+
+    entries(): IterableIterator<[T, T]> {
+      structure.value;
+      return data.entries();
+    },
+
+    [Symbol.iterator](): IterableIterator<T> {
+      structure.value;
+      return data.values();
+    },
+
+    forEach(fn: (v: T, v2: T, s: SignalSet<T>) => void): void {
+      structure.value;
+      data.forEach((v) => fn(v, v, set));
+    },
+  };
+
+  return set;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,9 +14,9 @@
 export { signal, computed, effect, batch } from "./reactive.js";
 export type { Signal, ReadonlySignal } from "./reactive.js";
 
-// Reactive collections
-export { signalMap, signalSet } from "./collections.js";
-export type { SignalMap, SignalSet } from "./collections.js";
+// Reactive collections (signalMap, signalSet) live in a sub-path import
+// to keep the top-level bundle under 5 KB:
+//   import { signalMap, signalSet } from "@whisq/core/collections";
 
 // Element functions (primary API)
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,10 @@
 export { signal, computed, effect, batch } from "./reactive.js";
 export type { Signal, ReadonlySignal } from "./reactive.js";
 
+// Reactive collections
+export { signalMap, signalSet } from "./collections.js";
+export type { SignalMap, SignalSet } from "./collections.js";
+
 // Element functions (primary API)
 export {
   // Core


### PR DESCRIPTION
## Summary
Two reactive collection primitives with per-key/per-value subscriptions, built on top of `signal()` so they participate in the same tracking and batching as the rest of the reactive core.

```ts
const users = signalMap<string, User>();
users.set("u1", alice);
effect(() => users.get("u1")?.name);   // tracks "u1" only
users.set("u2", bob);    // effect does NOT re-run
users.set("u1", carol);  // effect re-runs

const selected = signalSet<string>();
effect(() => selected.has("admin"));   // tracks "admin" only
selected.add("user");    // effect does NOT re-run
selected.add("admin");   // effect re-runs
```

## Internals
- Lazy per-key/per-value `Signal<...>` created on first read.
- A `MISSING` sentinel lets `signalMap` represent `V = undefined` as a valid stored value, distinct from "absent".
- A `structure` signal fires on add/delete/clear so `.size` and iteration (`keys`/`values`/`entries`/`forEach`/`for..of`) re-run on shape changes.

## Behavior matches `Map`/`Set` semantics
- Chainable `set()`/`add()` returns the collection
- `forEach((value, key, collection))`
- Idempotent writes (same value via `Object.is`, re-add of existing member, `clear()` on empty) do not notify

## Changes
- **New** `packages/core/src/collections.ts` — `signalMap<K, V>()`, `signalSet<T>()`, types
- `packages/core/src/index.ts` — export both + types
- **New** `packages/core/src/__tests__/collections.test.ts` — 19 tests

## Test plan
- [x] `pnpm --filter @whisq/core test` → 284 pass (up from 265)
- [x] Covers: initial values, round-trips, per-key isolation, reactive size, clear semantics, iteration, idempotent writes, undefined-as-valid-value (map), duplicate add no-op (set), chainability, forEach signature
- [x] `pnpm -r test` all green
- [x] `pnpm -r build` clean, `tsc --noEmit` clean, `prettier --check` clean
- [ ] CI (10 checks) all green

## Out of scope
- WeakMap / WeakSet variants
- Deep reactivity (nested objects)
- Auto-cleanup of empty per-key signals on delete (retained so live subscribers don't see behavior changes)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)