### PR TITLE
chore: restore PR-review release flow, document one-time app setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,31 @@
 name: Release
 
-# Full release automation via Changesets.
+# Fully automated release flow via Changesets.
 #
-# How it works:
+# - Every PR to develop includes a changeset (see CONTRIBUTING.md).
+# - On push to develop, this workflow runs:
+#     * If there are pending changeset .md files, it opens (or updates) a
+#       PR titled "chore: release packages" with the version bumps + CHANGELOG
+#       applied.
+#     * If the release PR was just merged, it runs `pnpm release` which
+#       publishes to npm, creates git tags, and then we create a GitHub
+#       Release with auto-generated notes.
 #
-# 1. Every PR to develop should include a changeset (a markdown file in
-#    `.changeset/`). PRs without one are blocked by the changeset-check job
-#    unless they carry the `skip-changeset` label (docs, repo tooling, etc.).
+# Why a GitHub App token instead of GITHUB_TOKEN:
+#   The runner's default GITHUB_TOKEN is blocked at the enterprise level
+#   from creating or approving pull requests (error:
+#   "GitHub Actions is not permitted to create or approve pull requests").
+#   The WHISQ_BOT GitHub App (already used by notify-docs-on-release) has
+#   explicit pull_requests:write + contents:write on this repo, which is
+#   what changesets/action needs.
 #
-# 2. On push to develop, this workflow runs changesets/action. If there are
-#    pending changeset files, it opens (or updates) a PR titled
-#    "chore: release packages" that applies all pending changesets — bumping
-#    versions, updating CHANGELOGs, and removing the consumed changeset files.
+# One-time setup (documented in docs/RELEASING.md):
+#   The WHISQ_BOT app must be granted these permissions on whisqjs/whisq:
+#     - Contents: Read & Write
+#     - Pull requests: Read & Write
+#     - Metadata: Read
 #
-# 3. Merging that release PR triggers this workflow again. This time there are
-#    no pending changesets, so the action runs `pnpm release` which publishes
-#    to npm and creates git tags for the newly-published versions.
-#
-# 4. A follow-up step turns the top-level tag (v<core-version>) into a
-#    GitHub Release with auto-generated notes.
-#
-# Manual override: `workflow_dispatch` lets you force a run, e.g. to recover
-# from a failed publish or publish a hotfix outside the normal flow.
+# Manual override: workflow_dispatch is available for recovery.
 
 on:
   push:
@@ -41,11 +45,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      # Mint a GitHub App installation token. The runner's GITHUB_TOKEN is
-      # blocked at the enterprise level from creating pull requests; the bot
-      # app token has explicit pull_requests:write + contents:write for this
-      # repo, which is what changesets/action needs to open the release PR.
-      - name: Mint app token
+      - name: Mint WHISQ_BOT app token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
@@ -69,8 +69,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Safety-net quality gates — the same gates run on every PR, but we
-      # re-run them here so a broken main-branch state can never reach npm.
+      # Safety-net quality gates
       - name: Build
         run: pnpm build
 
@@ -102,6 +101,7 @@ jobs:
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const published = JSON.parse(process.env.PUBLISHED_PACKAGES || "[]");
             const core = published.find((p) => p.name === "@whisq/core");

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,116 +1,99 @@
 # Releasing Whisq
 
-> How to publish new versions of Whisq packages to npm.
+> How Whisq publishes new versions to npm. The short version: you don't. Merging changesets into `develop` does it for you.
 
 ---
 
-## Prerequisites
+## Day-to-day: add a changeset to every PR
 
-1. **npm account** with access to the `@whisq` scope
-2. **NPM_TOKEN** secret configured in the GitHub repository
-3. **2FA enabled** on the npm account
-4. You're on the `develop` branch with a clean working tree
-
-## Release Flow
-
-### 1. Create a Changeset
-
-During development, create changesets to describe your changes:
+Every PR that changes code users can observe in `node_modules/@whisq/*` must include a changeset. The `changeset-check` workflow fails PRs that forget one (bypass with the `skip-changeset` label for docs, repo tooling, or no-op dep bumps).
 
 ```bash
 pnpm changeset
 ```
 
