### PR TITLE
WHISQ-33: bisect step 3 — full dispatcher

### DIFF
--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -9,14 +9,58 @@ on:
         description: Tag
         required: true
         default: test-dispatch
+      body:
+        description: Body
+        required: false
+        default: ""
+
+permissions:
+  contents: read
 
 jobs:
-  hello:
+  dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Echo with env
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.WHISQ_BOT_APP_ID }}
+          private-key: ${{ secrets.WHISQ_BOT_PRIVATE_KEY }}
+          owner: whisqjs
+          repositories: whisq.dev
+
+      - name: Build payload
+        id: payload
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
           INPUT_TAG: ${{ inputs.tag }}
+          INPUT_BODY: ${{ inputs.body }}
         run: |
-          echo "release_tag='${RELEASE_TAG}' input_tag='${INPUT_TAG}'"
+          set -euo pipefail
+          TAG="${RELEASE_TAG:-$INPUT_TAG}"
+          NAME="${RELEASE_NAME:-}"
+          BODY="${RELEASE_BODY:-${INPUT_BODY:-}}"
+          URL="${RELEASE_URL:-}"
+          PAYLOAD=$(jq -nc \
+            --arg tag "$TAG" \
+            --arg name "$NAME" \
+            --arg body "$BODY" \
+            --arg html_url "$URL" \
+            '{tag: $tag, name: $name, body: $body, html_url: $html_url}')
+          {
+            echo "payload<<EOF"
+            echo "$PAYLOAD"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send repository_dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: whisqjs/whisq.dev
+          event-type: framework-release
+          client-payload: ${{ steps.payload.outputs.payload }}


### PR DESCRIPTION
Adds both actions back: create-github-app-token + repository-dispatch.