### PR TITLE
WHISQ-33: build dispatcher payload in a shell step

### DIFF
--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -16,10 +16,13 @@ on:
       tag:
         description: Release tag to simulate (e.g. v0.1.0-alpha.5)
         required: true
+        type: string
         default: test-dispatch
       body:
         description: Release notes markdown (optional)
         required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -38,16 +41,38 @@ jobs:
           owner: whisqjs
           repositories: whisq.dev
 
+      - name: Build payload
+        id: payload
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_BODY: ${{ inputs.body }}
+        run: |
+          set -euo pipefail
+          TAG="${RELEASE_TAG:-$INPUT_TAG}"
+          NAME="${RELEASE_NAME:-}"
+          BODY="${RELEASE_BODY:-${INPUT_BODY:-}}"
+          URL="${RELEASE_URL:-}"
+          PAYLOAD=$(jq -nc \
+            --arg tag "$TAG" \
+            --arg name "$NAME" \
+            --arg body "$BODY" \
+            --arg html_url "$URL" \
+            '{tag: $tag, name: $name, body: $body, html_url: $html_url}')
+          {
+            echo "payload<<EOF"
+            echo "$PAYLOAD"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Send repository_dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: whisqjs/whisq.dev
           event-type: framework-release
-          client-payload: |-
-            {
-              "tag": ${{ toJSON(github.event.release.tag_name || github.event.inputs.tag) }},
-              "name": ${{ toJSON(github.event.release.name) }},
-              "body": ${{ toJSON(github.event.release.body || github.event.inputs.body) }},
-              "html_url": ${{ toJSON(github.event.release.html_url) }}
-            }
+          client-payload: ${{ steps.payload.outputs.payload }}


### PR DESCRIPTION
Hot-fix for the workflow shipped in #35.

The original `with: client-payload: |- ...` block used conditional `${{ github.event.release.X || github.event.inputs.Y }}` fallbacks. When triggered via `workflow_dispatch` (release event payload absent), the expression evaluator caused a `startup_failure` before any step ran.

Rebuild the payload in a dedicated shell step using `jq`, fed via `env:` vars so expressions evaluate lazily and unset paths just become empty strings. Pass the resulting JSON string to `peter-evans/repository-dispatch` as `client-payload`. Also tighten input declarations with explicit `type: string` and `default: ""` for body.

After merge, smoke-test:
```
gh workflow run notify-docs-on-release.yml --repo whisqjs/whisq --ref develop -f tag=test-dispatch -f body="smoke test"
```
expected: run completes successfully; receiver workflow on `whisqjs/whisq.dev` opens a `[TEST] Document test-dispatch` issue.