-Select the packages you changed and the semver bump type:
+Answer the prompts — which packages changed, and whether the change is `patch` / `minor` / `major`. We're currently in **alpha pre mode** (`.changeset/pre.json` is present), so any bump becomes `0.1.0-alpha.N → 0.1.0-alpha.N+1`. The tool writes a small `.changeset/<slug>.md` file. Commit it alongside your code.
 
-- **patch** — bug fixes, docs changes
-- **minor** — new features, additive API changes
-- **major** — breaking changes (only for v2.0+)
+## What happens after merge to `develop`
 
-This creates a file in `.changeset/` that describes the change.
+The Release workflow (`.github/workflows/release.yml`) runs on every push to `develop`:
 
-### 2. Version Packages
+1. **If there are pending changeset files**, it opens (or updates) a PR titled **"chore: release packages"**. This PR shows the version bumps and CHANGELOG entries that will ship. Nothing has been published yet.
+2. **If the release PR just got merged** (so the push contains version-bumped `package.json` files and consumed changesets are gone), it runs `pnpm release` which:
+   - publishes each bumped package to npm with `--provenance`,
+   - creates a git tag per package,
+   - creates a GitHub Release for `@whisq/core` with auto-generated notes.
 
-When ready to release, apply all pending changesets:
+So the entire human workflow is: write code, run `pnpm changeset`, commit, open PR, merge. Later, review and merge the auto-opened release PR.
+
+## One-time setup (already done, documented here so future maintainers can reproduce)
+
+### `WHISQ_BOT` GitHub App
+
+The enterprise policy blocks the runner's built-in `GITHUB_TOKEN` from creating pull requests. The Release workflow uses the `WHISQ_BOT` installation token instead. This requires:
+
+- **Secrets** on `whisqjs/whisq`:
+  - `WHISQ_BOT_APP_ID`
+  - `WHISQ_BOT_PRIVATE_KEY`
+- **App permissions** on `whisqjs/whisq`:
+  - Contents: **Read & Write**
+  - Pull requests: **Read & Write**
+  - Metadata: **Read**
+
+To (re)grant those permissions: go to github.com/organizations/whisqjs/settings/installations, find the WHISQ_BOT app, ensure `whisq` is in the selected repos, and confirm the three scopes above.
+
+### Allowed third-party actions
+
+`changesets/action@*` and `pnpm/action-setup@*` are allowed via `Settings → Actions → General → Allow select actions and reusable workflows`. `actions/create-github-app-token` is GitHub-owned so it's allowed by default.
+
+### Branch protection on `develop`
+
+Requires PR, all 6 CI checks, no force-push, no deletion. The WHISQ_BOT app is **not** an admin — it cannot push directly to `develop`. That's why we use the release-PR flow (the PR goes through normal merge, not a direct push).
+
+## Exiting pre mode
+
+When ready to cut a `0.1.0` stable:
 
 ```bash
-pnpm version
+pnpm changeset pre exit
 ```
 
-This:
+Commit the deleted `.changeset/pre.json` in a PR. After that, bumps resolve as normal semver — the next release will be `0.1.0`, then `0.1.1` / `0.2.0` / etc.
 
-- Bumps all package versions according to changesets
-- Generates/updates CHANGELOG.md in each package
-- Removes consumed changeset files
+## Emergency manual override
 
-### 3. Commit and Push
+If the automation is broken (e.g. npm outage, bad app token, enterprise policy change), re-run via `workflow_dispatch` on the Release workflow. If that also fails:
 
 ```bash
-git add .
-git commit -m "chore: release v0.0.1-alpha.1"
-git push
-```
-
-### 4. Create a Release Tag
-
-```bash
-git tag v0.0.1-alpha.1
-git push --tags
-```
-
-### 5. Automated Publish
-
-Pushing a `v*` tag triggers the release workflow (`.github/workflows/release.yml`) which:
-
-1. Runs the full CI pipeline (lint, typecheck, test, build)
-2. Publishes all packages to npm with `--provenance`
-3. Creates a GitHub Release with auto-generated release notes
-
-### 6. Verify
-
-After the workflow completes:
-
-```bash
-# Check packages are on npm
-npm view @whisq/core version
-npm view @whisq/router version
-
-# Test install in a fresh project
-mkdir /tmp/test-whisq && cd /tmp/test-whisq
-npm init -y
-npm install @whisq/core
-
-# Test create-whisq
-npm create whisq@latest test-app
-```
-
-## Pre-release Versions
-
-For alpha/beta releases, the tag name determines the pre-release label:
-
-- `v0.0.1-alpha.1` → publishes as alpha
-- `v0.0.1-beta.1` → publishes as beta
-- `v0.0.1-rc.1` → publishes as release candidate
-
-The GitHub Release will automatically be marked as "pre-release".
-
-## Manual Publish (Emergency)
-
-If the CI pipeline fails and you need to publish manually:
-
-```bash
+# On develop, with a clean working tree and no pending changesets:
+pnpm install --frozen-lockfile
 pnpm build
 pnpm test
-pnpm -r publish --access public --no-git-checks
+pnpm -r publish --access public --no-git-checks --provenance
 ```
 
 Requires `NPM_TOKEN` in your environment or `npm login` with 2FA.
 
