### PR TITLE
WHISQ-33: notify docs on release published

### DIFF
--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -1,0 +1,53 @@
+name: Notify docs on release
+
+# Fires a repository_dispatch event at whisqjs/whisq.dev whenever a
+# release is published here. The receiver over there
+# (.github/workflows/on-framework-release.yml) opens a tracking issue
+# with the release notes and a docs checklist.
+#
+# Design: whisqjs/whisq.dev#21.
+
+on:
+  release:
+    types: [published]
+  # Manual override for end-to-end testing without cutting a release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to simulate (e.g. v0.1.0-alpha.5)
+        required: true
+        default: test-dispatch
+      body:
+        description: Release notes markdown (optional)
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch to docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.WHISQ_BOT_APP_ID }}
+          private-key: ${{ secrets.WHISQ_BOT_PRIVATE_KEY }}
+          owner: whisqjs
+          repositories: whisq.dev
+
+      - name: Send repository_dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: whisqjs/whisq.dev
+          event-type: framework-release
+          client-payload: |-
+            {
+              "tag": ${{ toJSON(github.event.release.tag_name || github.event.inputs.tag) }},
+              "name": ${{ toJSON(github.event.release.name) }},
+              "body": ${{ toJSON(github.event.release.body || github.event.inputs.body) }},
+              "html_url": ${{ toJSON(github.event.release.html_url) }}
+            }


### PR DESCRIPTION
Closes #33

## Summary

- Adds `.github/workflows/notify-docs-on-release.yml` — fires on `release: published`, mints a token via the `whisq-bot` GitHub App (`WHISQ_BOT_APP_ID` / `WHISQ_BOT_PRIVATE_KEY` repo secrets), sends a `repository_dispatch` of type `framework-release` at `whisqjs/whisq.dev`.
- The receiver workflow on the docs side (`whisqjs/whisq.dev/.github/workflows/on-framework-release.yml`, merged via [whisqjs/whisq.dev#23](https://github.com/whisqjs/whisq.dev/pull/23)) handles the actual issue creation, including a duplicate-issue guard, blockquoted release notes, and a docs checklist.
- Also exposes `workflow_dispatch` with `tag` / `body` inputs so we can test end-to-end without cutting a real release.

## Differences from the draft in #33

- **Auth: GitHub App (`whisq-bot`) instead of `DOCS_REPO_TOKEN` PAT.** No expiry to chase, scales to future cross-repo plumbing (e.g. the deploy hook from whisqjs/whisq.dev#18). App is installed only on `whisqjs/whisq` and `whisqjs/whisq.dev` with `Contents: read+write`, `Issues: read+write`, `Metadata: read-only`. The minted token here is scoped to `whisq.dev` only via `repositories: whisq.dev`.
- **Pattern: `repository_dispatch` to a docs-side receiver instead of direct `github.rest.issues.create()` from this repo.** Keeps the issue body / checklist / labels owned by the docs repo (where docs maintainers naturally edit them) and decouples future docs-side responses (e.g. additional jobs that refresh the playground bundle, ping Slack, or trigger a redeploy).

## Acceptance criteria (from #33)

- [x] Workflow added at `.github/workflows/notify-docs-on-release.yml`.
- [x] Cross-repo auth set up (GitHub App, not PAT). Both `WHISQ_BOT_APP_ID` and `WHISQ_BOT_PRIVATE_KEY` confirmed via `gh secret list --repo whisqjs/whisq`.
- [ ] **Dry-run end-to-end** — verify after merge: `gh workflow run notify-docs-on-release.yml --repo whisqjs/whisq --ref develop -f tag=test-dispatch -f body="smoke test"` should produce a `[TEST] Document test-dispatch` issue in `whisqjs/whisq.dev`.
- [x] **Idempotency** — handled by the receiver's exact-title duplicate guard. Re-dispatching the same tag logs a notice and skips creation.

## Notes

- For `release: published`, GitHub runs workflows from the repo's default branch (`develop` here), so this PR landing on develop is enough — no main-targeting needed.
- Action versions match this repo's existing convention (`actions/create-github-app-token@v1` for third-party, the dispatcher action `peter-evans/repository-dispatch@v3` is also major-pinned). If you decide to switch to SHA-pinning across the board, that's a separate sweep across all workflows.
