### PR TITLE
fix(release): use `pnpm run` to bypass pnpm's reserved `version`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,14 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm version
-          publish: pnpm release
+          # Use `pnpm run <script>` because pnpm's built-in `pnpm version`
+          # command shadows our package.json script of the same name (same
+          # applies to `release`). Running through `pnpm run` dispatches to
+          # the script we actually want (`changeset version` + template sync
+          # for version; `pnpm build && pnpm test && changeset publish` for
+          # release).
+          version: pnpm run version
+          publish: pnpm run release
           title: "chore: release packages"
           commit: "chore: release packages"
         env:


### PR DESCRIPTION
## Summary
One-line fix: the Release workflow was invoking `pnpm version` but pnpm has a **built-in `pnpm version`** subcommand that prints the Node.js version JSON — it shadows our `package.json` script of the same name.

Result: `pnpm version` ran on the runner and produced no file changes, so `changesets/action` created an empty `changeset-release/develop` branch and the PR opening failed with `No commits between develop and changeset-release/develop`.

Fix: use `pnpm run version` and `pnpm run release` — these always dispatch to the matching script, bypassing the reserved command names.

## Test plan
- [ ] CI passes (repo tooling — `skip-changeset` label)
- [ ] After merge: Release workflow runs `pnpm run version` which calls `changeset version && node scripts/sync-template-versions.mjs`, bumps every `package.json` to `0.1.0-alpha.5`, writes CHANGELOG, and opens the "chore: release packages" PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)