+## Verifying a release
+
+```bash
+npm view @whisq/core version
+npm view create-whisq version
+
+# Fresh install sanity check:
+mkdir /tmp/whisq-sanity && cd /tmp/whisq-sanity
+npm init -y
+npm install @whisq/core
+```
+
 ## Troubleshooting
 
-| Issue                           | Solution                                                        |
-| ------------------------------- | --------------------------------------------------------------- |
-| `403 Forbidden` on publish      | Check NPM_TOKEN is valid and has publish access to @whisq scope |
-| Provenance error                | Ensure `id-token: write` permission in workflow                 |
-| Package not found after publish | Wait 1-2 minutes for npm registry to propagate                  |
-| Version conflict                | Run `pnpm version` to consume changesets, then commit           |
+| Symptom                                                                         | Likely cause                                           | Fix                                                                                            |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| Release workflow `startup_failure`                                              | New third-party action not allowlisted                 | Add to `Settings → Actions → General → Allow select actions`                                   |
+| `HttpError: GitHub Actions is not permitted to create or approve pull requests` | Using runner's `GITHUB_TOKEN` instead of the app token | Ensure `GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}` is on the `changesets/action` step |
+| `Resource not accessible by integration`                                        | WHISQ_BOT app lacks `pull_requests:write` on this repo | Re-grant the permission in the app's installation settings                                     |
+| `403 Forbidden` on publish                                                      | `NPM_TOKEN` expired or revoked                         | Rotate the secret                                                                              |
+| Provenance error                                                                | Missing `id-token: write` permission                   | Already set at the workflow level                                                              |
+| Tag already exists                                                              | Release was re-run after a partial success             | Delete the tag on GitHub if it's wrong, or move on — publishing is idempotent per-version      |
+| Version conflict between packages                                               | Someone hand-edited `package.json`                     | `node scripts/check-versions.mjs` to diagnose; re-run `pnpm version` after fixing              |


### PR DESCRIPTION
## Summary
Follow-up to #41 / #43. After diagnosing two startup failures and one publish failure, this PR finalizes the Release workflow and spells out the exact manual setup needed.

## What's still blocking the actual release
The workflow code is correct. **The `WHISQ_BOT` GitHub App is missing `pull_requests:write` on this repo** — when `changesets/action` tried to open the "chore: release packages" PR it got `Resource not accessible by integration`.

**One-time manual step (cannot be done via API):**

Go to **github.com/organizations/whisqjs/settings/installations → WHISQ_BOT → Configure**, and ensure:

- `whisq` is in the selected repositories
- Permissions include: **Contents: Read & Write**, **Pull requests: Read & Write**, **Metadata: Read**

After clicking "Save", re-run the Release workflow via `workflow_dispatch` (or merge any trivial change to develop) and the release PR will appear.

## What this PR does
- Keeps `changesets/action@v1` with the WHISQ_BOT app token (correct approach).
- Drops the short-lived direct-publish experiment that would have fought branch protection.
- Rewrites `docs/RELEASING.md` to document the whole automated flow, the one-time app setup, and a troubleshooting table keyed on the exact error messages we hit while bringing this online.

## Test plan
- [ ] CI passes (changeset-check skipped via `skip-changeset` label — repo tooling, no npm change)
- [ ] After merging AND granting the app permission: Release workflow opens the "chore: release packages" PR showing alpha.5 bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)