### PR TITLE
fix(release): remove redundant GitHub Release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,37 +100,6 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create GitHub Release
-        if: steps.changesets.outputs.published == 'true'
-        uses: actions/github-script@v9
-        env:
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const published = JSON.parse(process.env.PUBLISHED_PACKAGES || "[]");
-            const core = published.find((p) => p.name === "@whisq/core");
-            if (!core) {
-              console.log("No @whisq/core in published set — skipping GitHub Release.");
-              return;
-            }
-            const tag = `v${core.version}`;
-            const isPrerelease = /alpha|beta|rc/i.test(tag);
-            try {
-              await github.rest.repos.createRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag_name: tag,
-                name: tag,
-                generate_release_notes: true,
-                prerelease: isPrerelease,
-              });
-              console.log(`Created GitHub Release ${tag}`);
-            } catch (e) {
-              if (e.status === 422) {
-                console.log(`GitHub Release ${tag} already exists, skipping.`);
-                return;
-              }
-              throw e;
-            }
+      # GitHub Releases for each published package are created automatically
+      # by changesets/action (its `createGithubReleases: true` default).
+      # No follow-up step needed.


### PR DESCRIPTION
## Summary
`changesets/action` creates per-package GitHub Releases for everything it publishes — we verified this by inspecting the release list after v0.1.0-alpha.5 shipped: 9 pre-releases were already there. Our extra step was redundant, and buggy (used `const core = ...` which collides with `@actions/github-script`'s built-in `core` global), so it crashed the whole run even though the actual release was fine.

This deletes the step. Future releases will finish green.

## v0.1.0-alpha.5 is live
All 9 packages are on npm at `0.1.0-alpha.5`. Nothing to re-run.

## Test plan
- [ ] CI passes (repo tooling — `skip-changeset` label)
- [ ] Next release run finishes cleanly with no trailing failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)