### PR TITLE
chore: use WHISQ_BOT app token for release PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,23 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # Mint a GitHub App installation token. The runner's GITHUB_TOKEN is
+      # blocked at the enterprise level from creating pull requests; the bot
+      # app token has explicit pull_requests:write + contents:write for this
+      # repo, which is what changesets/action needs to open the release PR.
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.WHISQ_BOT_APP_ID }}
+          private-key: ${{ secrets.WHISQ_BOT_PRIVATE_KEY }}
+          owner: whisqjs
+          repositories: whisq
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@v4
 
@@ -78,7 +92,7 @@ jobs:
           title: "chore: release packages"
           commit: "chore: release packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary
Follow-up to #41. The Release workflow's initial run hit two blockers:

1. **`changesets/action@v1` wasn't in the repo's allowed-actions patterns** — fixed at settings level (no code change), now in the allowlist.
2. **The runner's `GITHUB_TOKEN` is blocked at the enterprise level from creating pull requests**, so `changesets/action` couldn't open the "chore: release packages" PR (`HttpError: GitHub Actions is not permitted to create or approve pull requests`).

This PR fixes #2 by minting a `WHISQ_BOT` GitHub App token and using it instead of the runner's default token.

## Why this works
- The `WHISQ_BOT` app is already installed on this repo (same app used by `notify-docs-on-release.yml`, with secrets `WHISQ_BOT_APP_ID` / `WHISQ_BOT_PRIVATE_KEY`).
- The app's permissions (`contents: write`, `pull_requests: write`) aren't subject to the enterprise policy that blocks the runner's built-in token.
- `actions/checkout@v6` also uses the app token so the release-PR commit gets pushed as the bot.

## Test plan
- [ ] CI passes (changeset-check will skip via `skip-changeset` label — this is repo tooling)
- [ ] After merge, the Release workflow fires on the push to `develop`, sees the pending `alpha-5-batch.md` changeset from #42, and opens "chore: release packages" PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)