### PR TITLE
chore: retrospective changeset for v0.1.0-alpha.5

### DIFF
--- a/.changeset/alpha-5-batch.md
+++ b/.changeset/alpha-5-batch.md
@@ -1,0 +1,33 @@
+---
+"@whisq/core": minor
+"@whisq/router": minor
+"@whisq/ssr": minor
+"@whisq/testing": minor
+"@whisq/devtools": minor
+"@whisq/sandbox": minor
+"@whisq/mcp-server": minor
+"@whisq/vite-plugin": minor
+"create-whisq": minor
+---
+
+**Retrospective changeset for the batch of work merged since `v0.1.0-alpha.4`.** In pre mode this bumps every package to `0.1.0-alpha.5`.
+
+### New `@whisq/core` API
+
+- **`ref<T>()`** primitive + exported `Ref<T>` type — typed signal refs for DOM elements (#18 · #26)
+- **`bind(signal, options?)`** two-way form-binding helper for `input`/`textarea`/`select` — collapses 3-line controlled-input boilerplate to one spread (#19 · #25)
+- **`resource()` extensions** — `mutate(value | updater)` for optimistic updates, `source` option for reactive refetches, `initialValue`, `keepPrevious`, and an `AbortSignal` passed to the fetcher so requests cancel on refetch/source-change. Stale responses are dropped; AbortErrors don't leak into `.error()` (#20 · #28)
+- **`match(...branches, fallback?)`** multi-branch conditional — first-true-wins renderer in the `when`/`each` family (#21 · #30)
+- **Style prop object form** with per-property reactive subscriptions + new **`sx()`** compositional helper (#22 · #31)
+- **`signalMap<K, V>` / `signalSet<T>`** reactive collections with per-key/per-value tracking, at sub-path `@whisq/core/collections` to keep the top-level bundle under 5 KB (#23 · #32)
+- **Event handler type narrowing** — `e.currentTarget` is now correctly typed per element (`HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, `HTMLFormElement`, `HTMLAnchorElement`, `HTMLImageElement`). New dedicated `TextareaProps` interface (textarea was incorrectly reusing `InputProps`) (#24 · #34)
+
+### Tooling
+
+- **`dist/public-api.json`** manifest shipped inside `@whisq/core` on every build, fetchable via `unpkg.com/@whisq/core@<version>/dist/public-api.json`. Powers the docs-repo drift-check for the AI reference card (#27 · #29)
+
+### Notes
+
+- Backward compatible with `0.1.0-alpha.4`. No breaking changes.
+- Bundle size: `@whisq/core` is **4.75 KB gzipped** (under the 5 KB marketing gate).
+- Test count: 284 in `@whisq/core` (up from ~194 at alpha.4).


### PR DESCRIPTION
## Summary
Single retrospective changeset covering every feature/tooling PR merged since `v0.1.0-alpha.4`. After this merges, the automation set up in #41 takes over: the Release workflow will open a **"chore: release packages"** PR that bumps every package to `0.1.0-alpha.5` and applies CHANGELOG entries. Merging that PR publishes to npm, tags, and creates the GitHub Release — all hands-off.

## What's in `v0.1.0-alpha.5`

### New `@whisq/core` API (all additive, no breaking changes)
- **`ref<T>()`** + exported `Ref<T>` type — #18 / #26
- **`bind(signal, options?)`** two-way form-binding helper — #19 / #25
- **`resource()` extensions**: `mutate`, `source`, `keepPrevious`, `initialValue`, `AbortSignal` — #20 / #28
- **`match(...branches, fallback?)`** multi-branch conditional — #21 / #30
- **Style prop object form + `sx()`** composition helper — #22 / #31
- **`signalMap<K,V>` / `signalSet<T>`** at sub-path `@whisq/core/collections` — #23 / #32
- **Event handler type narrowing** per element (+ new `TextareaProps`) — #24 / #34

### Tooling
- **`dist/public-api.json`** manifest shipped on every build — #27 / #29

### Stats
- Backward compatible with alpha.4
- Bundle: **4.75 KB gzipped** (under 5 KB gate)
- Tests: ~194 → **284** in `@whisq/core`

## Test plan
- [x] `pnpm changeset status` reports all 9 packages queued for `minor` bump (alpha.5 in pre-mode)
- [ ] CI on this PR passes (changeset-check finds the new file)
- [ ] After merge: Release workflow opens the "chore: release packages" PR
- [ ] After that PR merges: npm publish happens; `v0.1.0-alpha.5` tag + GitHub Release created

🤖 Generated with [Claude Code](https://claude.com/claude-code)