### PR TITLE
chore: enforce feature → develop → release → main flow

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -6,7 +6,7 @@ name: Changeset check
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [develop, main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,107 @@
+name: Release — prepare
+
+# Step 1 of the release flow: on `develop`, roll up all pending changesets
+# into a `release/v<version>` branch and open a PR to `main`.
+#
+# Triggered manually so releases are explicit. When you're ready to cut a
+# release, go to Actions → "Release — prepare" → Run workflow. The job:
+#
+#   1. Verifies there's at least one pending changeset to release.
+#   2. Runs `pnpm run version` which applies all changesets (bumps versions
+#      in every package.json, writes CHANGELOG entries, deletes consumed
+#      changeset files, syncs create-whisq templates).
+#   3. Commits those changes to a new `release/v<version>` branch.
+#   4. Opens a PR from that branch into `main`.
+#
+# Merging the release PR into `main` triggers `.github/workflows/release.yml`
+# which does the npm publish + tagging + back-merge-to-develop PR.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release-prepare
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint WHISQ_BOT app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.WHISQ_BOT_APP_ID }}
+          private-key: ${{ secrets.WHISQ_BOT_PRIVATE_KEY }}
+          owner: whisqjs
+          repositories: whisq
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: develop
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Verify pending changesets exist
+        run: |
+          count=$(find .changeset -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')
+          if [ "$count" = "0" ]; then
+            echo "::error::No pending changesets on develop. Nothing to release."
+            exit 1
+          fi
+          echo "Found $count pending changeset(s)."
+
+      - name: Apply changesets (bump versions + write CHANGELOGs)
+        run: pnpm run version
+
+      - name: Determine new version
+        id: ver
+        run: echo "version=$(node -p "require('./packages/core/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push release branch
+        run: |
+          git config user.name "whisq-bot[bot]"
+          git config user.email "whisq-bot[bot]@users.noreply.github.com"
+          BRANCH="release/v${{ steps.ver.outputs.version }}"
+          git checkout -b "$BRANCH"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::error::pnpm run version produced no changes — aborting."
+            exit 1
+          fi
+          git commit -m "chore: release v${{ steps.ver.outputs.version }}"
+          git push -u origin "$BRANCH"
+
+      - name: Open release PR to main
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "release/v${{ steps.ver.outputs.version }}" \
+            --title "chore: release v${{ steps.ver.outputs.version }}" \
+            --label "skip-changeset" \
+            --body "$(cat <<EOF
+          Automated release PR for **v${{ steps.ver.outputs.version }}**.
+
+          Merging this PR into \`main\` triggers the publish workflow:
+          - \`pnpm run release\` publishes all bumped packages to npm with provenance
+          - changesets/action creates per-package git tags and GitHub Releases
+          - A follow-up PR will be opened to back-merge \`main\` → \`develop\`
+
+          See each package's \`CHANGELOG.md\` (in the diff) for what's shipping.
+          EOF
+          )"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,35 +1,23 @@
 name: Release
 
-# Fully automated release flow via Changesets.
+# Step 2 of the release flow: publish on push to `main`.
 #
-# - Every PR to develop includes a changeset (see CONTRIBUTING.md).
-# - On push to develop, this workflow runs:
-#     * If there are pending changeset .md files, it opens (or updates) a
-#       PR titled "chore: release packages" with the version bumps + CHANGELOG
-#       applied.
-#     * If the release PR was just merged, it runs `pnpm release` which
-#       publishes to npm, creates git tags, and then we create a GitHub
-#       Release with auto-generated notes.
+# Triggered when the release PR (opened by `release-prepare.yml`) merges
+# into `main`. This workflow:
 #
-# Why a GitHub App token instead of GITHUB_TOKEN:
-#   The runner's default GITHUB_TOKEN is blocked at the enterprise level
-#   from creating or approving pull requests (error:
-#   "GitHub Actions is not permitted to create or approve pull requests").
-#   The WHISQ_BOT GitHub App (already used by notify-docs-on-release) has
-#   explicit pull_requests:write + contents:write on this repo, which is
-#   what changesets/action needs.
+#   1. Re-runs build + test as a safety net.
+#   2. Invokes `pnpm run release` via changesets/action — publishes all
+#      bumped packages to npm with provenance, creates per-package git tags,
+#      and creates a GitHub Release for each tag.
+#   3. Opens a back-merge PR from `main` into `develop` so `develop` picks
+#      up the version bumps and CHANGELOG entries.
 #
-# One-time setup (documented in docs/RELEASING.md):
-#   The WHISQ_BOT app must be granted these permissions on whisqjs/whisq:
-#     - Contents: Read & Write
-#     - Pull requests: Read & Write
-#     - Metadata: Read
-#
-# Manual override: workflow_dispatch is available for recovery.
+# If there are no unpublished packages (e.g. workflow fires from an
+# unrelated push), changesets/action detects that and skips publishing.
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -42,8 +30,11 @@ permissions:
   id-token: write
 
 jobs:
-  release:
+  publish:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Mint WHISQ_BOT app token
         id: app-token
@@ -69,7 +60,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Safety-net quality gates
       - name: Build
         run: pnpm build
 
@@ -82,24 +72,56 @@ jobs:
       - name: Check bundle size
         run: cd packages/core && pnpm size
 
-      - name: Create release PR or publish
+      - name: Record current @whisq/core version
+        id: ver
+        run: echo "version=$(node -p "require('./packages/core/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to npm + create tags + GitHub Releases
         id: changesets
         uses: changesets/action@v1
         with:
-          # Use `pnpm run <script>` because pnpm's built-in `pnpm version`
-          # command shadows our package.json script of the same name (same
-          # applies to `release`). Running through `pnpm run` dispatches to
-          # the script we actually want (`changeset version` + template sync
-          # for version; `pnpm build && pnpm test && changeset publish` for
-          # release).
-          version: pnpm run version
           publish: pnpm run release
-          title: "chore: release packages"
-          commit: "chore: release packages"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      # GitHub Releases for each published package are created automatically
-      # by changesets/action (its `createGithubReleases: true` default).
-      # No follow-up step needed.
+
+  backmerge:
+    needs: publish
+    if: needs.publish.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Mint WHISQ_BOT app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.WHISQ_BOT_APP_ID }}
+          private-key: ${{ secrets.WHISQ_BOT_PRIVATE_KEY }}
+          owner: whisqjs
+          repositories: whisq
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create back-merge branch and open PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.publish.outputs.version }}
+        run: |
+          git config user.name "whisq-bot[bot]"
+          git config user.email "whisq-bot[bot]@users.noreply.github.com"
+          BRANCH="chore/backmerge-main-to-develop-v$VERSION"
+          git checkout -b "$BRANCH"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "chore: back-merge main → develop after v$VERSION" \
+            --label "skip-changeset" \
+            --body "Automated back-merge following the v$VERSION release. Bringing version bumps and CHANGELOG updates from \`main\` into \`develop\` so future feature branches start from the released state."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,11 +82,15 @@ If your PR genuinely doesn't need a version bump (docs-only, repo tooling, inter
 
 ### How the release actually cuts
 
-1. Merging a PR with changesets into `develop` triggers the Release workflow.
-2. The workflow accumulates pending changesets and opens (or updates) a PR titled **"chore: release packages"**. This PR shows the version bumps and CHANGELOG entries that would ship.
-3. When you merge that release PR, the workflow runs again and this time publishes to npm + creates git tags + opens a GitHub Release.
+The branch flow is strict: `feature → develop → release/v<version> → main → back-merge → develop`. No package.json editing by hand; two workflows do all the mechanical work.
 
-Nothing is done by hand — no `pnpm version` / `pnpm release` locally, no manual tag pushes. If something goes wrong, `workflow_dispatch` on the Release workflow is the manual escape hatch.
+1. Your PR merges to `develop` with its changeset attached.
+2. When enough changesets have accumulated, a maintainer opens **Actions → Release — prepare → Run workflow**. That creates a `release/v<version>` branch, bumps every `package.json`, writes CHANGELOGs, and opens a PR to `main`.
+3. A maintainer reviews the release PR and squash-merges it into `main`.
+4. The merge triggers **`release.yml`**, which publishes all bumped packages to npm with provenance, creates per-package git tags and GitHub Releases, and opens a back-merge PR.
+5. A maintainer squash-merges the back-merge PR into `develop`.
+
+Full details in [`docs/RELEASING.md`](./docs/RELEASING.md).
 
 ## License
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,7 +43,7 @@ It:
 
 ### 2. Review and merge the release PR into `main`
 
-The PR body shows the version bumps and each package's CHANGELOG diff. If something looks wrong, close the PR and the release branch; your pending changesets on `develop` are untouched. If it looks right, **squash-merge** it.
+The PR body shows the version bumps and each package's CHANGELOG diff. If something looks wrong, close the PR and the release branch; your pending changesets on `develop` are untouched. If it looks right, **use a merge commit (not squash)** — `main` keeps the full history of every feature that made it into the release.
 
 ### 3. Automated publish
 
@@ -55,7 +55,18 @@ Merging to `main` triggers `.github/workflows/release.yml`:
 
 ### 4. Merge the back-merge PR into `develop`
 
-Title: `chore: back-merge main → develop after v<version>`. Carries the `skip-changeset` label. Squash-merge it to bring the version bumps and CHANGELOG updates into `develop`. Your next feature branch starts from the released state.
+Title: `chore: back-merge main → develop after v<version>`. Carries the `skip-changeset` label. **Squash-merge** it so `develop` gets a single "back-merge" commit — `develop` stays clean and linear at one commit per merged PR.
+
+## Merge style per branch
+
+Whisq deliberately uses different merge styles for `develop` and `main`:
+
+| Target                                                             | Style            | Why                                                                                                                                      |
+| ------------------------------------------------------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| PRs into `develop` (all PRs — features, fixes, chore, back-merges) | **Squash**       | Each PR collapses into a single commit on `develop` — clean, linear, easy to scan.                                                       |
+| PRs into `main` (release PRs only)                                 | **Merge commit** | Preserves the history of every feature that made it into the release, so `git log main` shows every squashed PR as an individual commit. |
+
+This is convention, not enforced by GitHub — pick the right option from the dropdown on the green merge button.
 
 ## One-time setup (already done, documented for future maintainers)
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,71 +1,100 @@
 # Releasing Whisq
 
-> How Whisq publishes new versions to npm. The short version: you don't. Merging changesets into `develop` does it for you.
+> How Whisq publishes new versions. The short version: you merge a changeset, click "Run workflow" on _Release — prepare_, review and merge the resulting release PR into `main`, then merge the back-merge PR into `develop`. Two clicks.
 
 ---
 
-## Day-to-day: add a changeset to every PR
+## The branch flow
 
-Every PR that changes code users can observe in `node_modules/@whisq/*` must include a changeset. The `changeset-check` workflow fails PRs that forget one (bypass with the `skip-changeset` label for docs, repo tooling, or no-op dep bumps).
+```
+feature/*  →  develop  →  release/v<version>  →  main  →  (back-merge)  →  develop
+```
+
+- **`feature/*` / `bugfix/*` / `chore/*`** branches → PR to `develop` (every PR carries a changeset or the `skip-changeset` label)
+- **`develop`** accumulates merged changesets
+- **`release/v<version>`** is cut from `develop` by the _Release — prepare_ workflow when you want to ship
+- **`main`** is production: merging the release PR here triggers npm publish
+- **Back-merge PR** from `main` → `develop` brings the version bumps home
+
+Nobody edits `package.json` versions by hand. The workflows do it.
+
+## Day-to-day: add a changeset to every PR
 
 ```bash
 pnpm changeset
 ```
 
-Answer the prompts — which packages changed, and whether the change is `patch` / `minor` / `major`. We're currently in **alpha pre mode** (`.changeset/pre.json` is present), so any bump becomes `0.1.0-alpha.N → 0.1.0-alpha.N+1`. The tool writes a small `.changeset/<slug>.md` file. Commit it alongside your code.
+Answer the prompts. Commit the generated `.changeset/<slug>.md` alongside your code. We're in **alpha pre mode** (`.changeset/pre.json` is present), so any bump resolves as `0.1.0-alpha.N → 0.1.0-alpha.N+1`.
 
-## What happens after merge to `develop`
+The `changeset-check` workflow fails PRs without a changeset unless they carry the `skip-changeset` label (docs, repo tooling, dep bumps with no API impact).
 
-The Release workflow (`.github/workflows/release.yml`) runs on every push to `develop`:
+## Cutting a release
 
-1. **If there are pending changeset files**, it opens (or updates) a PR titled **"chore: release packages"**. This PR shows the version bumps and CHANGELOG entries that will ship. Nothing has been published yet.
-2. **If the release PR just got merged** (so the push contains version-bumped `package.json` files and consumed changesets are gone), it runs `pnpm release` which:
-   - publishes each bumped package to npm with `--provenance`,
-   - creates a git tag per package,
-   - creates a GitHub Release for `@whisq/core` with auto-generated notes.
+### 1. Open _Release — prepare_
 
-So the entire human workflow is: write code, run `pnpm changeset`, commit, open PR, merge. Later, review and merge the auto-opened release PR.
+**Actions → Release — prepare → Run workflow** (on `develop`).
 
-## One-time setup (already done, documented here so future maintainers can reproduce)
+It:
+
+- verifies there's at least one pending changeset on `develop`
+- runs `pnpm run version` (applies all pending changesets, bumps every affected `package.json`, writes CHANGELOG entries, syncs create-whisq templates)
+- creates a `release/v<new-version>` branch with a single "chore: release v<version>" commit
+- opens a PR from that branch into `main`
+
+### 2. Review and merge the release PR into `main`
+
+The PR body shows the version bumps and each package's CHANGELOG diff. If something looks wrong, close the PR and the release branch; your pending changesets on `develop` are untouched. If it looks right, **squash-merge** it.
+
+### 3. Automated publish
+
+Merging to `main` triggers `.github/workflows/release.yml`:
+
+- re-runs build + test + version-consistency + bundle-size
+- runs `pnpm run release` via `changesets/action` — publishes every bumped package to npm with `--provenance`, creates per-package git tags (`@whisq/core@<version>` etc.), and creates a GitHub Release per tag with auto-generated notes
+- opens a back-merge PR from `main` into `develop`
+
+### 4. Merge the back-merge PR into `develop`
+
+Title: `chore: back-merge main → develop after v<version>`. Carries the `skip-changeset` label. Squash-merge it to bring the version bumps and CHANGELOG updates into `develop`. Your next feature branch starts from the released state.
+
+## One-time setup (already done, documented for future maintainers)
 
 ### `WHISQ_BOT` GitHub App
 
-The enterprise policy blocks the runner's built-in `GITHUB_TOKEN` from creating pull requests. The Release workflow uses the `WHISQ_BOT` installation token instead. This requires:
+Both release workflows use a `WHISQ_BOT` app installation token because the runner's default `GITHUB_TOKEN` is blocked at the enterprise level from creating pull requests.
 
-- **Secrets** on `whisqjs/whisq`:
-  - `WHISQ_BOT_APP_ID`
-  - `WHISQ_BOT_PRIVATE_KEY`
-- **App permissions** on `whisqjs/whisq`:
-  - Contents: **Read & Write**
-  - Pull requests: **Read & Write**
-  - Metadata: **Read**
+- **Secrets** on `whisqjs/whisq`: `WHISQ_BOT_APP_ID`, `WHISQ_BOT_PRIVATE_KEY`
+- **App permissions** on `whisqjs/whisq`: Contents R/W, Pull requests R/W, Metadata R
+- **Repository access**: `whisq` must be in the app's selected repositories
 
-To (re)grant those permissions: go to github.com/organizations/whisqjs/settings/installations, find the WHISQ_BOT app, ensure `whisq` is in the selected repos, and confirm the three scopes above.
+Grant/re-grant via github.com/organizations/whisqjs/settings/installations → WHISQ_BOT → Configure.
 
 ### Allowed third-party actions
 
-`changesets/action@*` and `pnpm/action-setup@*` are allowed via `Settings → Actions → General → Allow select actions and reusable workflows`. `actions/create-github-app-token` is GitHub-owned so it's allowed by default.
+`changesets/action@*` and `pnpm/action-setup@*` are allowed via Settings → Actions → General → Allow select actions. `actions/create-github-app-token` is GitHub-owned so it's allowed by default.
 
-### Branch protection on `develop`
+### Branch protection
 
-Requires PR, all 6 CI checks, no force-push, no deletion. The WHISQ_BOT app is **not** an admin — it cannot push directly to `develop`. That's why we use the release-PR flow (the PR goes through normal merge, not a direct push).
+- `main`: PR required, all CI checks, conversation resolution, no force-push, no deletion.
+- `develop`: PR required, all CI checks, no force-push, no deletion.
+- The WHISQ_BOT app can push feature-like branches (`release/*`, `chore/backmerge-*`) but cannot push directly to `main` or `develop` — that's why everything happens through PRs.
 
 ## Exiting pre mode
 
-When ready to cut a `0.1.0` stable:
+When the API is stable enough to drop `-alpha`:
 
 ```bash
 pnpm changeset pre exit
 ```
 
-Commit the deleted `.changeset/pre.json` in a PR. After that, bumps resolve as normal semver — the next release will be `0.1.0`, then `0.1.1` / `0.2.0` / etc.
+Commit the deletion of `.changeset/pre.json` on a feature branch, PR to develop, merge. After that, the next _Release — prepare_ will produce a normal semver version (e.g. `0.1.0`).
 
 ## Emergency manual override
 
-If the automation is broken (e.g. npm outage, bad app token, enterprise policy change), re-run via `workflow_dispatch` on the Release workflow. If that also fails:
+Both release workflows also accept `workflow_dispatch`. If the automation is broken entirely:
 
 ```bash
-# On develop, with a clean working tree and no pending changesets:
+# On a release/v<version> branch checked out locally, with no pending changesets:
 pnpm install --frozen-lockfile
 pnpm build
 pnpm test
@@ -80,7 +109,7 @@ Requires `NPM_TOKEN` in your environment or `npm login` with 2FA.
 npm view @whisq/core version
 npm view create-whisq version
 
-# Fresh install sanity check:
+# Fresh-install sanity:
 mkdir /tmp/whisq-sanity && cd /tmp/whisq-sanity
 npm init -y
 npm install @whisq/core
@@ -88,12 +117,13 @@ npm install @whisq/core
 
 ## Troubleshooting
 
-| Symptom                                                                         | Likely cause                                           | Fix                                                                                            |
-| ------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| Release workflow `startup_failure`                                              | New third-party action not allowlisted                 | Add to `Settings → Actions → General → Allow select actions`                                   |
-| `HttpError: GitHub Actions is not permitted to create or approve pull requests` | Using runner's `GITHUB_TOKEN` instead of the app token | Ensure `GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}` is on the `changesets/action` step |
-| `Resource not accessible by integration`                                        | WHISQ_BOT app lacks `pull_requests:write` on this repo | Re-grant the permission in the app's installation settings                                     |
-| `403 Forbidden` on publish                                                      | `NPM_TOKEN` expired or revoked                         | Rotate the secret                                                                              |
-| Provenance error                                                                | Missing `id-token: write` permission                   | Already set at the workflow level                                                              |
-| Tag already exists                                                              | Release was re-run after a partial success             | Delete the tag on GitHub if it's wrong, or move on — publishing is idempotent per-version      |
-| Version conflict between packages                                               | Someone hand-edited `package.json`                     | `node scripts/check-versions.mjs` to diagnose; re-run `pnpm version` after fixing              |
+| Symptom                                                                         | Likely cause                                                 | Fix                                                                                                                                                  |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _Release — prepare_ errors with "No pending changesets on develop"              | No `.changeset/*.md` accumulated since last release          | Merge a PR that adds a changeset, or run `pnpm changeset` on a throwaway branch first                                                                |
+| Release workflow `startup_failure`                                              | New third-party action not allowlisted                       | Add to Settings → Actions → General → Allow select actions                                                                                           |
+| `HttpError: GitHub Actions is not permitted to create or approve pull requests` | Using runner's `GITHUB_TOKEN` instead of the app token       | Ensure `GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}` on all PR-creating steps                                                                 |
+| `Resource not accessible by integration`                                        | WHISQ_BOT app lacks `pull_requests:write` on this repo       | Re-grant the permission in the app's installation settings                                                                                           |
+| `403 Forbidden` on publish                                                      | `NPM_TOKEN` expired or revoked                               | Rotate the secret                                                                                                                                    |
+| `Package size limit has exceeded` on release run                                | A merged feature pushed `@whisq/core` past 5 KB gzipped      | Move the added code behind a sub-path export (like `@whisq/core/collections`), or bump the limit in `packages/core/package.json` `size-limit` config |
+| Tag already exists for a version we tried to republish                          | Prior run partially succeeded                                | Delete the stale tag on GitHub or move on — npm publish is idempotent per-version                                                                    |
+| `pnpm version` runs Node's version dump instead of the script                   | Never invoke `pnpm version` directly; use `pnpm run version` | Already baked into the release workflow                                                                                                              |


### PR DESCRIPTION
## Summary
Re-architects the release automation to go through `main`, matching the branch discipline in CLAUDE.md:

```
feature/*  →  develop  →  release/v<version>  →  main  →  back-merge  →  develop
```

The previous iteration (#41/#43/#44/#45/#47) published directly from `develop`, bypassing `main`. This PR splits that single workflow into two:

- **`release-prepare.yml`** — runs on `develop` via `workflow_dispatch`. Applies pending changesets, creates a `release/v<version>` branch with the bumps, opens a PR to `main`.
- **`release.yml`** — triggers on push to `main` (when the release PR merges). Publishes to npm via `pnpm run release`, creates per-package tags + GitHub Releases through `changesets/action`, then opens a back-merge PR `main → develop`.

Both workflows use the `WHISQ_BOT` app token (as before) so they can create the PRs. Everything else — bumps, CHANGELOGs, npm publish, tags, releases, branch creation — is automatic. A maintainer does two squash-merges per release (release PR into `main`; back-merge PR into `develop`).

## Changes
- **New** `.github/workflows/release-prepare.yml`
- **Refactored** `.github/workflows/release.yml` (now main-only, split into `publish` + `backmerge` jobs)
- `.github/workflows/changeset-check.yml` now also guards PRs targeting `main`
- `docs/RELEASING.md` rewritten around the new flow + one-time setup + troubleshooting
- `CONTRIBUTING.md` section updated to match

## Test plan
- [ ] CI passes on this PR (`skip-changeset` label — repo tooling)
- [ ] After merge, open Actions → **Release — prepare** → Run workflow on `develop`. Should fail with "No pending changesets" (accurate — none remaining after alpha.5).
- [ ] Create one throwaway changeset on a feature branch, merge to develop, re-run **Release — prepare** → see the release PR to `main` appear.

## One-time follow-up
`main` is currently at `fafb790` (the initial commit). It needs a catch-up merge to bring it to the `alpha.5` state. I'll handle that in a follow-up release PR — the publish step will be a no-op since alpha.5 is already on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)