### PR TITLE
chore: sync main to v0.1.0-alpha.5

### DIFF
--- a/.changeset/alpha-5-batch.md
+++ b/.changeset/alpha-5-batch.md
@@ -1,0 +1,33 @@
+---
+"@whisq/core": minor
+"@whisq/router": minor
+"@whisq/ssr": minor
+"@whisq/testing": minor
+"@whisq/devtools": minor
+"@whisq/sandbox": minor
+"@whisq/mcp-server": minor
+"@whisq/vite-plugin": minor
+"create-whisq": minor
+---
+
+**Retrospective changeset for the batch of work merged since `v0.1.0-alpha.4`.** In pre mode this bumps every package to `0.1.0-alpha.5`.
+
+### New `@whisq/core` API
+
+- **`ref<T>()`** primitive + exported `Ref<T>` type — typed signal refs for DOM elements (#18 · #26)
+- **`bind(signal, options?)`** two-way form-binding helper for `input`/`textarea`/`select` — collapses 3-line controlled-input boilerplate to one spread (#19 · #25)
+- **`resource()` extensions** — `mutate(value | updater)` for optimistic updates, `source` option for reactive refetches, `initialValue`, `keepPrevious`, and an `AbortSignal` passed to the fetcher so requests cancel on refetch/source-change. Stale responses are dropped; AbortErrors don't leak into `.error()` (#20 · #28)
+- **`match(...branches, fallback?)`** multi-branch conditional — first-true-wins renderer in the `when`/`each` family (#21 · #30)
+- **Style prop object form** with per-property reactive subscriptions + new **`sx()`** compositional helper (#22 · #31)
+- **`signalMap<K, V>` / `signalSet<T>`** reactive collections with per-key/per-value tracking, at sub-path `@whisq/core/collections` to keep the top-level bundle under 5 KB (#23 · #32)
+- **Event handler type narrowing** — `e.currentTarget` is now correctly typed per element (`HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, `HTMLFormElement`, `HTMLAnchorElement`, `HTMLImageElement`). New dedicated `TextareaProps` interface (textarea was incorrectly reusing `InputProps`) (#24 · #34)
+
+### Tooling
+
+- **`dist/public-api.json`** manifest shipped inside `@whisq/core` on every build, fetchable via `unpkg.com/@whisq/core@<version>/dist/public-api.json`. Powers the docs-repo drift-check for the AI reference card (#27 · #29)
+
+### Notes
+
+- Backward compatible with `0.1.0-alpha.4`. No breaking changes.
+- Bundle size: `@whisq/core` is **4.75 KB gzipped** (under the 5 KB marketing gate).
+- Test count: 284 in `@whisq/core` (up from ~194 at alpha.4).

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@whisq/*"]],
+  "fixed": [["@whisq/*", "create-whisq"]],
   "linked": [],
   "access": "public",
   "baseBranch": "develop",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,16 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@whisq/core": "0.1.0-alpha.4",
+    "create-whisq": "0.1.0-alpha.4",
+    "@whisq/devtools": "0.1.0-alpha.4",
+    "@whisq/mcp-server": "0.1.0-alpha.4",
+    "@whisq/router": "0.1.0-alpha.4",
+    "@whisq/sandbox": "0.1.0-alpha.4",
+    "@whisq/ssr": "0.1.0-alpha.4",
+    "@whisq/testing": "0.1.0-alpha.4",
+    "@whisq/vite-plugin": "0.1.0-alpha.4"
+  },
+  "changesets": []
+}

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -12,5 +12,7 @@
     "@whisq/testing": "0.1.0-alpha.4",
     "@whisq/vite-plugin": "0.1.0-alpha.4"
   },
-  "changesets": []
+  "changesets": [
+    "alpha-5-batch"
+  ]
 }

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,39 @@
+name: Changeset check
+
+# Guards against PRs that change shipped code but forget to include a
+# changeset. Add the `skip-changeset` label to bypass (for docs, repo
+# tooling, or any change that doesn't affect a published package).
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Require a changeset file to be added in this PR
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          added=$(git diff --name-only --diff-filter=A "origin/$BASE_REF"...HEAD -- '.changeset/*.md' | grep -v README.md || true)
+          if [ -z "$added" ]; then
+            echo "::error::This PR has no new changeset."
+            echo "Run 'pnpm changeset' locally, commit the generated .changeset/*.md file, and push."
+            echo "If this PR genuinely doesn't need a changeset (docs-only, repo tooling, dep bumps without API surface),"
+            echo "add the 'skip-changeset' label to the PR and this check will pass."
+            exit 1
+          fi
+          echo "Changeset present:"
+          echo "$added"
+        env:
+          BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -6,7 +6,7 @@ name: Changeset check
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [develop, main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:

--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -16,10 +16,13 @@ on:
       tag:
         description: Release tag to simulate (e.g. v0.1.0-alpha.5)
         required: true
+        type: string
         default: test-dispatch
       body:
         description: Release notes markdown (optional)
         required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -38,16 +41,38 @@ jobs:
           owner: whisqjs
           repositories: whisq.dev
 
+      - name: Build payload
+        id: payload
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_BODY: ${{ inputs.body }}
+        run: |
+          set -euo pipefail
+          TAG="${RELEASE_TAG:-$INPUT_TAG}"
+          NAME="${RELEASE_NAME:-}"
+          BODY="${RELEASE_BODY:-${INPUT_BODY:-}}"
+          URL="${RELEASE_URL:-}"
+          PAYLOAD=$(jq -nc \
+            --arg tag "$TAG" \
+            --arg name "$NAME" \
+            --arg body "$BODY" \
+            --arg html_url "$URL" \
+            '{tag: $tag, name: $name, body: $body, html_url: $html_url}')
+          {
+            echo "payload<<EOF"
+            echo "$PAYLOAD"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Send repository_dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: whisqjs/whisq.dev
           event-type: framework-release
-          client-payload: |-
-            {
-              "tag": ${{ toJSON(github.event.release.tag_name || github.event.inputs.tag) }},
-              "name": ${{ toJSON(github.event.release.name) }},
-              "body": ${{ toJSON(github.event.release.body || github.event.inputs.body) }},
-              "html_url": ${{ toJSON(github.event.release.html_url) }}
-            }
+          client-payload: ${{ steps.payload.outputs.payload }}

--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -1,6 +1,8 @@
 name: Notify docs on release
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -12,5 +14,9 @@ jobs:
   hello:
     runs-on: ubuntu-latest
     steps:
-      - name: Echo
-        run: echo "hello, tag=${{ inputs.tag }}"
+      - name: Echo with env
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          echo "release_tag='${RELEASE_TAG}' input_tag='${INPUT_TAG}'"

--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -1,78 +1,16 @@
 name: Notify docs on release
 
-# Fires a repository_dispatch event at whisqjs/whisq.dev whenever a
-# release is published here. The receiver over there
-# (.github/workflows/on-framework-release.yml) opens a tracking issue
-# with the release notes and a docs checklist.
-#
-# Design: whisqjs/whisq.dev#21.
-
 on:
-  release:
-    types: [published]
-  # Manual override for end-to-end testing without cutting a release.
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to simulate (e.g. v0.1.0-alpha.5)
+        description: Tag
         required: true
-        type: string
         default: test-dispatch
-      body:
-        description: Release notes markdown (optional)
-        required: false
-        type: string
-        default: ""
-
-permissions:
-  contents: read
 
 jobs:
-  dispatch:
-    name: Dispatch to docs
+  hello:
     runs-on: ubuntu-latest
     steps:
-      - name: Mint app token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.WHISQ_BOT_APP_ID }}
-          private-key: ${{ secrets.WHISQ_BOT_PRIVATE_KEY }}
-          owner: whisqjs
-          repositories: whisq.dev
-
-      - name: Build payload
-        id: payload
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_NAME: ${{ github.event.release.name }}
-          RELEASE_BODY: ${{ github.event.release.body }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
-          INPUT_TAG: ${{ inputs.tag }}
-          INPUT_BODY: ${{ inputs.body }}
-        run: |
-          set -euo pipefail
-          TAG="${RELEASE_TAG:-$INPUT_TAG}"
-          NAME="${RELEASE_NAME:-}"
-          BODY="${RELEASE_BODY:-${INPUT_BODY:-}}"
-          URL="${RELEASE_URL:-}"
-          PAYLOAD=$(jq -nc \
-            --arg tag "$TAG" \
-            --arg name "$NAME" \
-            --arg body "$BODY" \
-            --arg html_url "$URL" \
-            '{tag: $tag, name: $name, body: $body, html_url: $html_url}')
-          {
-            echo "payload<<EOF"
-            echo "$PAYLOAD"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Send repository_dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          repository: whisqjs/whisq.dev
-          event-type: framework-release
-          client-payload: ${{ steps.payload.outputs.payload }}
+      - name: Echo
+        run: echo "hello, tag=${{ inputs.tag }}"

--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -1,0 +1,53 @@
+name: Notify docs on release
+
+# Fires a repository_dispatch event at whisqjs/whisq.dev whenever a
+# release is published here. The receiver over there
+# (.github/workflows/on-framework-release.yml) opens a tracking issue
+# with the release notes and a docs checklist.
+#
+# Design: whisqjs/whisq.dev#21.
+
+on:
+  release:
+    types: [published]
+  # Manual override for end-to-end testing without cutting a release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to simulate (e.g. v0.1.0-alpha.5)
+        required: true
+        default: test-dispatch
+      body:
+        description: Release notes markdown (optional)
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch to docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.WHISQ_BOT_APP_ID }}
+          private-key: ${{ secrets.WHISQ_BOT_PRIVATE_KEY }}
+          owner: whisqjs
+          repositories: whisq.dev
+
+      - name: Send repository_dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: whisqjs/whisq.dev
+          event-type: framework-release
+          client-payload: |-
+            {
+              "tag": ${{ toJSON(github.event.release.tag_name || github.event.inputs.tag) }},
+              "name": ${{ toJSON(github.event.release.name) }},
+              "body": ${{ toJSON(github.event.release.body || github.event.inputs.body) }},
+              "html_url": ${{ toJSON(github.event.release.html_url) }}
+            }

--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -9,14 +9,58 @@ on:
         description: Tag
         required: true
         default: test-dispatch
+      body:
+        description: Body
+        required: false
+        default: ""
+
+permissions:
+  contents: read
 
 jobs:
-  hello:
+  dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Echo with env
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.WHISQ_BOT_APP_ID }}
+          private-key: ${{ secrets.WHISQ_BOT_PRIVATE_KEY }}
+          owner: whisqjs
+          repositories: whisq.dev
+
+      - name: Build payload
+        id: payload
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
           INPUT_TAG: ${{ inputs.tag }}
+          INPUT_BODY: ${{ inputs.body }}
         run: |
-          echo "release_tag='${RELEASE_TAG}' input_tag='${INPUT_TAG}'"
+          set -euo pipefail
+          TAG="${RELEASE_TAG:-$INPUT_TAG}"
+          NAME="${RELEASE_NAME:-}"
+          BODY="${RELEASE_BODY:-${INPUT_BODY:-}}"
+          URL="${RELEASE_URL:-}"
+          PAYLOAD=$(jq -nc \
+            --arg tag "$TAG" \
+            --arg name "$NAME" \
+            --arg body "$BODY" \
+            --arg html_url "$URL" \
+            '{tag: $tag, name: $name, body: $body, html_url: $html_url}')
+          {
+            echo "payload<<EOF"
+            echo "$PAYLOAD"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send repository_dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: whisqjs/whisq.dev
+          event-type: framework-release
+          client-payload: ${{ steps.payload.outputs.payload }}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,107 @@
+name: Release — prepare
+
+# Step 1 of the release flow: on `develop`, roll up all pending changesets
+# into a `release/v<version>` branch and open a PR to `main`.
+#
+# Triggered manually so releases are explicit. When you're ready to cut a
+# release, go to Actions → "Release — prepare" → Run workflow. The job:
+#
+#   1. Verifies there's at least one pending changeset to release.
+#   2. Runs `pnpm run version` which applies all changesets (bumps versions
+#      in every package.json, writes CHANGELOG entries, deletes consumed
+#      changeset files, syncs create-whisq templates).
+#   3. Commits those changes to a new `release/v<version>` branch.
+#   4. Opens a PR from that branch into `main`.
+#
+# Merging the release PR into `main` triggers `.github/workflows/release.yml`
+# which does the npm publish + tagging + back-merge-to-develop PR.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release-prepare
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint WHISQ_BOT app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.WHISQ_BOT_APP_ID }}
+          private-key: ${{ secrets.WHISQ_BOT_PRIVATE_KEY }}
+          owner: whisqjs
+          repositories: whisq
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: develop
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Verify pending changesets exist
+        run: |
+          count=$(find .changeset -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')
+          if [ "$count" = "0" ]; then
+            echo "::error::No pending changesets on develop. Nothing to release."
+            exit 1
+          fi
+          echo "Found $count pending changeset(s)."
+
+      - name: Apply changesets (bump versions + write CHANGELOGs)
+        run: pnpm run version
+
+      - name: Determine new version
+        id: ver
+        run: echo "version=$(node -p "require('./packages/core/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push release branch
+        run: |
+          git config user.name "whisq-bot[bot]"
+          git config user.email "whisq-bot[bot]@users.noreply.github.com"
+          BRANCH="release/v${{ steps.ver.outputs.version }}"
+          git checkout -b "$BRANCH"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::error::pnpm run version produced no changes — aborting."
+            exit 1
+          fi
+          git commit -m "chore: release v${{ steps.ver.outputs.version }}"
+          git push -u origin "$BRANCH"
+
+      - name: Open release PR to main
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "release/v${{ steps.ver.outputs.version }}" \
+            --title "chore: release v${{ steps.ver.outputs.version }}" \
+            --label "skip-changeset" \
+            --body "$(cat <<EOF
+          Automated release PR for **v${{ steps.ver.outputs.version }}**.
+
+          Merging this PR into \`main\` triggers the publish workflow:
+          - \`pnpm run release\` publishes all bumped packages to npm with provenance
+          - changesets/action creates per-package git tags and GitHub Releases
+          - A follow-up PR will be opened to back-merge \`main\` → \`develop\`
+
+          See each package's \`CHANGELOG.md\` (in the diff) for what's shipping.
+          EOF
+          )"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,44 @@
 name: Release
 
-# Triggered by pushing a version tag (v0.1.0-alpha.0, v1.0.0, etc.)
-# or manually via workflow_dispatch.
+# Full release automation via Changesets.
+#
+# How it works:
+#
+# 1. Every PR to develop should include a changeset (a markdown file in
+#    `.changeset/`). PRs without one are blocked by the changeset-check job
+#    unless they carry the `skip-changeset` label (docs, repo tooling, etc.).
+#
+# 2. On push to develop, this workflow runs changesets/action. If there are
+#    pending changeset files, it opens (or updates) a PR titled
+#    "chore: release packages" that applies all pending changesets — bumping
+#    versions, updating CHANGELOGs, and removing the consumed changeset files.
+#
+# 3. Merging that release PR triggers this workflow again. This time there are
+#    no pending changesets, so the action runs `pnpm release` which publishes
+#    to npm and creates git tags for the newly-published versions.
+#
+# 4. A follow-up step turns the top-level tag (v<core-version>) into a
+#    GitHub Release with auto-generated notes.
+#
+# Manual override: `workflow_dispatch` lets you force a run, e.g. to recover
+# from a failed publish or publish a hotfix outside the normal flow.
 
 on:
   push:
-    tags: ["v*"]
+    branches: [develop]
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "Dry run (skip publish)"
-        required: false
-        default: "false"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
+  pull-requests: write
   id-token: write
 
 jobs:
-  build-and-publish:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -35,54 +55,62 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Lint
-        run: pnpm format --check
-
-      - name: Version consistency
-        run: node scripts/check-versions.mjs
-
-      - name: Typecheck
-        run: pnpm build && pnpm -r exec tsc --noEmit
+      # Safety-net quality gates — the same gates run on every PR, but we
+      # re-run them here so a broken main-branch state can never reach npm.
+      - name: Build
+        run: pnpm build
 
       - name: Test
         run: pnpm test
 
-      - name: Build
-        run: pnpm build
+      - name: Version consistency
+        run: node scripts/check-versions.mjs
 
       - name: Check bundle size
         run: cd packages/core && pnpm size
 
-      # Publish is split so a failure on the unscoped `create-whisq` package
-      # (which has its own token permissions on npm) does not block the
-      # @whisq/* scope. The whisq scope must stay internally consistent;
-      # create-whisq can lag until its token is wired up.
-      - name: Publish @whisq/* to npm
-        if: inputs.dry_run != 'true' && startsWith(github.ref, 'refs/tags/v')
-        run: pnpm --filter "@whisq/*" publish --access public --no-git-checks --provenance
+      - name: Create release PR or publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: pnpm version
+          publish: pnpm release
+          title: "chore: release packages"
+          commit: "chore: release packages"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish create-whisq to npm
-        if: inputs.dry_run != 'true' && startsWith(github.ref, 'refs/tags/v')
-        continue-on-error: true
-        run: pnpm --filter create-whisq publish --access public --no-git-checks --provenance
-        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: steps.changesets.outputs.published == 'true'
         uses: actions/github-script@v9
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         with:
           script: |
-            const tag = context.ref.replace('refs/tags/', '');
-            const isPrerelease = tag.includes('alpha') || tag.includes('beta') || tag.includes('rc');
-
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: tag,
-              name: tag,
-              generate_release_notes: true,
-              prerelease: isPrerelease,
-            });
+            const published = JSON.parse(process.env.PUBLISHED_PACKAGES || "[]");
+            const core = published.find((p) => p.name === "@whisq/core");
+            if (!core) {
+              console.log("No @whisq/core in published set — skipping GitHub Release.");
+              return;
+            }
+            const tag = `v${core.version}`;
+            const isPrerelease = /alpha|beta|rc/i.test(tag);
+            try {
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                name: tag,
+                generate_release_notes: true,
+                prerelease: isPrerelease,
+              });
+              console.log(`Created GitHub Release ${tag}`);
+            } catch (e) {
+              if (e.status === 422) {
+                console.log(`GitHub Release ${tag} already exists, skipping.`);
+                return;
+              }
+              throw e;
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,35 +1,23 @@
 name: Release
 
-# Fully automated release flow via Changesets.
+# Step 2 of the release flow: publish on push to `main`.
 #
-# - Every PR to develop includes a changeset (see CONTRIBUTING.md).
-# - On push to develop, this workflow runs:
-#     * If there are pending changeset .md files, it opens (or updates) a
-#       PR titled "chore: release packages" with the version bumps + CHANGELOG
-#       applied.
-#     * If the release PR was just merged, it runs `pnpm release` which
-#       publishes to npm, creates git tags, and then we create a GitHub
-#       Release with auto-generated notes.
+# Triggered when the release PR (opened by `release-prepare.yml`) merges
+# into `main`. This workflow:
 #
-# Why a GitHub App token instead of GITHUB_TOKEN:
-#   The runner's default GITHUB_TOKEN is blocked at the enterprise level
-#   from creating or approving pull requests (error:
-#   "GitHub Actions is not permitted to create or approve pull requests").
-#   The WHISQ_BOT GitHub App (already used by notify-docs-on-release) has
-#   explicit pull_requests:write + contents:write on this repo, which is
-#   what changesets/action needs.
+#   1. Re-runs build + test as a safety net.
+#   2. Invokes `pnpm run release` via changesets/action — publishes all
+#      bumped packages to npm with provenance, creates per-package git tags,
+#      and creates a GitHub Release for each tag.
+#   3. Opens a back-merge PR from `main` into `develop` so `develop` picks
+#      up the version bumps and CHANGELOG entries.
 #
-# One-time setup (documented in docs/RELEASING.md):
-#   The WHISQ_BOT app must be granted these permissions on whisqjs/whisq:
-#     - Contents: Read & Write
-#     - Pull requests: Read & Write
-#     - Metadata: Read
-#
-# Manual override: workflow_dispatch is available for recovery.
+# If there are no unpublished packages (e.g. workflow fires from an
+# unrelated push), changesets/action detects that and skips publishing.
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -42,8 +30,11 @@ permissions:
   id-token: write
 
 jobs:
-  release:
+  publish:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Mint WHISQ_BOT app token
         id: app-token
@@ -69,7 +60,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Safety-net quality gates
       - name: Build
         run: pnpm build
 
@@ -82,24 +72,56 @@ jobs:
       - name: Check bundle size
         run: cd packages/core && pnpm size
 
-      - name: Create release PR or publish
+      - name: Record current @whisq/core version
+        id: ver
+        run: echo "version=$(node -p "require('./packages/core/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to npm + create tags + GitHub Releases
         id: changesets
         uses: changesets/action@v1
         with:
-          # Use `pnpm run <script>` because pnpm's built-in `pnpm version`
-          # command shadows our package.json script of the same name (same
-          # applies to `release`). Running through `pnpm run` dispatches to
-          # the script we actually want (`changeset version` + template sync
-          # for version; `pnpm build && pnpm test && changeset publish` for
-          # release).
-          version: pnpm run version
           publish: pnpm run release
-          title: "chore: release packages"
-          commit: "chore: release packages"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      # GitHub Releases for each published package are created automatically
-      # by changesets/action (its `createGithubReleases: true` default).
-      # No follow-up step needed.
+
+  backmerge:
+    needs: publish
+    if: needs.publish.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Mint WHISQ_BOT app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.WHISQ_BOT_APP_ID }}
+          private-key: ${{ secrets.WHISQ_BOT_PRIVATE_KEY }}
+          owner: whisqjs
+          repositories: whisq
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create back-merge branch and open PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.publish.outputs.version }}
+        run: |
+          git config user.name "whisq-bot[bot]"
+          git config user.email "whisq-bot[bot]@users.noreply.github.com"
+          BRANCH="chore/backmerge-main-to-develop-v$VERSION"
+          git checkout -b "$BRANCH"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "chore: back-merge main → develop after v$VERSION" \
+            --label "skip-changeset" \
+            --body "Automated back-merge following the v$VERSION release. Bringing version bumps and CHANGELOG updates from \`main\` into \`develop\` so future feature branches start from the released state."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,37 +100,6 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create GitHub Release
-        if: steps.changesets.outputs.published == 'true'
-        uses: actions/github-script@v9
-        env:
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const published = JSON.parse(process.env.PUBLISHED_PACKAGES || "[]");
-            const core = published.find((p) => p.name === "@whisq/core");
-            if (!core) {
-              console.log("No @whisq/core in published set — skipping GitHub Release.");
-              return;
-            }
-            const tag = `v${core.version}`;
-            const isPrerelease = /alpha|beta|rc/i.test(tag);
-            try {
-              await github.rest.repos.createRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag_name: tag,
-                name: tag,
-                generate_release_notes: true,
-                prerelease: isPrerelease,
-              });
-              console.log(`Created GitHub Release ${tag}`);
-            } catch (e) {
-              if (e.status === 422) {
-                console.log(`GitHub Release ${tag} already exists, skipping.`);
-                return;
-              }
-              throw e;
-            }
+      # GitHub Releases for each published package are created automatically
+      # by changesets/action (its `createGithubReleases: true` default).
+      # No follow-up step needed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,14 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm version
-          publish: pnpm release
+          # Use `pnpm run <script>` because pnpm's built-in `pnpm version`
+          # command shadows our package.json script of the same name (same
+          # applies to `release`). Running through `pnpm run` dispatches to
+          # the script we actually want (`changeset version` + template sync
+          # for version; `pnpm build && pnpm test && changeset publish` for
+          # release).
+          version: pnpm run version
+          publish: pnpm run release
           title: "chore: release packages"
           commit: "chore: release packages"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,23 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # Mint a GitHub App installation token. The runner's GITHUB_TOKEN is
+      # blocked at the enterprise level from creating pull requests; the bot
+      # app token has explicit pull_requests:write + contents:write for this
+      # repo, which is what changesets/action needs to open the release PR.
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.WHISQ_BOT_APP_ID }}
+          private-key: ${{ secrets.WHISQ_BOT_PRIVATE_KEY }}
+          owner: whisqjs
+          repositories: whisq
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@v4
 
@@ -78,7 +92,7 @@ jobs:
           title: "chore: release packages"
           commit: "chore: release packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,20 @@ jobs:
       - name: Check bundle size
         run: cd packages/core && pnpm size
 
-      - name: Publish to npm
+      # Publish is split so a failure on the unscoped `create-whisq` package
+      # (which has its own token permissions on npm) does not block the
+      # @whisq/* scope. The whisq scope must stay internally consistent;
+      # create-whisq can lag until its token is wired up.
+      - name: Publish @whisq/* to npm
         if: inputs.dry_run != 'true' && startsWith(github.ref, 'refs/tags/v')
-        run: pnpm -r publish --access public --no-git-checks --provenance
+        run: pnpm --filter "@whisq/*" publish --access public --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish create-whisq to npm
+        if: inputs.dry_run != 'true' && startsWith(github.ref, 'refs/tags/v')
+        continue-on-error: true
+        run: pnpm --filter create-whisq publish --access public --no-git-checks --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,31 @@
 name: Release
 
-# Full release automation via Changesets.
+# Fully automated release flow via Changesets.
 #
-# How it works:
+# - Every PR to develop includes a changeset (see CONTRIBUTING.md).
+# - On push to develop, this workflow runs:
+#     * If there are pending changeset .md files, it opens (or updates) a
+#       PR titled "chore: release packages" with the version bumps + CHANGELOG
+#       applied.
+#     * If the release PR was just merged, it runs `pnpm release` which
+#       publishes to npm, creates git tags, and then we create a GitHub
+#       Release with auto-generated notes.
 #
-# 1. Every PR to develop should include a changeset (a markdown file in
-#    `.changeset/`). PRs without one are blocked by the changeset-check job
-#    unless they carry the `skip-changeset` label (docs, repo tooling, etc.).
+# Why a GitHub App token instead of GITHUB_TOKEN:
+#   The runner's default GITHUB_TOKEN is blocked at the enterprise level
+#   from creating or approving pull requests (error:
+#   "GitHub Actions is not permitted to create or approve pull requests").
+#   The WHISQ_BOT GitHub App (already used by notify-docs-on-release) has
+#   explicit pull_requests:write + contents:write on this repo, which is
+#   what changesets/action needs.
 #
-# 2. On push to develop, this workflow runs changesets/action. If there are
-#    pending changeset files, it opens (or updates) a PR titled
-#    "chore: release packages" that applies all pending changesets — bumping
-#    versions, updating CHANGELOGs, and removing the consumed changeset files.
+# One-time setup (documented in docs/RELEASING.md):
+#   The WHISQ_BOT app must be granted these permissions on whisqjs/whisq:
+#     - Contents: Read & Write
+#     - Pull requests: Read & Write
+#     - Metadata: Read
 #
-# 3. Merging that release PR triggers this workflow again. This time there are
-#    no pending changesets, so the action runs `pnpm release` which publishes
-#    to npm and creates git tags for the newly-published versions.
-#
-# 4. A follow-up step turns the top-level tag (v<core-version>) into a
-#    GitHub Release with auto-generated notes.
-#
-# Manual override: `workflow_dispatch` lets you force a run, e.g. to recover
-# from a failed publish or publish a hotfix outside the normal flow.
+# Manual override: workflow_dispatch is available for recovery.
 
 on:
   push:
@@ -41,11 +45,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      # Mint a GitHub App installation token. The runner's GITHUB_TOKEN is
-      # blocked at the enterprise level from creating pull requests; the bot
-      # app token has explicit pull_requests:write + contents:write for this
-      # repo, which is what changesets/action needs to open the release PR.
-      - name: Mint app token
+      - name: Mint WHISQ_BOT app token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
@@ -69,8 +69,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Safety-net quality gates — the same gates run on every PR, but we
-      # re-run them here so a broken main-branch state can never reach npm.
+      # Safety-net quality gates
       - name: Build
         run: pnpm build
 
@@ -102,6 +101,7 @@ jobs:
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const published = JSON.parse(process.env.PUBLISHED_PACKAGES || "[]");
             const core = published.find((p) => p.name === "@whisq/core");

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,30 @@ pnpm test
 WHISQ-<issue#>: <short description>
 ```
 
+## Changesets & Releases
+
+Whisq uses [Changesets](https://github.com/changesets/changesets) to automate versioning and publishing. **Every PR that changes shipped code must include a changeset.**
+
+### Adding a changeset to your PR
+
+From the repo root:
+
+```bash
+pnpm changeset
+```
+
+The CLI asks which packages changed and whether each change is a `patch`, `minor`, or `major` (we're currently in `alpha` pre-mode, so all bumps are prerelease bumps of `0.1.0-alpha.N`). It writes a small Markdown file in `.changeset/` — commit it alongside your code.
+
+If your PR genuinely doesn't need a version bump (docs-only, repo tooling, internal dependency tweaks with no API impact), add the `skip-changeset` label to the PR and the check will pass.
+
+### How the release actually cuts
+
+1. Merging a PR with changesets into `develop` triggers the Release workflow.
+2. The workflow accumulates pending changesets and opens (or updates) a PR titled **"chore: release packages"**. This PR shows the version bumps and CHANGELOG entries that would ship.
+3. When you merge that release PR, the workflow runs again and this time publishes to npm + creates git tags + opens a GitHub Release.
+
+Nothing is done by hand — no `pnpm version` / `pnpm release` locally, no manual tag pushes. If something goes wrong, `workflow_dispatch` on the Release workflow is the manual escape hatch.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,11 +82,15 @@ If your PR genuinely doesn't need a version bump (docs-only, repo tooling, inter
 
 ### How the release actually cuts
 
-1. Merging a PR with changesets into `develop` triggers the Release workflow.
-2. The workflow accumulates pending changesets and opens (or updates) a PR titled **"chore: release packages"**. This PR shows the version bumps and CHANGELOG entries that would ship.
-3. When you merge that release PR, the workflow runs again and this time publishes to npm + creates git tags + opens a GitHub Release.
+The branch flow is strict: `feature → develop → release/v<version> → main → back-merge → develop`. No package.json editing by hand; two workflows do all the mechanical work.
 
-Nothing is done by hand — no `pnpm version` / `pnpm release` locally, no manual tag pushes. If something goes wrong, `workflow_dispatch` on the Release workflow is the manual escape hatch.
+1. Your PR merges to `develop` with its changeset attached.
+2. When enough changesets have accumulated, a maintainer opens **Actions → Release — prepare → Run workflow**. That creates a `release/v<version>` branch, bumps every `package.json`, writes CHANGELOGs, and opens a PR to `main`.
+3. A maintainer reviews the release PR and squash-merges it into `main`.
+4. The merge triggers **`release.yml`**, which publishes all bumped packages to npm with provenance, creates per-package git tags and GitHub Releases, and opens a back-merge PR.
+5. A maintainer squash-merges the back-merge PR into `develop`.
+
+Full details in [`docs/RELEASING.md`](./docs/RELEASING.md).
 
 ## License
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,71 +1,111 @@
 # Releasing Whisq
 
-> How Whisq publishes new versions to npm. The short version: you don't. Merging changesets into `develop` does it for you.
+> How Whisq publishes new versions. The short version: you merge a changeset, click "Run workflow" on _Release — prepare_, review and merge the resulting release PR into `main`, then merge the back-merge PR into `develop`. Two clicks.
 
 ---
 
-## Day-to-day: add a changeset to every PR
+## The branch flow
 
-Every PR that changes code users can observe in `node_modules/@whisq/*` must include a changeset. The `changeset-check` workflow fails PRs that forget one (bypass with the `skip-changeset` label for docs, repo tooling, or no-op dep bumps).
+```
+feature/*  →  develop  →  release/v<version>  →  main  →  (back-merge)  →  develop
+```
+
+- **`feature/*` / `bugfix/*` / `chore/*`** branches → PR to `develop` (every PR carries a changeset or the `skip-changeset` label)
+- **`develop`** accumulates merged changesets
+- **`release/v<version>`** is cut from `develop` by the _Release — prepare_ workflow when you want to ship
+- **`main`** is production: merging the release PR here triggers npm publish
+- **Back-merge PR** from `main` → `develop` brings the version bumps home
+
+Nobody edits `package.json` versions by hand. The workflows do it.
+
+## Day-to-day: add a changeset to every PR
 
 ```bash
 pnpm changeset
 ```
 
-Answer the prompts — which packages changed, and whether the change is `patch` / `minor` / `major`. We're currently in **alpha pre mode** (`.changeset/pre.json` is present), so any bump becomes `0.1.0-alpha.N → 0.1.0-alpha.N+1`. The tool writes a small `.changeset/<slug>.md` file. Commit it alongside your code.
+Answer the prompts. Commit the generated `.changeset/<slug>.md` alongside your code. We're in **alpha pre mode** (`.changeset/pre.json` is present), so any bump resolves as `0.1.0-alpha.N → 0.1.0-alpha.N+1`.
 
-## What happens after merge to `develop`
+The `changeset-check` workflow fails PRs without a changeset unless they carry the `skip-changeset` label (docs, repo tooling, dep bumps with no API impact).
 
-The Release workflow (`.github/workflows/release.yml`) runs on every push to `develop`:
+## Cutting a release
 
-1. **If there are pending changeset files**, it opens (or updates) a PR titled **"chore: release packages"**. This PR shows the version bumps and CHANGELOG entries that will ship. Nothing has been published yet.
-2. **If the release PR just got merged** (so the push contains version-bumped `package.json` files and consumed changesets are gone), it runs `pnpm release` which:
-   - publishes each bumped package to npm with `--provenance`,
-   - creates a git tag per package,
-   - creates a GitHub Release for `@whisq/core` with auto-generated notes.
+### 1. Open _Release — prepare_
 
-So the entire human workflow is: write code, run `pnpm changeset`, commit, open PR, merge. Later, review and merge the auto-opened release PR.
+**Actions → Release — prepare → Run workflow** (on `develop`).
 
-## One-time setup (already done, documented here so future maintainers can reproduce)
+It:
+
+- verifies there's at least one pending changeset on `develop`
+- runs `pnpm run version` (applies all pending changesets, bumps every affected `package.json`, writes CHANGELOG entries, syncs create-whisq templates)
+- creates a `release/v<new-version>` branch with a single "chore: release v<version>" commit
+- opens a PR from that branch into `main`
+
+### 2. Review and merge the release PR into `main`
+
+The PR body shows the version bumps and each package's CHANGELOG diff. If something looks wrong, close the PR and the release branch; your pending changesets on `develop` are untouched. If it looks right, **use a merge commit (not squash)** — `main` keeps the full history of every feature that made it into the release.
+
+### 3. Automated publish
+
+Merging to `main` triggers `.github/workflows/release.yml`:
+
+- re-runs build + test + version-consistency + bundle-size
+- runs `pnpm run release` via `changesets/action` — publishes every bumped package to npm with `--provenance`, creates per-package git tags (`@whisq/core@<version>` etc.), and creates a GitHub Release per tag with auto-generated notes
+- opens a back-merge PR from `main` into `develop`
+
+### 4. Merge the back-merge PR into `develop`
+
+Title: `chore: back-merge main → develop after v<version>`. Carries the `skip-changeset` label. **Squash-merge** it so `develop` gets a single "back-merge" commit — `develop` stays clean and linear at one commit per merged PR.
+
+## Merge style per branch
+
+Whisq deliberately uses different merge styles for `develop` and `main`:
+
+| Target                                                             | Style            | Why                                                                                                                                      |
+| ------------------------------------------------------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| PRs into `develop` (all PRs — features, fixes, chore, back-merges) | **Squash**       | Each PR collapses into a single commit on `develop` — clean, linear, easy to scan.                                                       |
+| PRs into `main` (release PRs only)                                 | **Merge commit** | Preserves the history of every feature that made it into the release, so `git log main` shows every squashed PR as an individual commit. |
+
+This is convention, not enforced by GitHub — pick the right option from the dropdown on the green merge button.
+
+## One-time setup (already done, documented for future maintainers)
 
 ### `WHISQ_BOT` GitHub App
 
-The enterprise policy blocks the runner's built-in `GITHUB_TOKEN` from creating pull requests. The Release workflow uses the `WHISQ_BOT` installation token instead. This requires:
+Both release workflows use a `WHISQ_BOT` app installation token because the runner's default `GITHUB_TOKEN` is blocked at the enterprise level from creating pull requests.
 
-- **Secrets** on `whisqjs/whisq`:
-  - `WHISQ_BOT_APP_ID`
-  - `WHISQ_BOT_PRIVATE_KEY`
-- **App permissions** on `whisqjs/whisq`:
-  - Contents: **Read & Write**
-  - Pull requests: **Read & Write**
-  - Metadata: **Read**
+- **Secrets** on `whisqjs/whisq`: `WHISQ_BOT_APP_ID`, `WHISQ_BOT_PRIVATE_KEY`
+- **App permissions** on `whisqjs/whisq`: Contents R/W, Pull requests R/W, Metadata R
+- **Repository access**: `whisq` must be in the app's selected repositories
 
-To (re)grant those permissions: go to github.com/organizations/whisqjs/settings/installations, find the WHISQ_BOT app, ensure `whisq` is in the selected repos, and confirm the three scopes above.
+Grant/re-grant via github.com/organizations/whisqjs/settings/installations → WHISQ_BOT → Configure.
 
 ### Allowed third-party actions
 
-`changesets/action@*` and `pnpm/action-setup@*` are allowed via `Settings → Actions → General → Allow select actions and reusable workflows`. `actions/create-github-app-token` is GitHub-owned so it's allowed by default.
+`changesets/action@*` and `pnpm/action-setup@*` are allowed via Settings → Actions → General → Allow select actions. `actions/create-github-app-token` is GitHub-owned so it's allowed by default.
 
-### Branch protection on `develop`
+### Branch protection
 
-Requires PR, all 6 CI checks, no force-push, no deletion. The WHISQ_BOT app is **not** an admin — it cannot push directly to `develop`. That's why we use the release-PR flow (the PR goes through normal merge, not a direct push).
+- `main`: PR required, all CI checks, conversation resolution, no force-push, no deletion.
+- `develop`: PR required, all CI checks, no force-push, no deletion.
+- The WHISQ_BOT app can push feature-like branches (`release/*`, `chore/backmerge-*`) but cannot push directly to `main` or `develop` — that's why everything happens through PRs.
 
 ## Exiting pre mode
 
-When ready to cut a `0.1.0` stable:
+When the API is stable enough to drop `-alpha`:
 
 ```bash
 pnpm changeset pre exit
 ```
 
-Commit the deleted `.changeset/pre.json` in a PR. After that, bumps resolve as normal semver — the next release will be `0.1.0`, then `0.1.1` / `0.2.0` / etc.
+Commit the deletion of `.changeset/pre.json` on a feature branch, PR to develop, merge. After that, the next _Release — prepare_ will produce a normal semver version (e.g. `0.1.0`).
 
 ## Emergency manual override
 
-If the automation is broken (e.g. npm outage, bad app token, enterprise policy change), re-run via `workflow_dispatch` on the Release workflow. If that also fails:
+Both release workflows also accept `workflow_dispatch`. If the automation is broken entirely:
 
 ```bash
-# On develop, with a clean working tree and no pending changesets:
+# On a release/v<version> branch checked out locally, with no pending changesets:
 pnpm install --frozen-lockfile
 pnpm build
 pnpm test
@@ -80,7 +120,7 @@ Requires `NPM_TOKEN` in your environment or `npm login` with 2FA.
 npm view @whisq/core version
 npm view create-whisq version
 
-# Fresh install sanity check:
+# Fresh-install sanity:
 mkdir /tmp/whisq-sanity && cd /tmp/whisq-sanity
 npm init -y
 npm install @whisq/core
@@ -88,12 +128,13 @@ npm install @whisq/core
 
 ## Troubleshooting
 
-| Symptom                                                                         | Likely cause                                           | Fix                                                                                            |
-| ------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| Release workflow `startup_failure`                                              | New third-party action not allowlisted                 | Add to `Settings → Actions → General → Allow select actions`                                   |
-| `HttpError: GitHub Actions is not permitted to create or approve pull requests` | Using runner's `GITHUB_TOKEN` instead of the app token | Ensure `GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}` is on the `changesets/action` step |
-| `Resource not accessible by integration`                                        | WHISQ_BOT app lacks `pull_requests:write` on this repo | Re-grant the permission in the app's installation settings                                     |
-| `403 Forbidden` on publish                                                      | `NPM_TOKEN` expired or revoked                         | Rotate the secret                                                                              |
-| Provenance error                                                                | Missing `id-token: write` permission                   | Already set at the workflow level                                                              |
-| Tag already exists                                                              | Release was re-run after a partial success             | Delete the tag on GitHub if it's wrong, or move on — publishing is idempotent per-version      |
-| Version conflict between packages                                               | Someone hand-edited `package.json`                     | `node scripts/check-versions.mjs` to diagnose; re-run `pnpm version` after fixing              |
+| Symptom                                                                         | Likely cause                                                 | Fix                                                                                                                                                  |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _Release — prepare_ errors with "No pending changesets on develop"              | No `.changeset/*.md` accumulated since last release          | Merge a PR that adds a changeset, or run `pnpm changeset` on a throwaway branch first                                                                |
+| Release workflow `startup_failure`                                              | New third-party action not allowlisted                       | Add to Settings → Actions → General → Allow select actions                                                                                           |
+| `HttpError: GitHub Actions is not permitted to create or approve pull requests` | Using runner's `GITHUB_TOKEN` instead of the app token       | Ensure `GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}` on all PR-creating steps                                                                 |
+| `Resource not accessible by integration`                                        | WHISQ_BOT app lacks `pull_requests:write` on this repo       | Re-grant the permission in the app's installation settings                                                                                           |
+| `403 Forbidden` on publish                                                      | `NPM_TOKEN` expired or revoked                               | Rotate the secret                                                                                                                                    |
+| `Package size limit has exceeded` on release run                                | A merged feature pushed `@whisq/core` past 5 KB gzipped      | Move the added code behind a sub-path export (like `@whisq/core/collections`), or bump the limit in `packages/core/package.json` `size-limit` config |
+| Tag already exists for a version we tried to republish                          | Prior run partially succeeded                                | Delete the stale tag on GitHub or move on — npm publish is idempotent per-version                                                                    |
+| `pnpm version` runs Node's version dump instead of the script                   | Never invoke `pnpm version` directly; use `pnpm run version` | Already baked into the release workflow                                                                                                              |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,116 +1,99 @@
 # Releasing Whisq
 
-> How to publish new versions of Whisq packages to npm.
+> How Whisq publishes new versions to npm. The short version: you don't. Merging changesets into `develop` does it for you.
 
 ---
 
-## Prerequisites
+## Day-to-day: add a changeset to every PR
 
-1. **npm account** with access to the `@whisq` scope
-2. **NPM_TOKEN** secret configured in the GitHub repository
-3. **2FA enabled** on the npm account
-4. You're on the `develop` branch with a clean working tree
-
-## Release Flow
-
-### 1. Create a Changeset
-
-During development, create changesets to describe your changes:
+Every PR that changes code users can observe in `node_modules/@whisq/*` must include a changeset. The `changeset-check` workflow fails PRs that forget one (bypass with the `skip-changeset` label for docs, repo tooling, or no-op dep bumps).
 
 ```bash
 pnpm changeset
 ```
 
-Select the packages you changed and the semver bump type:
+Answer the prompts — which packages changed, and whether the change is `patch` / `minor` / `major`. We're currently in **alpha pre mode** (`.changeset/pre.json` is present), so any bump becomes `0.1.0-alpha.N → 0.1.0-alpha.N+1`. The tool writes a small `.changeset/<slug>.md` file. Commit it alongside your code.
 
-- **patch** — bug fixes, docs changes
-- **minor** — new features, additive API changes
-- **major** — breaking changes (only for v2.0+)
+## What happens after merge to `develop`
 
-This creates a file in `.changeset/` that describes the change.
+The Release workflow (`.github/workflows/release.yml`) runs on every push to `develop`:
 
-### 2. Version Packages
+1. **If there are pending changeset files**, it opens (or updates) a PR titled **"chore: release packages"**. This PR shows the version bumps and CHANGELOG entries that will ship. Nothing has been published yet.
+2. **If the release PR just got merged** (so the push contains version-bumped `package.json` files and consumed changesets are gone), it runs `pnpm release` which:
+   - publishes each bumped package to npm with `--provenance`,
+   - creates a git tag per package,
+   - creates a GitHub Release for `@whisq/core` with auto-generated notes.
 
-When ready to release, apply all pending changesets:
+So the entire human workflow is: write code, run `pnpm changeset`, commit, open PR, merge. Later, review and merge the auto-opened release PR.
+
+## One-time setup (already done, documented here so future maintainers can reproduce)
+
+### `WHISQ_BOT` GitHub App
+
+The enterprise policy blocks the runner's built-in `GITHUB_TOKEN` from creating pull requests. The Release workflow uses the `WHISQ_BOT` installation token instead. This requires:
+
+- **Secrets** on `whisqjs/whisq`:
+  - `WHISQ_BOT_APP_ID`
+  - `WHISQ_BOT_PRIVATE_KEY`
+- **App permissions** on `whisqjs/whisq`:
+  - Contents: **Read & Write**
+  - Pull requests: **Read & Write**
+  - Metadata: **Read**
+
+To (re)grant those permissions: go to github.com/organizations/whisqjs/settings/installations, find the WHISQ_BOT app, ensure `whisq` is in the selected repos, and confirm the three scopes above.
+
+### Allowed third-party actions
+
+`changesets/action@*` and `pnpm/action-setup@*` are allowed via `Settings → Actions → General → Allow select actions and reusable workflows`. `actions/create-github-app-token` is GitHub-owned so it's allowed by default.
+
+### Branch protection on `develop`
+
+Requires PR, all 6 CI checks, no force-push, no deletion. The WHISQ_BOT app is **not** an admin — it cannot push directly to `develop`. That's why we use the release-PR flow (the PR goes through normal merge, not a direct push).
+
+## Exiting pre mode
+
+When ready to cut a `0.1.0` stable:
 
 ```bash
-pnpm version
+pnpm changeset pre exit
 ```
 
-This:
+Commit the deleted `.changeset/pre.json` in a PR. After that, bumps resolve as normal semver — the next release will be `0.1.0`, then `0.1.1` / `0.2.0` / etc.
 
-- Bumps all package versions according to changesets
-- Generates/updates CHANGELOG.md in each package
-- Removes consumed changeset files
+## Emergency manual override
 
-### 3. Commit and Push
+If the automation is broken (e.g. npm outage, bad app token, enterprise policy change), re-run via `workflow_dispatch` on the Release workflow. If that also fails:
 
 ```bash
-git add .
-git commit -m "chore: release v0.0.1-alpha.1"
-git push
-```
-
-### 4. Create a Release Tag
-
-```bash
-git tag v0.0.1-alpha.1
-git push --tags
-```
-
-### 5. Automated Publish
-
-Pushing a `v*` tag triggers the release workflow (`.github/workflows/release.yml`) which:
-
-1. Runs the full CI pipeline (lint, typecheck, test, build)
-2. Publishes all packages to npm with `--provenance`
-3. Creates a GitHub Release with auto-generated release notes
-
-### 6. Verify
-
-After the workflow completes:
-
-```bash
-# Check packages are on npm
-npm view @whisq/core version
-npm view @whisq/router version
-
-# Test install in a fresh project
-mkdir /tmp/test-whisq && cd /tmp/test-whisq
-npm init -y
-npm install @whisq/core
-
-# Test create-whisq
-npm create whisq@latest test-app
-```
-
-## Pre-release Versions
-
-For alpha/beta releases, the tag name determines the pre-release label:
-
-- `v0.0.1-alpha.1` → publishes as alpha
-- `v0.0.1-beta.1` → publishes as beta
-- `v0.0.1-rc.1` → publishes as release candidate
-
-The GitHub Release will automatically be marked as "pre-release".
-
-## Manual Publish (Emergency)
-
-If the CI pipeline fails and you need to publish manually:
-
-```bash
+# On develop, with a clean working tree and no pending changesets:
+pnpm install --frozen-lockfile
 pnpm build
 pnpm test
-pnpm -r publish --access public --no-git-checks
+pnpm -r publish --access public --no-git-checks --provenance
 ```
 
 Requires `NPM_TOKEN` in your environment or `npm login` with 2FA.
 
+## Verifying a release
+
+```bash
+npm view @whisq/core version
+npm view create-whisq version
+
+# Fresh install sanity check:
+mkdir /tmp/whisq-sanity && cd /tmp/whisq-sanity
+npm init -y
+npm install @whisq/core
+```
+
 ## Troubleshooting
 
-| Issue                           | Solution                                                        |
-| ------------------------------- | --------------------------------------------------------------- |
-| `403 Forbidden` on publish      | Check NPM_TOKEN is valid and has publish access to @whisq scope |
-| Provenance error                | Ensure `id-token: write` permission in workflow                 |
-| Package not found after publish | Wait 1-2 minutes for npm registry to propagate                  |
-| Version conflict                | Run `pnpm version` to consume changesets, then commit           |
+| Symptom                                                                         | Likely cause                                           | Fix                                                                                            |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| Release workflow `startup_failure`                                              | New third-party action not allowlisted                 | Add to `Settings → Actions → General → Allow select actions`                                   |
+| `HttpError: GitHub Actions is not permitted to create or approve pull requests` | Using runner's `GITHUB_TOKEN` instead of the app token | Ensure `GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}` is on the `changesets/action` step |
+| `Resource not accessible by integration`                                        | WHISQ_BOT app lacks `pull_requests:write` on this repo | Re-grant the permission in the app's installation settings                                     |
+| `403 Forbidden` on publish                                                      | `NPM_TOKEN` expired or revoked                         | Rotate the secret                                                                              |
+| Provenance error                                                                | Missing `id-token: write` permission                   | Already set at the workflow level                                                              |
+| Tag already exists                                                              | Release was re-run after a partial success             | Delete the tag on GitHub if it's wrong, or move on — publishing is idempotent per-version      |
+| Version conflict between packages                                               | Someone hand-edited `package.json`                     | `node scripts/check-versions.mjs` to diagnose; re-run `pnpm version` after fixing              |

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @whisq/core
 
+## 0.1.0-alpha.5
+
+### Minor Changes
+
+- 0191d7e: **Retrospective changeset for the batch of work merged since `v0.1.0-alpha.4`.** In pre mode this bumps every package to `0.1.0-alpha.5`.
+
+  ### New `@whisq/core` API
+  - **`ref<T>()`** primitive + exported `Ref<T>` type — typed signal refs for DOM elements (#18 · #26)
+  - **`bind(signal, options?)`** two-way form-binding helper for `input`/`textarea`/`select` — collapses 3-line controlled-input boilerplate to one spread (#19 · #25)
+  - **`resource()` extensions** — `mutate(value | updater)` for optimistic updates, `source` option for reactive refetches, `initialValue`, `keepPrevious`, and an `AbortSignal` passed to the fetcher so requests cancel on refetch/source-change. Stale responses are dropped; AbortErrors don't leak into `.error()` (#20 · #28)
+  - **`match(...branches, fallback?)`** multi-branch conditional — first-true-wins renderer in the `when`/`each` family (#21 · #30)
+  - **Style prop object form** with per-property reactive subscriptions + new **`sx()`** compositional helper (#22 · #31)
+  - **`signalMap<K, V>` / `signalSet<T>`** reactive collections with per-key/per-value tracking, at sub-path `@whisq/core/collections` to keep the top-level bundle under 5 KB (#23 · #32)
+  - **Event handler type narrowing** — `e.currentTarget` is now correctly typed per element (`HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, `HTMLFormElement`, `HTMLAnchorElement`, `HTMLImageElement`). New dedicated `TextareaProps` interface (textarea was incorrectly reusing `InputProps`) (#24 · #34)
+
+  ### Tooling
+  - **`dist/public-api.json`** manifest shipped inside `@whisq/core` on every build, fetchable via `unpkg.com/@whisq/core@<version>/dist/public-api.json`. Powers the docs-repo drift-check for the AI reference card (#27 · #29)
+
+  ### Notes
+  - Backward compatible with `0.1.0-alpha.4`. No breaking changes.
+  - Bundle size: `@whisq/core` is **4.75 KB gzipped** (under the 5 KB marketing gate).
+  - Test count: 284 in `@whisq/core` (up from ~194 at alpha.4).
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,6 +27,32 @@ mount(App, document.getElementById("app"));
 
 Full documentation at [whisq.dev](https://whisq.dev).
 
+## Public API manifest
+
+Every published release ships a machine-readable list of exports at
+`dist/public-api.json` inside the npm package. It's the source of truth
+for "what `@whisq/core` exposes at this version" and is used by the
+docs site to guard against silent drift in the AI reference card.
+
+Shape:
+
+```json
+{
+  "version": "0.1.0-alpha.4",
+  "exports": ["Signal", "bind", "component", "mount", "..."]
+}
+```
+
+Fetch it via any CDN that mirrors npm:
+
+```
+https://unpkg.com/@whisq/core@<version>/dist/public-api.json
+https://cdn.jsdelivr.net/npm/@whisq/core@<version>/dist/public-api.json
+```
+
+Regenerated on every build by `scripts/generate-public-api.mjs` reading
+`src/index.ts`.
+
 ## License
 
 MIT

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/generate-public-api.mjs",
     "dev": "tsc --watch",
     "test": "vitest run --passWithNoTests",
     "size": "size-limit",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,8 +21,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc && node scripts/generate-public-api.mjs",
-    "dev": "tsc --watch",
+    "build": "tsc -p tsconfig.build.json && node scripts/generate-public-api.mjs",
+    "dev": "tsc --watch -p tsconfig.build.json",
     "test": "vitest run --passWithNoTests",
     "size": "size-limit",
     "bench": "tsx bench/signal-throughput.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./collections": {
+      "types": "./dist/collections.d.ts",
+      "import": "./dist/collections.js"
     }
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/scripts/generate-public-api.mjs
+++ b/packages/core/scripts/generate-public-api.mjs
@@ -1,0 +1,89 @@
+// ============================================================================
+// Whisq Core — Public API manifest generator
+//
+// Reads src/index.ts, extracts every named export (values + types),
+// and writes dist/public-api.json with { version, exports[] }.
+//
+// The manifest ships with the npm package, so consumers (e.g. the docs
+// repo's drift check) can fetch it from:
+//
+//   https://unpkg.com/@whisq/core@<version>/dist/public-api.json
+//
+// Pure extraction logic is exported so tests can exercise it without disk IO.
+// ============================================================================
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const RE_REEXPORT =
+  /export\s+(?:type\s+)?\{([\s\S]*?)\}\s+from\s+["'][^"']+["']/g;
+
+/**
+ * Extract every named export from an `index.ts` re-export file.
+ * Handles value re-exports, `type` re-exports, `as` aliases, and multi-line
+ * export blocks. Returns sorted unique names.
+ */
+export function extractExports(source) {
+  // Strip whole-line and end-of-line single-line comments so commented-out
+  // re-export statements don't leak into the manifest.
+  const cleaned = source.replace(/\/\/[^\n]*/g, "");
+  const names = new Set();
+  for (const match of cleaned.matchAll(RE_REEXPORT)) {
+    // Strip single-line // comments that live inside the re-export block so
+    // they don't leak into the extracted names.
+    const inner = match[1].replace(/\/\/[^\n]*/g, "");
+    for (const raw of inner.split(",")) {
+      const part = raw.trim();
+      if (!part) continue;
+      const aliasMatch = part.match(/\s+as\s+(\w+)$/);
+      const name = aliasMatch
+        ? aliasMatch[1]
+        : part.replace(/^type\s+/, "").trim();
+      // Only keep clean identifiers — reject anything that still contains
+      // whitespace or punctuation (defensive against odd formatting).
+      if (/^\w+$/.test(name)) {
+        names.add(name);
+      }
+    }
+  }
+  return [...names].sort();
+}
+
+/**
+ * Build the manifest object from a version string and the source file content.
+ */
+export function generateManifest(version, source) {
+  return {
+    version,
+    exports: extractExports(source),
+  };
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+const isDirectRun =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url === `file:///${process.argv[1].replace(/\\/g, "/")}`;
+
+if (isDirectRun) {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const pkgRoot = resolve(__dirname, "..");
+
+  const pkg = JSON.parse(
+    readFileSync(resolve(pkgRoot, "package.json"), "utf8"),
+  );
+  const src = readFileSync(resolve(pkgRoot, "src/index.ts"), "utf8");
+
+  const manifest = generateManifest(pkg.version, src);
+
+  const outDir = resolve(pkgRoot, "dist");
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+
+  const outPath = resolve(outDir, "public-api.json");
+  writeFileSync(outPath, JSON.stringify(manifest, null, 2) + "\n");
+
+  console.log(
+    `Wrote ${outPath}: ${manifest.exports.length} exports, version ${manifest.version}`,
+  );
+}

--- a/packages/core/src/__tests__/bind.test.ts
+++ b/packages/core/src/__tests__/bind.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { signal } from "../reactive.js";
+import { input, textarea, select, option, mount } from "../elements.js";
+import { bind } from "../bind.js";
+
+let container: HTMLElement;
+let dispose: () => void;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+});
+
+describe("bind() — text input", () => {
+  it("reflects initial signal value into DOM", () => {
+    const name = signal("ada");
+    dispose = mount(input({ ...bind(name) }), container);
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("ada");
+  });
+
+  it("updates signal when user types into the input", () => {
+    const name = signal("");
+    dispose = mount(input({ ...bind(name) }), container);
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "grace";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(name.value).toBe("grace");
+  });
+
+  it("propagates programmatic signal updates to DOM", () => {
+    const name = signal("ada");
+    dispose = mount(input({ ...bind(name) }), container);
+    const el = container.querySelector("input") as HTMLInputElement;
+    name.value = "grace";
+    expect(el.value).toBe("grace");
+  });
+});
+
+describe("bind() — number input", () => {
+  it("parses numeric input via valueAsNumber", () => {
+    const age = signal(0);
+    dispose = mount(
+      input({ type: "number", ...bind(age, { as: "number" }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "42";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(age.value).toBe(42);
+  });
+
+  it("ignores NaN (e.g. empty string) keeping signal at previous value", () => {
+    const age = signal(7);
+    dispose = mount(
+      input({ type: "number", ...bind(age, { as: "number" }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(age.value).toBe(7);
+  });
+
+  it("reflects signal value as DOM string", () => {
+    const age = signal(21);
+    dispose = mount(
+      input({ type: "number", ...bind(age, { as: "number" }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("21");
+    age.value = 99;
+    expect(el.value).toBe("99");
+  });
+});
+
+describe("bind() — checkbox", () => {
+  it("reflects signal as checked", () => {
+    const agreed = signal(true);
+    dispose = mount(
+      input({ type: "checkbox", ...bind(agreed, { as: "checkbox" }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(true);
+    agreed.value = false;
+    expect(el.checked).toBe(false);
+  });
+
+  it("toggles signal on change", () => {
+    const agreed = signal(false);
+    dispose = mount(
+      input({ type: "checkbox", ...bind(agreed, { as: "checkbox" }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(agreed.value).toBe(true);
+    el.checked = false;
+    el.dispatchEvent(new Event("change"));
+    expect(agreed.value).toBe(false);
+  });
+});
+
+describe("bind() — radio", () => {
+  it("sets checked only when signal equals the radio's value", () => {
+    const role = signal<"admin" | "user">("user");
+    dispose = mount(
+      input({
+        type: "radio",
+        name: "role",
+        ...bind(role, { as: "radio", value: "admin" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(false);
+    role.value = "admin";
+    expect(el.checked).toBe(true);
+  });
+
+  it("sets signal to the radio's value on change", () => {
+    const role = signal<"admin" | "user">("user");
+    dispose = mount(
+      input({
+        type: "radio",
+        name: "role",
+        ...bind(role, { as: "radio", value: "admin" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(role.value).toBe("admin");
+  });
+});
+
+describe("bind() — textarea and select", () => {
+  it("works with textarea (string signal)", () => {
+    const notes = signal("hi");
+    dispose = mount(textarea({ ...bind(notes) }), container);
+    const el = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(el.value).toBe("hi");
+    el.value = "updated";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(notes.value).toBe("updated");
+  });
+
+  it("works with select (string signal)", () => {
+    const role = signal("user");
+    dispose = mount(
+      select(
+        { ...bind(role) },
+        option({ value: "user" }, "User"),
+        option({ value: "admin" }, "Admin"),
+      ),
+      container,
+    );
+    const el = container.querySelector("select") as HTMLSelectElement;
+    expect(el.value).toBe("user");
+    el.value = "admin";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(role.value).toBe("admin");
+  });
+});
+
+describe("bind() — input validation", () => {
+  it("throws TypeError when first argument is not a signal", () => {
+    expect(() => bind({} as never)).toThrow(TypeError);
+    expect(() => bind(null as never)).toThrow(TypeError);
+    expect(() => bind("not a signal" as never)).toThrow(TypeError);
+  });
+});

--- a/packages/core/src/__tests__/collections.test.ts
+++ b/packages/core/src/__tests__/collections.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi } from "vitest";
+import { effect } from "../reactive.js";
+// Imported from the internal module path. Public API is
+// `@whisq/core/collections` (see packages/core/package.json exports).
+import { signalMap, signalSet } from "../collections.js";
+
+describe("signalMap()", () => {
+  it("accepts initial entries", () => {
+    const m = signalMap<string, number>([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    expect(m.get("a")).toBe(1);
+    expect(m.get("b")).toBe(2);
+    expect(m.size).toBe(2);
+  });
+
+  it("set / get / has / delete round-trip", () => {
+    const m = signalMap<string, number>();
+    expect(m.has("x")).toBe(false);
+
+    m.set("x", 42);
+    expect(m.has("x")).toBe(true);
+    expect(m.get("x")).toBe(42);
+
+    expect(m.delete("x")).toBe(true);
+    expect(m.delete("x")).toBe(false);
+    expect(m.has("x")).toBe(false);
+    expect(m.get("x")).toBeUndefined();
+  });
+
+  it("get() subscription fires only when that key changes", () => {
+    const m = signalMap<string, number>();
+    m.set("a", 1);
+    m.set("b", 2);
+
+    const spy = vi.fn(() => {
+      m.get("a");
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.set("b", 99); // different key
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.set("a", 5);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("has() subscription fires only on add/delete of that key", () => {
+    const m = signalMap<string, number>();
+
+    const spy = vi.fn(() => {
+      m.has("a");
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.set("b", 1);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.set("a", 1);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    m.delete("a");
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it("size is reactive on add/delete/clear", () => {
+    const m = signalMap<string, number>();
+
+    let seen: number[] = [];
+    effect(() => {
+      seen.push(m.size);
+    });
+    expect(seen).toEqual([0]);
+
+    m.set("a", 1);
+    m.set("b", 2);
+    expect(seen).toEqual([0, 1, 2]);
+
+    m.delete("a");
+    expect(seen).toEqual([0, 1, 2, 1]);
+
+    m.clear();
+    expect(seen).toEqual([0, 1, 2, 1, 0]);
+  });
+
+  it("iteration subscribes to structural changes", () => {
+    const m = signalMap<string, number>([["a", 1]]);
+    let snapshots: string[][] = [];
+
+    effect(() => {
+      snapshots.push([...m.keys()]);
+    });
+    expect(snapshots).toEqual([["a"]]);
+
+    m.set("b", 2);
+    expect(snapshots).toEqual([["a"], ["a", "b"]]);
+
+    m.delete("a");
+    expect(snapshots).toEqual([["a"], ["a", "b"], ["b"]]);
+  });
+
+  it("setting the same value twice on an existing key still triggers (no Object.is skip)", () => {
+    // Matches Map's semantics — set always emits, consistent with how other
+    // reactive libs behave for collections. Users can check before setting.
+    const m = signalMap<string, number>([["a", 1]]);
+    const spy = vi.fn(() => {
+      m.get("a");
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.set("a", 1);
+    m.set("a", 1);
+    // Each set notifies. The underlying signal() dedup's via Object.is, so
+    // identical values should NOT re-fire.
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves undefined as a valid stored value (distinct from absent)", () => {
+    const m = signalMap<string, number | undefined>();
+    m.set("x", undefined);
+    expect(m.has("x")).toBe(true);
+    expect(m.get("x")).toBeUndefined();
+
+    m.delete("x");
+    expect(m.has("x")).toBe(false);
+  });
+
+  it("forEach passes (value, key, map)", () => {
+    const m = signalMap<string, number>([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    const seen: Array<[number, string]> = [];
+    m.forEach((v, k) => seen.push([v, k]));
+    expect(seen).toEqual([
+      [1, "a"],
+      [2, "b"],
+    ]);
+  });
+
+  it("set returns the map (chainable)", () => {
+    const m = signalMap<string, number>();
+    const res = m.set("a", 1).set("b", 2);
+    expect(res).toBe(m);
+    expect(m.size).toBe(2);
+  });
+
+  it("clear on an empty map is a no-op (no subscriber re-runs)", () => {
+    const m = signalMap<string, number>();
+    const spy = vi.fn(() => {
+      m.size;
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    m.clear();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("signalSet()", () => {
+  it("accepts initial values", () => {
+    const s = signalSet<string>(["a", "b"]);
+    expect(s.has("a")).toBe(true);
+    expect(s.has("b")).toBe(true);
+    expect(s.size).toBe(2);
+  });
+
+  it("add / has / delete round-trip", () => {
+    const s = signalSet<string>();
+    expect(s.has("x")).toBe(false);
+
+    s.add("x");
+    expect(s.has("x")).toBe(true);
+
+    expect(s.delete("x")).toBe(true);
+    expect(s.delete("x")).toBe(false);
+    expect(s.has("x")).toBe(false);
+  });
+
+  it("has() subscription fires only for that value", () => {
+    const s = signalSet<string>();
+
+    const spy = vi.fn(() => {
+      s.has("admin");
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    s.add("user"); // different value
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    s.add("admin");
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    s.delete("admin");
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it("size is reactive", () => {
+    const s = signalSet<string>();
+    let seen: number[] = [];
+    effect(() => {
+      seen.push(s.size);
+    });
+    expect(seen).toEqual([0]);
+
+    s.add("a");
+    s.add("b");
+    expect(seen).toEqual([0, 1, 2]);
+
+    s.delete("a");
+    expect(seen).toEqual([0, 1, 2, 1]);
+
+    s.clear();
+    expect(seen).toEqual([0, 1, 2, 1, 0]);
+  });
+
+  it("duplicate add() is a no-op", () => {
+    const s = signalSet<string>(["a"]);
+    const spy = vi.fn(() => {
+      s.size;
+    });
+    effect(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    s.add("a"); // already present
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("iteration subscribes to structural changes", () => {
+    const s = signalSet<string>(["a"]);
+    const snapshots: string[][] = [];
+
+    effect(() => {
+      snapshots.push([...s]);
+    });
+    expect(snapshots).toEqual([["a"]]);
+
+    s.add("b");
+    expect(snapshots).toEqual([["a"], ["a", "b"]]);
+  });
+
+  it("forEach passes (value, value, set)", () => {
+    const s = signalSet<string>(["a", "b"]);
+    const seen: string[] = [];
+    s.forEach((v, v2, setArg) => {
+      expect(v).toBe(v2);
+      expect(setArg).toBe(s);
+      seen.push(v);
+    });
+    expect(seen).toEqual(["a", "b"]);
+  });
+
+  it("add returns the set (chainable)", () => {
+    const s = signalSet<string>();
+    const res = s.add("a").add("b");
+    expect(res).toBe(s);
+    expect(s.size).toBe(2);
+  });
+});

--- a/packages/core/src/__tests__/component.test.ts
+++ b/packages/core/src/__tests__/component.test.ts
@@ -241,4 +241,159 @@ describe("resource()", () => {
       expect(r.data()).toBe(2);
     });
   });
+
+  // ── mutate() ───────────────────────────────────────────────────────────
+
+  it("mutate(value) sets data synchronously without fetching", async () => {
+    const r = resource(() => Promise.resolve("fetched"));
+    await vi.waitFor(() => expect(r.loading()).toBe(false));
+
+    r.mutate("optimistic");
+    expect(r.data()).toBe("optimistic");
+  });
+
+  it("mutate(updater) receives the previous value", async () => {
+    const r = resource<number[]>(() => Promise.resolve([1, 2, 3]));
+    await vi.waitFor(() => expect(r.loading()).toBe(false));
+
+    r.mutate((prev) => [...(prev ?? []), 4]);
+    expect(r.data()).toEqual([1, 2, 3, 4]);
+  });
+
+  // ── initialValue ───────────────────────────────────────────────────────
+
+  it("initialValue populates data() before the first fetch resolves", () => {
+    const r = resource(() => Promise.resolve("late"), {
+      initialValue: "early",
+    });
+    expect(r.data()).toBe("early");
+    expect(r.loading()).toBe(true);
+  });
+
+  it("initialValue is replaced by the fetched value", async () => {
+    const r = resource(() => Promise.resolve("late"), {
+      initialValue: "early",
+    });
+    await vi.waitFor(() => expect(r.loading()).toBe(false));
+    expect(r.data()).toBe("late");
+  });
+
+  // ── keepPrevious ───────────────────────────────────────────────────────
+
+  it("keeps the previous value during refetch by default", async () => {
+    let nth = 0;
+    const r = resource(() => Promise.resolve(++nth));
+    await vi.waitFor(() => expect(r.loading()).toBe(false));
+    expect(r.data()).toBe(1);
+
+    r.refetch();
+    expect(r.data()).toBe(1); // still visible during refetch
+    await vi.waitFor(() => expect(r.data()).toBe(2));
+  });
+
+  it("resets data to undefined during refetch when keepPrevious is false", async () => {
+    let nth = 0;
+    const r = resource(() => Promise.resolve(++nth), { keepPrevious: false });
+    await vi.waitFor(() => expect(r.loading()).toBe(false));
+    expect(r.data()).toBe(1);
+
+    r.refetch();
+    expect(r.data()).toBeUndefined();
+    await vi.waitFor(() => expect(r.data()).toBe(2));
+  });
+
+  // ── AbortSignal ────────────────────────────────────────────────────────
+
+  it("passes an AbortSignal to the fetcher", async () => {
+    let captured: AbortSignal | undefined;
+    const r = resource(({ signal }) => {
+      captured = signal;
+      return Promise.resolve("ok");
+    });
+    await vi.waitFor(() => expect(r.loading()).toBe(false));
+    expect(captured).toBeInstanceOf(AbortSignal);
+    expect(captured!.aborted).toBe(false);
+  });
+
+  it("aborts the previous signal when refetch is called", async () => {
+    const signals: AbortSignal[] = [];
+    const r = resource(({ signal }) => {
+      signals.push(signal);
+      return new Promise<string>((resolve) =>
+        setTimeout(() => resolve("done"), 20),
+      );
+    });
+    r.refetch();
+    await vi.waitFor(() => expect(r.data()).toBe("done"));
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[signals.length - 1].aborted).toBe(false);
+  });
+
+  it("drops stale responses — newer fetch always wins", async () => {
+    const fetches: Array<(v: string) => void> = [];
+    const r = resource(
+      () =>
+        new Promise<string>((resolve) => {
+          fetches.push(resolve);
+        }),
+    );
+    r.refetch();
+    // Resolve the second (newer) fetch first, then the first (stale).
+    fetches[1]("new");
+    await vi.waitFor(() => expect(r.data()).toBe("new"));
+    fetches[0]("old");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(r.data()).toBe("new");
+  });
+
+  it("does not surface an AbortError when a fetch is cancelled", async () => {
+    const r = resource(
+      ({ signal }) =>
+        new Promise<string>((resolve, reject) => {
+          signal.addEventListener("abort", () =>
+            reject(new Error("AbortError")),
+          );
+          setTimeout(() => resolve("done"), 20);
+        }),
+    );
+    r.refetch();
+    await vi.waitFor(() => expect(r.data()).toBe("done"));
+    expect(r.error()).toBeUndefined();
+  });
+
+  // ── source ─────────────────────────────────────────────────────────────
+
+  it("re-runs the fetcher when the source signal changes", async () => {
+    const id = signal(1);
+    const seen: number[] = [];
+    const r = resource(
+      (src: number) => {
+        seen.push(src);
+        return Promise.resolve(`user-${src}`);
+      },
+      { source: () => id.value },
+    );
+    await vi.waitFor(() => expect(r.data()).toBe("user-1"));
+
+    id.value = 2;
+    await vi.waitFor(() => expect(r.data()).toBe("user-2"));
+    expect(seen).toEqual([1, 2]);
+  });
+
+  it("passes source as the first fetcher arg and signal as the second", async () => {
+    const id = signal("abc");
+    let capturedSrc: string | undefined;
+    let capturedSignal: AbortSignal | undefined;
+    const r = resource(
+      (src: string, { signal }) => {
+        capturedSrc = src;
+        capturedSignal = signal;
+        return Promise.resolve(`ok-${src}`);
+      },
+      { source: () => id.value },
+    );
+    await vi.waitFor(() => expect(r.data()).toBe("ok-abc"));
+    expect(capturedSrc).toBe("abc");
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+  });
 });

--- a/packages/core/src/__tests__/event-types.test-d.ts
+++ b/packages/core/src/__tests__/event-types.test-d.ts
@@ -1,0 +1,129 @@
+// Type-level assertions for element event handler inference.
+// Included in tsc's typecheck via packages/core/tsconfig.json's
+// `src/**/*.ts` glob. Runtime work is a no-op — the file exercises the type
+// checker, not the DOM.
+
+import { describe, it, expectTypeOf } from "vitest";
+import {
+  input,
+  textarea,
+  select,
+  option,
+  form,
+  button,
+  a,
+  img,
+  div,
+} from "../elements.js";
+
+describe("event handler type inference", () => {
+  it("input oninput narrows currentTarget to HTMLInputElement", () => {
+    input({
+      oninput: (e) => {
+        // The motivating use case — no cast required on currentTarget.value
+        expectTypeOf(e.currentTarget.value).toEqualTypeOf<string>();
+        expectTypeOf(e.currentTarget.checked).toEqualTypeOf<boolean>();
+        expectTypeOf(e).toMatchTypeOf<InputEvent>();
+      },
+    });
+  });
+
+  it("input onchange / onfocus / onblur / onkeydown narrow to HTMLInputElement", () => {
+    input({
+      onchange: (e) => {
+        expectTypeOf(e.currentTarget.type).toEqualTypeOf<string>();
+      },
+      onfocus: (e) => {
+        expectTypeOf(e).toMatchTypeOf<FocusEvent>();
+        expectTypeOf(e.currentTarget.select).toBeFunction();
+      },
+      onblur: (e) => {
+        expectTypeOf(e).toMatchTypeOf<FocusEvent>();
+      },
+      onkeydown: (e) => {
+        expectTypeOf(e).toMatchTypeOf<KeyboardEvent>();
+        expectTypeOf(e.key).toEqualTypeOf<string>();
+        expectTypeOf(e.currentTarget.value).toEqualTypeOf<string>();
+      },
+    });
+  });
+
+  it("textarea narrows currentTarget to HTMLTextAreaElement", () => {
+    textarea({
+      oninput: (e) => {
+        expectTypeOf(e.currentTarget.rows).toEqualTypeOf<number>();
+        expectTypeOf(e.currentTarget.cols).toEqualTypeOf<number>();
+        expectTypeOf(e.currentTarget.value).toEqualTypeOf<string>();
+      },
+    });
+  });
+
+  it("select narrows currentTarget to HTMLSelectElement", () => {
+    select({
+      onchange: (e) => {
+        expectTypeOf(e.currentTarget.selectedIndex).toEqualTypeOf<number>();
+        expectTypeOf(e.currentTarget.options).toMatchTypeOf<HTMLCollection>();
+      },
+    });
+  });
+
+  it("form narrows onsubmit currentTarget to HTMLFormElement", () => {
+    form({
+      onsubmit: (e) => {
+        expectTypeOf(e).toMatchTypeOf<SubmitEvent>();
+        expectTypeOf(e.currentTarget.reset).toBeFunction();
+        expectTypeOf(e.currentTarget.submit).toBeFunction();
+      },
+    });
+  });
+
+  it("anchor narrows onclick currentTarget to HTMLAnchorElement", () => {
+    a({
+      onclick: (e) => {
+        expectTypeOf(e).toMatchTypeOf<MouseEvent>();
+        expectTypeOf(e.currentTarget.href).toEqualTypeOf<string>();
+        expectTypeOf(e.currentTarget.target).toEqualTypeOf<string>();
+      },
+    });
+  });
+
+  it("img narrows onclick currentTarget to HTMLImageElement", () => {
+    img({
+      onclick: (e) => {
+        expectTypeOf(e.currentTarget.naturalWidth).toEqualTypeOf<number>();
+        expectTypeOf(e.currentTarget.naturalHeight).toEqualTypeOf<number>();
+      },
+    });
+  });
+
+  it("option accepts its base props", () => {
+    // Option has no narrowed event handlers; ensure the prop shape compiles.
+    option({ value: "admin", selected: true });
+  });
+
+  it("generic elements (div, button) keep a usable HTMLElement on currentTarget", () => {
+    div({
+      onclick: (e) => {
+        // HTMLElement members accessible without cast:
+        expectTypeOf(e.currentTarget.click).toBeFunction();
+        expectTypeOf(e.currentTarget.classList).toMatchTypeOf<DOMTokenList>();
+      },
+    });
+    button({
+      onclick: (e) => {
+        expectTypeOf(e.currentTarget.focus).toBeFunction();
+      },
+    });
+  });
+
+  it("event type itself is still narrowed per prop name", () => {
+    button({
+      onclick: (e) => {
+        expectTypeOf(e).toMatchTypeOf<MouseEvent>();
+      },
+      onkeydown: (e) => {
+        expectTypeOf(e).toMatchTypeOf<KeyboardEvent>();
+      },
+    });
+  });
+});

--- a/packages/core/src/__tests__/match.test.ts
+++ b/packages/core/src/__tests__/match.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { signal } from "../reactive.js";
+import { div, p, span, match, mount } from "../elements.js";
+
+let container: HTMLElement;
+let dispose: () => void;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+});
+
+describe("match()", () => {
+  it("renders the first branch whose predicate is true", () => {
+    const node = div(
+      match([() => true, () => p("first")], [() => true, () => p("second")]),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelectorAll("p")).toHaveLength(1);
+    expect(container.querySelector("p")!.textContent).toBe("first");
+  });
+
+  it("renders a later branch when earlier predicates are false", () => {
+    const node = div(
+      match(
+        [() => false, () => p("skipped")],
+        [() => false, () => p("also skipped")],
+        [() => true, () => p("winner")],
+      ),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelector("p")!.textContent).toBe("winner");
+  });
+
+  it("renders the fallback when no branch matches", () => {
+    const node = div(
+      match([() => false, () => p("a")], [() => false, () => p("b")], () =>
+        p("fallback"),
+      ),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelector("p")!.textContent).toBe("fallback");
+  });
+
+  it("renders nothing when no branch matches and no fallback is given", () => {
+    const node = div(
+      match([() => false, () => p("a")], [() => false, () => p("b")]),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelector("p")).toBeNull();
+  });
+
+  it("is reactive — predicate changes swap the rendered branch", () => {
+    const status = signal<"loading" | "error" | "ready">("loading");
+    const node = div(
+      match(
+        [() => status.value === "loading", () => p("Loading...")],
+        [() => status.value === "error", () => p({ class: "error" }, "Oops")],
+        [() => status.value === "ready", () => p("Done")],
+      ),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelector("p")!.textContent).toBe("Loading...");
+
+    status.value = "error";
+    expect(container.querySelector("p")!.textContent).toBe("Oops");
+    expect(container.querySelector("p")!.className).toBe("error");
+
+    status.value = "ready";
+    expect(container.querySelector("p")!.textContent).toBe("Done");
+  });
+
+  it("renders the fallback when all predicates turn false reactively", () => {
+    const active = signal(true);
+    const node = div(
+      match([() => active.value, () => p("on")], () => p("off")),
+    );
+    dispose = mount(node, container);
+
+    expect(container.querySelector("p")!.textContent).toBe("on");
+    active.value = false;
+    expect(container.querySelector("p")!.textContent).toBe("off");
+  });
+
+  it("supports complex children (nested hyperscript)", () => {
+    const node = div(
+      match([
+        () => true,
+        () => div({ class: "card" }, p("title"), span("subtitle")),
+      ]),
+    );
+    dispose = mount(node, container);
+
+    const card = container.querySelector(".card");
+    expect(card).not.toBeNull();
+    expect(card!.querySelector("p")!.textContent).toBe("title");
+    expect(card!.querySelector("span")!.textContent).toBe("subtitle");
+  });
+
+  it("returns null when called with no arguments", () => {
+    const node = div(match());
+    dispose = mount(node, container);
+    expect(container.querySelector("p")).toBeNull();
+  });
+
+  it("renders the fallback when branches is empty but fallback is provided", () => {
+    const node = div(match(() => p("only the fallback")));
+    dispose = mount(node, container);
+    expect(container.querySelector("p")!.textContent).toBe("only the fallback");
+  });
+});

--- a/packages/core/src/__tests__/public-api.test.ts
+++ b/packages/core/src/__tests__/public-api.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+// @ts-expect-error — .mjs module without type declarations
+import {
+  extractExports,
+  generateManifest,
+} from "../../scripts/generate-public-api.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(__dirname, "../..");
+
+describe("extractExports()", () => {
+  it("extracts value re-exports", () => {
+    const src = `export { signal, computed } from "./reactive.js";`;
+    expect(extractExports(src)).toEqual(["computed", "signal"]);
+  });
+
+  it("extracts type re-exports", () => {
+    const src = `export type { Signal, ReadonlySignal } from "./reactive.js";`;
+    expect(extractExports(src)).toEqual(["ReadonlySignal", "Signal"]);
+  });
+
+  it("resolves `as` aliases to the exported name", () => {
+    const src = `export { internal as publicName } from "./x.js";`;
+    expect(extractExports(src)).toEqual(["publicName"]);
+  });
+
+  it("handles multi-line export blocks", () => {
+    const src = `
+      export {
+        h,
+        raw,
+        when,
+        each,
+      } from "./elements.js";
+    `;
+    expect(extractExports(src)).toEqual(["each", "h", "raw", "when"]);
+  });
+
+  it("deduplicates names that appear more than once", () => {
+    const src = `
+      export { foo } from "./a.js";
+      export type { foo } from "./b.js";
+    `;
+    expect(extractExports(src)).toEqual(["foo"]);
+  });
+
+  it("ignores commented-out re-export statements", () => {
+    const src = `
+      // export { ghost } from "./nope.js";
+      export { real } from "./x.js";
+    `;
+    expect(extractExports(src)).toEqual(["real"]);
+  });
+
+  it("ignores in-block // comments without swallowing the following name", () => {
+    const src = `
+      export {
+        // Core
+        h,
+        raw,
+      } from "./elements.js";
+    `;
+    expect(extractExports(src)).toEqual(["h", "raw"]);
+  });
+
+  it("extracts canonical exports from the real src/index.ts", () => {
+    const src = readFileSync(resolve(pkgRoot, "src/index.ts"), "utf8");
+    const exports = extractExports(src);
+
+    // Sanity: substantial surface
+    expect(exports.length).toBeGreaterThan(30);
+
+    // Sorted
+    expect(exports).toEqual([...exports].sort());
+
+    // Key public surface must be present
+    for (const name of [
+      "signal",
+      "computed",
+      "effect",
+      "batch",
+      "component",
+      "mount",
+      "resource",
+      "ref",
+      "bind",
+      "Resource",
+      "Signal",
+    ]) {
+      expect(exports).toContain(name);
+    }
+  });
+});
+
+describe("generateManifest()", () => {
+  it("returns version and sorted exports", () => {
+    const manifest = generateManifest(
+      "1.2.3",
+      `export { b, a } from "./x.js"; export type { C } from "./y.js";`,
+    );
+    expect(manifest).toEqual({
+      version: "1.2.3",
+      exports: ["C", "a", "b"],
+    });
+  });
+});
+
+describe("generate-public-api.mjs CLI", () => {
+  const outPath = resolve(pkgRoot, "dist/public-api.json");
+
+  beforeAll(() => {
+    execFileSync(
+      "node",
+      [resolve(pkgRoot, "scripts/generate-public-api.mjs")],
+      { stdio: "pipe" },
+    );
+  });
+
+  it("writes dist/public-api.json", () => {
+    expect(existsSync(outPath)).toBe(true);
+  });
+
+  it("writes valid JSON with version and exports fields", () => {
+    const manifest = JSON.parse(readFileSync(outPath, "utf8"));
+    expect(manifest).toHaveProperty("version");
+    expect(typeof manifest.version).toBe("string");
+    expect(manifest).toHaveProperty("exports");
+    expect(Array.isArray(manifest.exports)).toBe(true);
+    expect(manifest.exports.length).toBeGreaterThan(30);
+  });
+
+  it("version matches package.json", () => {
+    const manifest = JSON.parse(readFileSync(outPath, "utf8"));
+    const pkg = JSON.parse(
+      readFileSync(resolve(pkgRoot, "package.json"), "utf8"),
+    );
+    expect(manifest.version).toBe(pkg.version);
+  });
+
+  it("exports are sorted and unique", () => {
+    const manifest = JSON.parse(readFileSync(outPath, "utf8"));
+    const sorted = [...manifest.exports].sort();
+    expect(manifest.exports).toEqual(sorted);
+    expect(new Set(manifest.exports).size).toBe(manifest.exports.length);
+  });
+});

--- a/packages/core/src/__tests__/ref.test.ts
+++ b/packages/core/src/__tests__/ref.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { signal } from "../reactive.js";
+import { signal, isSignal } from "../reactive.js";
 import { div, input, button, mount } from "../elements.js";
+import { ref } from "../ref.js";
 
 let container: HTMLElement;
 let dispose: () => void;
@@ -90,5 +91,47 @@ describe("ref prop", () => {
         "Click me",
       );
     });
+  });
+});
+
+describe("ref() helper", () => {
+  it("returns a Signal", () => {
+    const r = ref<HTMLInputElement>();
+    expect(isSignal(r)).toBe(true);
+  });
+
+  it("initializes to null", () => {
+    const r = ref<HTMLInputElement>();
+    expect(r.value).toBeNull();
+  });
+
+  it("populates on mount when used as an element ref", () => {
+    const inputRef = ref<HTMLInputElement>();
+    dispose = mount(input({ ref: inputRef, type: "text" }), container);
+    expect(inputRef.value).toBeInstanceOf(HTMLInputElement);
+    expect(inputRef.value!.type).toBe("text");
+  });
+
+  it("resets to null on dispose", () => {
+    const inputRef = ref<HTMLInputElement>();
+    dispose = mount(input({ ref: inputRef }), container);
+    expect(inputRef.value).toBeInstanceOf(HTMLInputElement);
+    dispose();
+    expect(inputRef.value).toBeNull();
+  });
+
+  it("is typed to the requested element", () => {
+    // Compile-time assertion: ref<HTMLInputElement>() typed as Signal<HTMLInputElement | null>
+    const r = ref<HTMLInputElement>();
+    dispose = mount(input({ ref: r }), container);
+    // .focus is HTMLInputElement-specific; this line only typechecks if r.value narrows correctly.
+    r.value?.focus();
+    expect(document.activeElement).toBe(r.value);
+  });
+
+  it("defaults element type to HTMLElement when unspecified", () => {
+    const r = ref();
+    dispose = mount(div({ ref: r }), container);
+    expect(r.value).toBeInstanceOf(HTMLDivElement);
   });
 });

--- a/packages/core/src/__tests__/style-object.test.ts
+++ b/packages/core/src/__tests__/style-object.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { signal } from "../reactive.js";
+import { div, mount } from "../elements.js";
+import { sx } from "../styling.js";
+
+let container: HTMLElement;
+let dispose: () => void;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+});
+
+describe("style prop — object form", () => {
+  it("applies static properties on mount", () => {
+    const node = div({ style: { color: "red", padding: "1rem" } });
+    dispose = mount(node, container);
+
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.color).toBe("red");
+    expect(el.style.padding).toBe("1rem");
+  });
+
+  it("reactively updates a property when its signal changes", () => {
+    const color = signal("red");
+    const node = div({ style: { color: () => color.value } });
+    dispose = mount(node, container);
+
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.color).toBe("red");
+
+    color.value = "blue";
+    expect(el.style.color).toBe("blue");
+  });
+
+  it("updates only the changed property, not others", () => {
+    const color = signal("red");
+    const padding = signal("1rem");
+    const node = div({
+      style: {
+        color: () => color.value,
+        padding: () => padding.value,
+      },
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    color.value = "blue";
+    expect(el.style.color).toBe("blue");
+    expect(el.style.padding).toBe("1rem");
+  });
+
+  it("mixes static and reactive properties", () => {
+    const x = signal(10);
+    const node = div({
+      style: {
+        color: "red",
+        transform: () => `translateX(${x.value}px)`,
+      },
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.color).toBe("red");
+    expect(el.style.transform).toBe("translateX(10px)");
+    x.value = 20;
+    expect(el.style.transform).toBe("translateX(20px)");
+  });
+
+  it("converts camelCase keys to kebab-case", () => {
+    const node = div({
+      style: { backgroundColor: "yellow", borderRadius: "4px" },
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.backgroundColor).toBe("yellow");
+    expect(el.style.borderRadius).toBe("4px");
+  });
+
+  it("accepts kebab-case keys directly", () => {
+    const node = div({ style: { "background-color": "yellow" } });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.backgroundColor).toBe("yellow");
+  });
+
+  it("passes CSS custom properties through unchanged", () => {
+    const accent = signal("#5ce0f2");
+    const node = div({ style: { "--accent": () => accent.value } });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.getPropertyValue("--accent")).toBe("#5ce0f2");
+    accent.value = "#4F46E5";
+    expect(el.style.getPropertyValue("--accent")).toBe("#4F46E5");
+  });
+
+  it("removes the property when the getter returns undefined", () => {
+    const color = signal<string | undefined>("red");
+    const node = div({ style: { color: () => color.value } });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.color).toBe("red");
+    color.value = undefined;
+    expect(el.style.color).toBe("");
+  });
+
+  it("removes the property when the getter returns empty string", () => {
+    const pad = signal("1rem");
+    const node = div({ style: { padding: () => pad.value } });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    pad.value = "";
+    expect(el.style.padding).toBe("");
+  });
+
+  it("coerces numeric values to string", () => {
+    const op = signal(1);
+    const node = div({
+      style: {
+        opacity: () => op.value,
+        zIndex: 5,
+      },
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.opacity).toBe("1");
+    expect(el.style.zIndex).toBe("5");
+    op.value = 0;
+    expect(el.style.opacity).toBe("0");
+  });
+
+  it("skips null and empty-string static entries without error", () => {
+    const node = div({
+      style: {
+        color: "red",
+        padding: null,
+        margin: "",
+      },
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.color).toBe("red");
+    expect(el.style.padding).toBe("");
+    expect(el.style.margin).toBe("");
+  });
+
+  // Regression checks — make sure the existing forms still work.
+
+  it("regression — static string form still sets cssText", () => {
+    const node = div({ style: "color: red; padding: 1rem" });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.style.color).toBe("red");
+    expect(el.style.padding).toBe("1rem");
+  });
+
+  it("regression — reactive string form still updates", () => {
+    const c = signal("red");
+    const node = div({ style: () => `color: ${c.value}` });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.color).toBe("red");
+    c.value = "blue";
+    expect(el.style.color).toBe("blue");
+  });
+});
+
+describe("sx() — style composition", () => {
+  it("merges multiple objects, later wins", () => {
+    expect(sx({ a: "1", b: "2" }, { b: "3", c: "4" })).toEqual({
+      a: "1",
+      b: "3",
+      c: "4",
+    });
+  });
+
+  it("ignores false / null / undefined args", () => {
+    expect(sx({ a: "1" }, false, null, undefined, { b: "2" })).toEqual({
+      a: "1",
+      b: "2",
+    });
+  });
+
+  it("preserves function values without invoking them", () => {
+    const getter = () => "red";
+    const merged = sx({ color: getter });
+    expect(merged.color).toBe(getter);
+  });
+
+  it("supports the conditional `cond && {...}` pattern", () => {
+    const active = true;
+    const merged = sx({ color: "red" }, active && { borderColor: "blue" }, {
+      padding: "1rem",
+    });
+    expect(merged).toEqual({
+      color: "red",
+      borderColor: "blue",
+      padding: "1rem",
+    });
+  });
+
+  it("integrates with the style prop (composition end-to-end)", () => {
+    const active = signal(true);
+    const node = div({
+      style: sx({ color: "red" }, active.value && { borderColor: "blue" }, {
+        padding: () => (active.value ? "1rem" : "0"),
+      }),
+    });
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.style.color).toBe("red");
+    expect(el.style.borderColor).toBe("blue");
+    expect(el.style.padding).toBe("1rem");
+  });
+});

--- a/packages/core/src/bind.ts
+++ b/packages/core/src/bind.ts
@@ -1,0 +1,109 @@
+// ============================================================================
+// Whisq Core — Two-way input binding helper
+// bind(signal, options?) returns a prop object to spread into input/select/textarea.
+// ============================================================================
+
+import { type Signal, isSignal } from "./reactive.js";
+
+export interface TextBind {
+  value: () => string;
+  oninput: (e: Event) => void;
+}
+
+export interface NumberBind {
+  value: () => string;
+  oninput: (e: Event) => void;
+}
+
+export interface CheckboxBind {
+  checked: () => boolean;
+  onchange: (e: Event) => void;
+}
+
+export interface RadioBind<V extends string> {
+  value: V;
+  checked: () => boolean;
+  onchange: (e: Event) => void;
+}
+
+export type BindOptions =
+  | { as: "number" }
+  | { as: "checkbox" }
+  | { as: "radio"; value: string };
+
+/**
+ * Two-way binding helper for form inputs.
+ *
+ * ```ts
+ * input({ ...bind(name) })                              // text
+ * input({ type: "number", ...bind(age, { as: "number" }) })
+ * input({ type: "checkbox", ...bind(agreed, { as: "checkbox" }) })
+ * input({ type: "radio", ...bind(role, { as: "radio", value: "admin" }) })
+ * ```
+ */
+export function bind(signal: Signal<string>): TextBind;
+export function bind(
+  signal: Signal<number>,
+  options: { as: "number" },
+): NumberBind;
+export function bind(
+  signal: Signal<boolean>,
+  options: { as: "checkbox" },
+): CheckboxBind;
+export function bind<V extends string>(
+  signal: Signal<V>,
+  options: { as: "radio"; value: V },
+): RadioBind<V>;
+export function bind(
+  signal: Signal<string | number | boolean>,
+  options?: BindOptions,
+): TextBind | NumberBind | CheckboxBind | RadioBind<string> {
+  if (!isSignal(signal)) {
+    throw new TypeError("bind() expects a Signal as its first argument");
+  }
+
+  if (options?.as === "checkbox") {
+    const sig = signal as Signal<boolean>;
+    return {
+      checked: () => sig.value,
+      onchange: (e: Event) => {
+        sig.value = (e.target as HTMLInputElement).checked;
+      },
+    };
+  }
+
+  if (options?.as === "radio") {
+    const sig = signal as Signal<string>;
+    const target = options.value;
+    return {
+      value: target,
+      checked: () => sig.value === target,
+      onchange: (e: Event) => {
+        if ((e.target as HTMLInputElement).checked) {
+          sig.value = target;
+        }
+      },
+    };
+  }
+
+  if (options?.as === "number") {
+    const sig = signal as Signal<number>;
+    return {
+      value: () => String(sig.value),
+      oninput: (e: Event) => {
+        const n = (e.target as HTMLInputElement).valueAsNumber;
+        if (!Number.isNaN(n)) sig.value = n;
+      },
+    };
+  }
+
+  const sig = signal as Signal<string>;
+  return {
+    value: () => sig.value,
+    oninput: (e: Event) => {
+      sig.value = (
+        e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+      ).value;
+    },
+  };
+}

--- a/packages/core/src/collections.ts
+++ b/packages/core/src/collections.ts
@@ -1,0 +1,243 @@
+// ============================================================================
+// Whisq Core — Reactive Collections
+//
+// signalMap<K, V> and signalSet<T> — Map/Set with per-key reactivity so
+// effects only re-run when the keys they actually read change. Built on
+// top of signal() so they participate in the same tracking/batching system
+// as the rest of the reactive core.
+// ============================================================================
+
+import { signal, type Signal } from "./reactive.js";
+
+const MISSING: unique symbol = Symbol("whisq.collections.missing");
+type Missing = typeof MISSING;
+
+// ── signalMap ──────────────────────────────────────────────────────────────
+
+export interface SignalMap<K, V> {
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  set(key: K, value: V): SignalMap<K, V>;
+  delete(key: K): boolean;
+  clear(): void;
+  readonly size: number;
+  keys(): IterableIterator<K>;
+  values(): IterableIterator<V>;
+  entries(): IterableIterator<[K, V]>;
+  [Symbol.iterator](): IterableIterator<[K, V]>;
+  forEach(fn: (value: V, key: K, map: SignalMap<K, V>) => void): void;
+}
+
+/**
+ * A reactive Map where each key has its own subscriber set. Effects that read
+ * a specific key via `.get()` or `.has()` re-run only when that key changes;
+ * effects that iterate or read `.size` re-run on any structural change.
+ *
+ * ```ts
+ * const users = signalMap<string, User>();
+ * users.set("u1", alice);
+ * effect(() => console.log(users.get("u1")?.name));  // tracks "u1" only
+ * users.set("u2", bob);   // effect does NOT re-run
+ * users.set("u1", carol); // effect re-runs
+ * ```
+ */
+export function signalMap<K, V>(
+  initial?: Iterable<readonly [K, V]>,
+): SignalMap<K, V> {
+  const data = new Map<K, V>(initial as Iterable<[K, V]> | undefined);
+  const keySignals = new Map<K, Signal<V | Missing>>();
+  const structure = signal(0);
+
+  function keySig(key: K): Signal<V | Missing> {
+    let s = keySignals.get(key);
+    if (!s) {
+      s = signal<V | Missing>(data.has(key) ? (data.get(key) as V) : MISSING);
+      keySignals.set(key, s);
+    }
+    return s;
+  }
+
+  function bumpStructure(): void {
+    structure.value = structure.value + 1;
+  }
+
+  const map: SignalMap<K, V> = {
+    get(key: K): V | undefined {
+      const v = keySig(key).value;
+      return v === MISSING ? undefined : v;
+    },
+
+    has(key: K): boolean {
+      return keySig(key).value !== MISSING;
+    },
+
+    set(key: K, value: V): SignalMap<K, V> {
+      const existed = data.has(key);
+      data.set(key, value);
+      keySig(key).value = value;
+      if (!existed) bumpStructure();
+      return map;
+    },
+
+    delete(key: K): boolean {
+      if (!data.has(key)) return false;
+      data.delete(key);
+      const sig = keySignals.get(key);
+      if (sig) sig.value = MISSING;
+      bumpStructure();
+      return true;
+    },
+
+    clear(): void {
+      if (data.size === 0) return;
+      for (const k of [...data.keys()]) {
+        data.delete(k);
+        const sig = keySignals.get(k);
+        if (sig) sig.value = MISSING;
+      }
+      bumpStructure();
+    },
+
+    get size(): number {
+      structure.value; // track structural changes
+      return data.size;
+    },
+
+    keys(): IterableIterator<K> {
+      structure.value; // track
+      return data.keys();
+    },
+
+    values(): IterableIterator<V> {
+      structure.value;
+      return data.values();
+    },
+
+    entries(): IterableIterator<[K, V]> {
+      structure.value;
+      return data.entries();
+    },
+
+    [Symbol.iterator](): IterableIterator<[K, V]> {
+      structure.value;
+      return data.entries();
+    },
+
+    forEach(fn: (value: V, key: K, m: SignalMap<K, V>) => void): void {
+      structure.value;
+      data.forEach((v, k) => fn(v, k, map));
+    },
+  };
+
+  return map;
+}
+
+// ── signalSet ──────────────────────────────────────────────────────────────
+
+export interface SignalSet<T> {
+  has(value: T): boolean;
+  add(value: T): SignalSet<T>;
+  delete(value: T): boolean;
+  clear(): void;
+  readonly size: number;
+  keys(): IterableIterator<T>;
+  values(): IterableIterator<T>;
+  entries(): IterableIterator<[T, T]>;
+  [Symbol.iterator](): IterableIterator<T>;
+  forEach(fn: (value: T, value2: T, set: SignalSet<T>) => void): void;
+}
+
+/**
+ * A reactive Set with per-value membership signals — effects that read
+ * `.has(x)` re-run only when `x` is added or removed, not on other changes.
+ *
+ * ```ts
+ * const selected = signalSet<string>();
+ * effect(() => console.log(selected.has("admin")));  // tracks "admin" only
+ * selected.add("user");   // effect does NOT re-run
+ * selected.add("admin");  // effect re-runs
+ * ```
+ */
+export function signalSet<T>(initial?: Iterable<T>): SignalSet<T> {
+  const data = new Set<T>(initial);
+  const memberSignals = new Map<T, Signal<boolean>>();
+  const structure = signal(0);
+
+  function memberSig(value: T): Signal<boolean> {
+    let s = memberSignals.get(value);
+    if (!s) {
+      s = signal<boolean>(data.has(value));
+      memberSignals.set(value, s);
+    }
+    return s;
+  }
+
+  function bumpStructure(): void {
+    structure.value = structure.value + 1;
+  }
+
+  const set: SignalSet<T> = {
+    has(value: T): boolean {
+      return memberSig(value).value;
+    },
+
+    add(value: T): SignalSet<T> {
+      if (data.has(value)) return set;
+      data.add(value);
+      memberSig(value).value = true;
+      bumpStructure();
+      return set;
+    },
+
+    delete(value: T): boolean {
+      if (!data.has(value)) return false;
+      data.delete(value);
+      const sig = memberSignals.get(value);
+      if (sig) sig.value = false;
+      bumpStructure();
+      return true;
+    },
+
+    clear(): void {
+      if (data.size === 0) return;
+      for (const v of [...data]) {
+        data.delete(v);
+        const sig = memberSignals.get(v);
+        if (sig) sig.value = false;
+      }
+      bumpStructure();
+    },
+
+    get size(): number {
+      structure.value;
+      return data.size;
+    },
+
+    keys(): IterableIterator<T> {
+      structure.value;
+      return data.values();
+    },
+
+    values(): IterableIterator<T> {
+      structure.value;
+      return data.values();
+    },
+
+    entries(): IterableIterator<[T, T]> {
+      structure.value;
+      return data.entries();
+    },
+
+    [Symbol.iterator](): IterableIterator<T> {
+      structure.value;
+      return data.values();
+    },
+
+    forEach(fn: (v: T, v2: T, s: SignalSet<T>) => void): void {
+      structure.value;
+      data.forEach((v) => fn(v, v, set));
+    },
+  };
+
+  return set;
+}

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -274,48 +274,131 @@ export interface Resource<T> {
   loading: () => boolean;
   error: () => Error | undefined;
   refetch: () => void;
+  /**
+   * Synchronously set the resource's data without fetching. Useful for
+   * optimistic updates — "add todo immediately, roll back on error."
+   * Accepts a value or an updater function that receives the previous value.
+   */
+  mutate: (next: T | ((prev: T | undefined) => T)) => void;
 }
 
+export interface ResourceOptions<T> {
+  /** Initial value for `data()` before the first fetch resolves. */
+  initialValue?: T;
+  /**
+   * If true (default), `data()` holds the previous value during refetches.
+   * If false, `data()` resets to `undefined` while a refetch is in flight.
+   */
+  keepPrevious?: boolean;
+}
+
+export interface ResourceSourceOptions<T, S> extends ResourceOptions<T> {
+  /** Reactive source — fetcher re-runs when this signal changes. */
+  source: () => S;
+}
+
+type Fetcher<T, S> =
+  | ((opts: { signal: AbortSignal }) => Promise<T>)
+  | ((source: S, opts: { signal: AbortSignal }) => Promise<T>);
+
 /**
- * Fetch async data with reactive loading/error states.
+ * Fetch async data with reactive loading/error states, cancellation,
+ * optimistic mutation, and optional reactive source dependencies.
  *
  * ```ts
- * const users = resource(() =>
- *   fetch("/api/users").then(r => r.json())
+ * // Simple fetch
+ * const users = resource(({ signal }) =>
+ *   fetch("/api/users", { signal }).then(r => r.json())
  * );
  *
- * // In template:
- * html`
- *   ${() => users.loading() ? "Loading..." : ""}
- *   ${() => users.error() ? users.error().message : ""}
- *   ${() => users.data()?.map(u => html`<p>${u.name}</p>`)}
- * `;
+ * // Dependent on a route param
+ * const user = resource(
+ *   (id, { signal }) => fetch(`/api/users/${id}`, { signal }).then(r => r.json()),
+ *   { source: () => route.params.value.id }
+ * );
+ *
+ * // Optimistic update
+ * users.mutate(prev => [...(prev ?? []), newUser]);
  * ```
+ *
+ * - `{ signal }` aborts on refetch and when a newer request starts.
+ * - Stale responses are dropped (a newer fetch always wins).
+ * - `data()` preserves the previous value during refetch by default;
+ *   set `keepPrevious: false` to reset to `undefined`.
  */
-export function resource<T>(fetcher: () => Promise<T>): Resource<T> {
-  const data = signal<T | undefined>(undefined);
+export function resource<T>(
+  fetcher: (opts: { signal: AbortSignal }) => Promise<T>,
+  options?: ResourceOptions<T>,
+): Resource<T>;
+export function resource<T, S>(
+  fetcher: (source: S, opts: { signal: AbortSignal }) => Promise<T>,
+  options: ResourceSourceOptions<T, S>,
+): Resource<T>;
+export function resource<T, S = undefined>(
+  fetcher: Fetcher<T, S>,
+  options?: ResourceOptions<T> | ResourceSourceOptions<T, S>,
+): Resource<T> {
+  const data = signal<T | undefined>(options?.initialValue);
   const loading = signal(true);
   const error = signal<Error | undefined>(undefined);
+  const keepPrevious = options?.keepPrevious !== false;
+  const sourceFn = options && "source" in options ? options.source : undefined;
+
+  let currentController: AbortController | null = null;
+  let requestId = 0;
 
   const execute = async () => {
+    currentController?.abort();
+    const controller = new AbortController();
+    currentController = controller;
+    const myId = ++requestId;
+
     loading.value = true;
     error.value = undefined;
+    if (!keepPrevious) data.value = undefined;
+
     try {
-      data.value = await fetcher();
+      const opts = { signal: controller.signal };
+      const result = sourceFn
+        ? await (fetcher as (s: S, o: typeof opts) => Promise<T>)(
+            sourceFn(),
+            opts,
+          )
+        : await (fetcher as (o: typeof opts) => Promise<T>)(opts);
+
+      if (myId === requestId) {
+        data.value = result;
+      }
     } catch (e) {
+      if (myId !== requestId || controller.signal.aborted) return;
       error.value = e instanceof Error ? e : new Error(String(e));
     } finally {
-      loading.value = false;
+      if (myId === requestId) {
+        loading.value = false;
+      }
     }
   };
 
-  execute();
+  if (sourceFn) {
+    effect(() => {
+      sourceFn();
+      execute();
+    });
+  } else {
+    execute();
+  }
 
   return {
     data: () => data.value,
     loading: () => loading.value,
     error: () => error.value,
     refetch: execute,
+    mutate: (next) => {
+      data.value =
+        typeof next === "function"
+          ? (next as (prev: T | undefined) => T)(data.value)
+          : next;
+    },
   };
 }
 

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -11,19 +11,11 @@
 // AI generates this correctly because it's just function calls.
 // ============================================================================
 
-import {
-  effect,
-  isSignal,
-  setEffectErrorHandler,
-  type Signal,
-} from "./reactive.js";
+import { effect, isSignal, setEffectErrorHandler } from "./reactive.js";
 import { reconcileKeyed, type KeyedEntry } from "./reconcile.js";
+import type { Ref } from "./ref.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
-
-type Ref<T extends HTMLElement = HTMLElement> =
-  | Signal<T | null>
-  | ((el: T | null) => void);
 
 type Child =
   | string

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -28,7 +28,14 @@ type Child =
   | (() => Child | Child[])
   | Child[];
 
-type EventHandler<E extends Event = Event> = (event: E) => void;
+/**
+ * An event handler generic over the event type and the element the handler
+ * is attached to. The second parameter narrows `event.currentTarget` so
+ * `e.currentTarget.value` on an input handler typechecks without casts.
+ */
+type EventHandler<E extends Event = Event, T extends Element = Element> = (
+  event: E & { currentTarget: T },
+) => void;
 
 type ReactiveProp<T> = T | (() => T);
 
@@ -45,7 +52,18 @@ interface BaseProps {
   [key: `data-${string}`]: ReactiveProp<string | undefined>;
 }
 
-interface InputProps extends BaseProps {
+// Shared form-control event bundle, generic over the control's element type
+// so input/textarea/select each narrow `e.currentTarget` correctly.
+interface FormControlEvents<T extends Element> {
+  oninput?: EventHandler<InputEvent, T>;
+  onchange?: EventHandler<Event, T>;
+  onfocus?: EventHandler<FocusEvent, T>;
+  onblur?: EventHandler<FocusEvent, T>;
+  onkeydown?: EventHandler<KeyboardEvent, T>;
+  onkeyup?: EventHandler<KeyboardEvent, T>;
+}
+
+interface InputProps extends BaseProps, FormControlEvents<HTMLInputElement> {
   type?: string;
   value?: ReactiveProp<string | number>;
   checked?: ReactiveProp<boolean>;
@@ -58,54 +76,64 @@ interface InputProps extends BaseProps {
   step?: string | number;
   required?: boolean;
   autofocus?: boolean;
-  oninput?: EventHandler<InputEvent>;
-  onchange?: EventHandler;
-  onfocus?: EventHandler<FocusEvent>;
-  onblur?: EventHandler<FocusEvent>;
-  onkeydown?: EventHandler<KeyboardEvent>;
-  onkeyup?: EventHandler<KeyboardEvent>;
+}
+
+interface TextareaProps
+  extends BaseProps, FormControlEvents<HTMLTextAreaElement> {
+  value?: ReactiveProp<string>;
+  placeholder?: string;
+  disabled?: ReactiveProp<boolean>;
+  readonly?: ReactiveProp<boolean>;
+  name?: string;
+  rows?: number;
+  cols?: number;
+  required?: boolean;
 }
 
 interface SelectProps extends BaseProps {
   value?: ReactiveProp<string>;
   disabled?: ReactiveProp<boolean>;
   name?: string;
-  onchange?: EventHandler;
+  onchange?: EventHandler<Event, HTMLSelectElement>;
+  oninput?: EventHandler<InputEvent, HTMLSelectElement>;
 }
 
 interface CommonProps extends BaseProps {
-  onclick?: EventHandler<MouseEvent>;
-  ondblclick?: EventHandler<MouseEvent>;
-  onmouseenter?: EventHandler<MouseEvent>;
-  onmouseleave?: EventHandler<MouseEvent>;
-  onkeydown?: EventHandler<KeyboardEvent>;
-  onsubmit?: EventHandler<SubmitEvent>;
-  onfocus?: EventHandler<FocusEvent>;
-  onblur?: EventHandler<FocusEvent>;
+  onclick?: EventHandler<MouseEvent, HTMLElement>;
+  ondblclick?: EventHandler<MouseEvent, HTMLElement>;
+  onmouseenter?: EventHandler<MouseEvent, HTMLElement>;
+  onmouseleave?: EventHandler<MouseEvent, HTMLElement>;
+  onkeydown?: EventHandler<KeyboardEvent, HTMLElement>;
+  onsubmit?: EventHandler<SubmitEvent, HTMLElement>;
+  onfocus?: EventHandler<FocusEvent, HTMLElement>;
+  onblur?: EventHandler<FocusEvent, HTMLElement>;
   role?: string;
   tabindex?: number;
   draggable?: boolean;
 }
 
-interface FormProps extends CommonProps {
+interface FormProps extends Omit<CommonProps, "onsubmit"> {
   action?: string;
   method?: string;
   enctype?: string;
   novalidate?: boolean;
+  onsubmit?: EventHandler<SubmitEvent, HTMLFormElement>;
 }
 
-interface AnchorProps extends CommonProps {
+interface AnchorProps extends Omit<CommonProps, "onclick"> {
   href?: ReactiveProp<string>;
   target?: string;
   rel?: string;
+  onclick?: EventHandler<MouseEvent, HTMLAnchorElement>;
 }
 
-interface ImgProps extends CommonProps {
+interface ImgProps extends Omit<CommonProps, "onclick"> {
   src?: ReactiveProp<string>;
   alt?: string;
   width?: number | string;
   height?: number | string;
   loading?: "lazy" | "eager";
+  onclick?: EventHandler<MouseEvent, HTMLImageElement>;
 }
 
 interface OptionProps extends BaseProps {
@@ -344,7 +372,7 @@ export const input = createElement("input") as (
   props?: InputProps,
 ) => WhisqNode;
 export const textarea = createElement("textarea") as (
-  props?: InputProps | Child,
+  props?: TextareaProps | Child,
   ...children: Child[]
 ) => WhisqNode;
 export const select = createElement("select") as (

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -490,6 +490,46 @@ export function when(
   return () => (condition() ? then() : otherwise ? otherwise() : null);
 }
 
+// ── match() — Multi-branch conditional rendering ───────────────────────────
+
+type MatchRender = () => WhisqNode | string | null;
+type MatchBranch = readonly [() => boolean, MatchRender];
+
+/**
+ * Multi-branch conditional renderer. Evaluates branches in order and renders
+ * the first whose predicate returns truthy. An optional trailing fallback
+ * (a bare render function, not wrapped in a tuple) renders when no branch
+ * matches. Re-evaluates reactively like other children.
+ *
+ * ```ts
+ * div(
+ *   match(
+ *     [() => users.loading(),    () => p("Loading...")],
+ *     [() => !!users.error(),    () => p({ class: "error" }, users.error()!.message)],
+ *     [() => !!users.data(),     () => List({ items: users.data()! })],
+ *     () => p("No data yet."), // fallback
+ *   ),
+ * )
+ * ```
+ *
+ * First-true-wins: if two predicates are true, only the earlier branch renders.
+ */
+export function match(...branches: MatchBranch[]): () => Child;
+export function match(...args: [...MatchBranch[], MatchRender]): () => Child;
+export function match(...args: Array<MatchBranch | MatchRender>): () => Child {
+  const last = args[args.length - 1];
+  const hasFallback = typeof last === "function";
+  const fallback = hasFallback ? (last as MatchRender) : undefined;
+  const branches = (hasFallback ? args.slice(0, -1) : args) as MatchBranch[];
+
+  return () => {
+    for (const [predicate, render] of branches) {
+      if (predicate()) return render();
+    }
+    return fallback ? fallback() : null;
+  };
+}
+
 // ── each() — List rendering ────────────────────────────────────────────────
 
 /**

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -32,11 +32,14 @@ type EventHandler<E extends Event = Event> = (event: E) => void;
 
 type ReactiveProp<T> = T | (() => T);
 
+type StyleValue = string | number | null | undefined;
+export type StyleObject = Record<string, StyleValue | (() => StyleValue)>;
+
 interface BaseProps {
   ref?: Ref;
   class?: ReactiveProp<string | undefined>;
   id?: ReactiveProp<string | undefined>;
-  style?: ReactiveProp<string | undefined>;
+  style?: ReactiveProp<string | undefined> | StyleObject;
   hidden?: ReactiveProp<boolean>;
   title?: ReactiveProp<string | undefined>;
   [key: `data-${string}`]: ReactiveProp<string | undefined>;
@@ -156,6 +159,11 @@ export function h(
             (value as (el: HTMLElement | null) => void)(null);
           });
         }
+        continue;
+      }
+      if (key === "style" && isPlainStyleObject(value)) {
+        // Style object — per-property reactive subscriptions
+        applyStyleObject(el as HTMLElement, value, disposers);
         continue;
       }
       if (key.startsWith("on") && typeof value === "function") {
@@ -818,6 +826,42 @@ export function mount(node: WhisqNode, container: Element): () => void {
 }
 
 // ── Internal ────────────────────────────────────────────────────────────────
+
+function isPlainStyleObject(value: unknown): value is StyleObject {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function camelToKebab(str: string): string {
+  return str.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+}
+
+function applyStyleObject(
+  el: HTMLElement,
+  style: StyleObject,
+  disposers: (() => void)[],
+): void {
+  for (const [prop, raw] of Object.entries(style)) {
+    const cssProp = prop.startsWith("--") ? prop : camelToKebab(prop);
+    if (typeof raw === "function") {
+      const getter = raw as () => StyleValue;
+      const dispose = effect(() => {
+        const v = getter();
+        if (v == null || v === "") {
+          el.style.removeProperty(cssProp);
+        } else {
+          el.style.setProperty(cssProp, String(v));
+        }
+      });
+      disposers.push(dispose);
+    } else if (raw != null && raw !== "") {
+      el.style.setProperty(cssProp, String(raw));
+    }
+  }
+}
 
 function applyProp(el: Element, key: string, value: unknown): void {
   if (key === "class") {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,10 @@
 export { signal, computed, effect, batch } from "./reactive.js";
 export type { Signal, ReadonlySignal } from "./reactive.js";
 
+// Reactive collections (signalMap, signalSet) live in a sub-path import
+// to keep the top-level bundle under 5 KB:
+//   import { signalMap, signalSet } from "@whisq/core/collections";
+
 // Element functions (primary API)
 export {
   // Core

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,7 +91,13 @@ export {
   inject,
   useHead,
 } from "./component.js";
-export type { ComponentDef, Resource, InjectionKey } from "./component.js";
+export type {
+  ComponentDef,
+  Resource,
+  ResourceOptions,
+  ResourceSourceOptions,
+  InjectionKey,
+} from "./component.js";
 
 // Refs
 export { ref } from "./ref.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,3 +95,13 @@ export type { ComponentDef, Resource, InjectionKey } from "./component.js";
 
 // Styling
 export { sheet, styles, cx, rcx, theme } from "./styling.js";
+
+// Forms
+export { bind } from "./bind.js";
+export type {
+  TextBind,
+  NumberBind,
+  CheckboxBind,
+  RadioBind,
+  BindOptions,
+} from "./bind.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,7 +105,8 @@ export { ref } from "./ref.js";
 export type { Ref } from "./ref.js";
 
 // Styling
-export { sheet, styles, cx, rcx, theme } from "./styling.js";
+export { sheet, styles, cx, rcx, sx, theme } from "./styling.js";
+export type { StyleObject } from "./elements.js";
 
 // Forms
 export { bind } from "./bind.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,6 +93,10 @@ export {
 } from "./component.js";
 export type { ComponentDef, Resource, InjectionKey } from "./component.js";
 
+// Refs
+export { ref } from "./ref.js";
+export type { Ref } from "./ref.js";
+
 // Styling
 export { sheet, styles, cx, rcx, theme } from "./styling.js";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export {
   h,
   raw,
   when,
+  match,
   each,
   errorBoundary,
   portal,

--- a/packages/core/src/ref.ts
+++ b/packages/core/src/ref.ts
@@ -1,0 +1,30 @@
+// ============================================================================
+// Whisq Core — DOM element ref
+// Signal-based and callback-based refs for imperative DOM access.
+// ============================================================================
+
+import { signal, type Signal } from "./reactive.js";
+
+/**
+ * A ref accepts either a Signal that will be populated with the element,
+ * or a callback invoked with the element (and later with null on unmount).
+ */
+export type Ref<T extends HTMLElement = HTMLElement> =
+  | Signal<T | null>
+  | ((el: T | null) => void);
+
+/**
+ * Create a typed signal ref for a DOM element.
+ *
+ * The signal starts at `null` and is populated with the element after mount;
+ * it is reset to `null` on unmount.
+ *
+ * ```ts
+ * const inputEl = ref<HTMLInputElement>();
+ * input({ ref: inputEl });
+ * onMount(() => inputEl.value?.focus());
+ * ```
+ */
+export function ref<T extends HTMLElement = HTMLElement>(): Signal<T | null> {
+  return signal<T | null>(null);
+}

--- a/packages/core/src/styling.ts
+++ b/packages/core/src/styling.ts
@@ -245,6 +245,46 @@ export function rcx(
   };
 }
 
+// ── sx() — Style object composition ────────────────────────────────────────
+
+type SxStyleValue = string | number | null | undefined;
+type SxStyleSource =
+  | Record<string, SxStyleValue | (() => SxStyleValue)>
+  | false
+  | null
+  | undefined;
+
+/**
+ * Merge style objects into a single object suitable for the element `style`
+ * prop. Later sources override earlier ones. Falsy sources (false / null /
+ * undefined) are skipped — useful for conditionals.
+ *
+ * ```ts
+ * div({
+ *   style: sx(
+ *     { color: "red", padding: "1rem" },           // base
+ *     active.value && { borderColor: "blue" },     // conditional
+ *     { transform: () => `translateX(${x.value}px)` }, // reactive
+ *   ),
+ * })
+ * ```
+ *
+ * Function values are preserved (not eagerly invoked), so the reactive
+ * per-property subscription in the `style` prop still sees them.
+ */
+export function sx(
+  ...sources: SxStyleSource[]
+): Record<string, SxStyleValue | (() => SxStyleValue)> {
+  const merged: Record<string, SxStyleValue | (() => SxStyleValue)> = {};
+  for (const source of sources) {
+    if (!source) continue;
+    for (const [key, value] of Object.entries(source)) {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
 // ── theme() — Design Tokens ────────────────────────────────────────────────
 
 type ThemeTokens = Record<

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test-d.ts",
+    "**/__tests__/**"
+  ]
+}

--- a/packages/create-whisq/CHANGELOG.md
+++ b/packages/create-whisq/CHANGELOG.md
@@ -1,5 +1,28 @@
 # create-whisq
 
+## 0.1.0-alpha.5
+
+### Minor Changes
+
+- 0191d7e: **Retrospective changeset for the batch of work merged since `v0.1.0-alpha.4`.** In pre mode this bumps every package to `0.1.0-alpha.5`.
+
+  ### New `@whisq/core` API
+  - **`ref<T>()`** primitive + exported `Ref<T>` type — typed signal refs for DOM elements (#18 · #26)
+  - **`bind(signal, options?)`** two-way form-binding helper for `input`/`textarea`/`select` — collapses 3-line controlled-input boilerplate to one spread (#19 · #25)
+  - **`resource()` extensions** — `mutate(value | updater)` for optimistic updates, `source` option for reactive refetches, `initialValue`, `keepPrevious`, and an `AbortSignal` passed to the fetcher so requests cancel on refetch/source-change. Stale responses are dropped; AbortErrors don't leak into `.error()` (#20 · #28)
+  - **`match(...branches, fallback?)`** multi-branch conditional — first-true-wins renderer in the `when`/`each` family (#21 · #30)
+  - **Style prop object form** with per-property reactive subscriptions + new **`sx()`** compositional helper (#22 · #31)
+  - **`signalMap<K, V>` / `signalSet<T>`** reactive collections with per-key/per-value tracking, at sub-path `@whisq/core/collections` to keep the top-level bundle under 5 KB (#23 · #32)
+  - **Event handler type narrowing** — `e.currentTarget` is now correctly typed per element (`HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, `HTMLFormElement`, `HTMLAnchorElement`, `HTMLImageElement`). New dedicated `TextareaProps` interface (textarea was incorrectly reusing `InputProps`) (#24 · #34)
+
+  ### Tooling
+  - **`dist/public-api.json`** manifest shipped inside `@whisq/core` on every build, fetchable via `unpkg.com/@whisq/core@<version>/dist/public-api.json`. Powers the docs-repo drift-check for the AI reference card (#27 · #29)
+
+  ### Notes
+  - Backward compatible with `0.1.0-alpha.4`. No breaking changes.
+  - Bundle size: `@whisq/core` is **4.75 KB gzipped** (under the 5 KB marketing gate).
+  - Test count: 284 in `@whisq/core` (up from ~194 at alpha.4).
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.4",
-    "@whisq/router": "^0.1.0-alpha.4"
+    "@whisq/core": "^0.1.0-alpha.5",
+    "@whisq/router": "^0.1.0-alpha.5"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1",
-    "@whisq/router": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4",
+    "@whisq/router": "^0.1.0-alpha.4"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.4"
+    "@whisq/core": "^0.1.0-alpha.5"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1",
-    "@whisq/ssr": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4",
+    "@whisq/ssr": "^0.1.0-alpha.4"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.4",
-    "@whisq/ssr": "^0.1.0-alpha.4"
+    "@whisq/core": "^0.1.0-alpha.5",
+    "@whisq/ssr": "^0.1.0-alpha.5"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.4",
-    "@whisq/router": "^0.1.0-alpha.4"
+    "@whisq/core": "^0.1.0-alpha.5",
+    "@whisq/router": "^0.1.0-alpha.5"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.4",
+    "@whisq/vite-plugin": "^0.1.0-alpha.5",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.1",
-    "@whisq/router": "^0.1.0-alpha.1"
+    "@whisq/core": "^0.1.0-alpha.4",
+    "@whisq/router": "^0.1.0-alpha.4"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.1",
+    "@whisq/vite-plugin": "^0.1.0-alpha.4",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,33 @@
 # @whisq/devtools
 
+## 0.1.0-alpha.5
+
+### Minor Changes
+
+- 0191d7e: **Retrospective changeset for the batch of work merged since `v0.1.0-alpha.4`.** In pre mode this bumps every package to `0.1.0-alpha.5`.
+
+  ### New `@whisq/core` API
+  - **`ref<T>()`** primitive + exported `Ref<T>` type — typed signal refs for DOM elements (#18 · #26)
+  - **`bind(signal, options?)`** two-way form-binding helper for `input`/`textarea`/`select` — collapses 3-line controlled-input boilerplate to one spread (#19 · #25)
+  - **`resource()` extensions** — `mutate(value | updater)` for optimistic updates, `source` option for reactive refetches, `initialValue`, `keepPrevious`, and an `AbortSignal` passed to the fetcher so requests cancel on refetch/source-change. Stale responses are dropped; AbortErrors don't leak into `.error()` (#20 · #28)
+  - **`match(...branches, fallback?)`** multi-branch conditional — first-true-wins renderer in the `when`/`each` family (#21 · #30)
+  - **Style prop object form** with per-property reactive subscriptions + new **`sx()`** compositional helper (#22 · #31)
+  - **`signalMap<K, V>` / `signalSet<T>`** reactive collections with per-key/per-value tracking, at sub-path `@whisq/core/collections` to keep the top-level bundle under 5 KB (#23 · #32)
+  - **Event handler type narrowing** — `e.currentTarget` is now correctly typed per element (`HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, `HTMLFormElement`, `HTMLAnchorElement`, `HTMLImageElement`). New dedicated `TextareaProps` interface (textarea was incorrectly reusing `InputProps`) (#24 · #34)
+
+  ### Tooling
+  - **`dist/public-api.json`** manifest shipped inside `@whisq/core` on every build, fetchable via `unpkg.com/@whisq/core@<version>/dist/public-api.json`. Powers the docs-repo drift-check for the AI reference card (#27 · #29)
+
+  ### Notes
+  - Backward compatible with `0.1.0-alpha.4`. No breaking changes.
+  - Bundle size: `@whisq/core` is **4.75 KB gzipped** (under the 5 KB marketing gate).
+  - Test count: 284 in `@whisq/core` (up from ~194 at alpha.4).
+
+### Patch Changes
+
+- Updated dependencies [0191d7e]
+  - @whisq/core@0.1.0-alpha.5
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @whisq/mcp-server
 
+## 0.1.0-alpha.5
+
+### Minor Changes
+
+- 0191d7e: **Retrospective changeset for the batch of work merged since `v0.1.0-alpha.4`.** In pre mode this bumps every package to `0.1.0-alpha.5`.
+
+  ### New `@whisq/core` API
+  - **`ref<T>()`** primitive + exported `Ref<T>` type — typed signal refs for DOM elements (#18 · #26)
+  - **`bind(signal, options?)`** two-way form-binding helper for `input`/`textarea`/`select` — collapses 3-line controlled-input boilerplate to one spread (#19 · #25)
+  - **`resource()` extensions** — `mutate(value | updater)` for optimistic updates, `source` option for reactive refetches, `initialValue`, `keepPrevious`, and an `AbortSignal` passed to the fetcher so requests cancel on refetch/source-change. Stale responses are dropped; AbortErrors don't leak into `.error()` (#20 · #28)
+  - **`match(...branches, fallback?)`** multi-branch conditional — first-true-wins renderer in the `when`/`each` family (#21 · #30)
+  - **Style prop object form** with per-property reactive subscriptions + new **`sx()`** compositional helper (#22 · #31)
+  - **`signalMap<K, V>` / `signalSet<T>`** reactive collections with per-key/per-value tracking, at sub-path `@whisq/core/collections` to keep the top-level bundle under 5 KB (#23 · #32)
+  - **Event handler type narrowing** — `e.currentTarget` is now correctly typed per element (`HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, `HTMLFormElement`, `HTMLAnchorElement`, `HTMLImageElement`). New dedicated `TextareaProps` interface (textarea was incorrectly reusing `InputProps`) (#24 · #34)
+
+  ### Tooling
+  - **`dist/public-api.json`** manifest shipped inside `@whisq/core` on every build, fetchable via `unpkg.com/@whisq/core@<version>/dist/public-api.json`. Powers the docs-repo drift-check for the AI reference card (#27 · #29)
+
+  ### Notes
+  - Backward compatible with `0.1.0-alpha.4`. No breaking changes.
+  - Bundle size: `@whisq/core` is **4.75 KB gzipped** (under the 5 KB marketing gate).
+  - Test count: 284 in `@whisq/core` (up from ~194 at alpha.4).
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,33 @@
 # @whisq/router
 
+## 0.1.0-alpha.5
+
+### Minor Changes
+
+- 0191d7e: **Retrospective changeset for the batch of work merged since `v0.1.0-alpha.4`.** In pre mode this bumps every package to `0.1.0-alpha.5`.
+
+  ### New `@whisq/core` API
+  - **`ref<T>()`** primitive + exported `Ref<T>` type — typed signal refs for DOM elements (#18 · #26)
+  - **`bind(signal, options?)`** two-way form-binding helper for `input`/`textarea`/`select` — collapses 3-line controlled-input boilerplate to one spread (#19 · #25)
+  - **`resource()` extensions** — `mutate(value | updater)` for optimistic updates, `source` option for reactive refetches, `initialValue`, `keepPrevious`, and an `AbortSignal` passed to the fetcher so requests cancel on refetch/source-change. Stale responses are dropped; AbortErrors don't leak into `.error()` (#20 · #28)
+  - **`match(...branches, fallback?)`** multi-branch conditional — first-true-wins renderer in the `when`/`each` family (#21 · #30)
+  - **Style prop object form** with per-property reactive subscriptions + new **`sx()`** compositional helper (#22 · #31)
+  - **`signalMap<K, V>` / `signalSet<T>`** reactive collections with per-key/per-value tracking, at sub-path `@whisq/core/collections` to keep the top-level bundle under 5 KB (#23 · #32)
+  - **Event handler type narrowing** — `e.currentTarget` is now correctly typed per element (`HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, `HTMLFormElement`, `HTMLAnchorElement`, `HTMLImageElement`). New dedicated `TextareaProps` interface (textarea was incorrectly reusing `InputProps`) (#24 · #34)
+
+  ### Tooling
+  - **`dist/public-api.json`** manifest shipped inside `@whisq/core` on every build, fetchable via `unpkg.com/@whisq/core@<version>/dist/public-api.json`. Powers the docs-repo drift-check for the AI reference card (#27 · #29)
+
+  ### Notes
+  - Backward compatible with `0.1.0-alpha.4`. No breaking changes.
+  - Bundle size: `@whisq/core` is **4.75 KB gzipped** (under the 5 KB marketing gate).
+  - Test count: 284 in `@whisq/core` (up from ~194 at alpha.4).
+
+### Patch Changes
+
+- Updated dependencies [0191d7e]
+  - @whisq/core@0.1.0-alpha.5
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @whisq/sandbox
 
+## 0.1.0-alpha.5
+
+### Minor Changes
+
+- 0191d7e: **Retrospective changeset for the batch of work merged since `v0.1.0-alpha.4`.** In pre mode this bumps every package to `0.1.0-alpha.5`.
+
+  ### New `@whisq/core` API
+  - **`ref<T>()`** primitive + exported `Ref<T>` type — typed signal refs for DOM elements (#18 · #26)
+  - **`bind(signal, options?)`** two-way form-binding helper for `input`/`textarea`/`select` — collapses 3-line controlled-input boilerplate to one spread (#19 · #25)
+  - **`resource()` extensions** — `mutate(value | updater)` for optimistic updates, `source` option for reactive refetches, `initialValue`, `keepPrevious`, and an `AbortSignal` passed to the fetcher so requests cancel on refetch/source-change. Stale responses are dropped; AbortErrors don't leak into `.error()` (#20 · #28)
+  - **`match(...branches, fallback?)`** multi-branch conditional — first-true-wins renderer in the `when`/`each` family (#21 · #30)
+  - **Style prop object form** with per-property reactive subscriptions + new **`sx()`** compositional helper (#22 · #31)
+  - **`signalMap<K, V>` / `signalSet<T>`** reactive collections with per-key/per-value tracking, at sub-path `@whisq/core/collections` to keep the top-level bundle under 5 KB (#23 · #32)
+  - **Event handler type narrowing** — `e.currentTarget` is now correctly typed per element (`HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, `HTMLFormElement`, `HTMLAnchorElement`, `HTMLImageElement`). New dedicated `TextareaProps` interface (textarea was incorrectly reusing `InputProps`) (#24 · #34)
+
+  ### Tooling
+  - **`dist/public-api.json`** manifest shipped inside `@whisq/core` on every build, fetchable via `unpkg.com/@whisq/core@<version>/dist/public-api.json`. Powers the docs-repo drift-check for the AI reference card (#27 · #29)
+
+  ### Notes
+  - Backward compatible with `0.1.0-alpha.4`. No breaking changes.
+  - Bundle size: `@whisq/core` is **4.75 KB gzipped** (under the 5 KB marketing gate).
+  - Test count: 284 in `@whisq/core` (up from ~194 at alpha.4).
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -1,5 +1,33 @@
 # @whisq/ssr
 
+## 0.1.0-alpha.5
+
+### Minor Changes
+
+- 0191d7e: **Retrospective changeset for the batch of work merged since `v0.1.0-alpha.4`.** In pre mode this bumps every package to `0.1.0-alpha.5`.
+
+  ### New `@whisq/core` API
+  - **`ref<T>()`** primitive + exported `Ref<T>` type — typed signal refs for DOM elements (#18 · #26)
+  - **`bind(signal, options?)`** two-way form-binding helper for `input`/`textarea`/`select` — collapses 3-line controlled-input boilerplate to one spread (#19 · #25)
+  - **`resource()` extensions** — `mutate(value | updater)` for optimistic updates, `source` option for reactive refetches, `initialValue`, `keepPrevious`, and an `AbortSignal` passed to the fetcher so requests cancel on refetch/source-change. Stale responses are dropped; AbortErrors don't leak into `.error()` (#20 · #28)
+  - **`match(...branches, fallback?)`** multi-branch conditional — first-true-wins renderer in the `when`/`each` family (#21 · #30)
+  - **Style prop object form** with per-property reactive subscriptions + new **`sx()`** compositional helper (#22 · #31)
+  - **`signalMap<K, V>` / `signalSet<T>`** reactive collections with per-key/per-value tracking, at sub-path `@whisq/core/collections` to keep the top-level bundle under 5 KB (#23 · #32)
+  - **Event handler type narrowing** — `e.currentTarget` is now correctly typed per element (`HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, `HTMLFormElement`, `HTMLAnchorElement`, `HTMLImageElement`). New dedicated `TextareaProps` interface (textarea was incorrectly reusing `InputProps`) (#24 · #34)
+
+  ### Tooling
+  - **`dist/public-api.json`** manifest shipped inside `@whisq/core` on every build, fetchable via `unpkg.com/@whisq/core@<version>/dist/public-api.json`. Powers the docs-repo drift-check for the AI reference card (#27 · #29)
+
+  ### Notes
+  - Backward compatible with `0.1.0-alpha.4`. No breaking changes.
+  - Bundle size: `@whisq/core` is **4.75 KB gzipped** (under the 5 KB marketing gate).
+  - Test count: 284 in `@whisq/core` (up from ~194 at alpha.4).
+
+### Patch Changes
+
+- Updated dependencies [0191d7e]
+  - @whisq/core@0.1.0-alpha.5
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,33 @@
 # @whisq/testing
 
+## 0.1.0-alpha.5
+
+### Minor Changes
+
+- 0191d7e: **Retrospective changeset for the batch of work merged since `v0.1.0-alpha.4`.** In pre mode this bumps every package to `0.1.0-alpha.5`.
+
+  ### New `@whisq/core` API
+  - **`ref<T>()`** primitive + exported `Ref<T>` type — typed signal refs for DOM elements (#18 · #26)
+  - **`bind(signal, options?)`** two-way form-binding helper for `input`/`textarea`/`select` — collapses 3-line controlled-input boilerplate to one spread (#19 · #25)
+  - **`resource()` extensions** — `mutate(value | updater)` for optimistic updates, `source` option for reactive refetches, `initialValue`, `keepPrevious`, and an `AbortSignal` passed to the fetcher so requests cancel on refetch/source-change. Stale responses are dropped; AbortErrors don't leak into `.error()` (#20 · #28)
+  - **`match(...branches, fallback?)`** multi-branch conditional — first-true-wins renderer in the `when`/`each` family (#21 · #30)
+  - **Style prop object form** with per-property reactive subscriptions + new **`sx()`** compositional helper (#22 · #31)
+  - **`signalMap<K, V>` / `signalSet<T>`** reactive collections with per-key/per-value tracking, at sub-path `@whisq/core/collections` to keep the top-level bundle under 5 KB (#23 · #32)
+  - **Event handler type narrowing** — `e.currentTarget` is now correctly typed per element (`HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, `HTMLFormElement`, `HTMLAnchorElement`, `HTMLImageElement`). New dedicated `TextareaProps` interface (textarea was incorrectly reusing `InputProps`) (#24 · #34)
+
+  ### Tooling
+  - **`dist/public-api.json`** manifest shipped inside `@whisq/core` on every build, fetchable via `unpkg.com/@whisq/core@<version>/dist/public-api.json`. Powers the docs-repo drift-check for the AI reference card (#27 · #29)
+
+  ### Notes
+  - Backward compatible with `0.1.0-alpha.4`. No breaking changes.
+  - Bundle size: `@whisq/core` is **4.75 KB gzipped** (under the 5 KB marketing gate).
+  - Test count: 284 in `@whisq/core` (up from ~194 at alpha.4).
+
+### Patch Changes
+
+- Updated dependencies [0191d7e]
+  - @whisq/core@0.1.0-alpha.5
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @whisq/vite-plugin
 
+## 0.1.0-alpha.5
+
+### Minor Changes
+
+- 0191d7e: **Retrospective changeset for the batch of work merged since `v0.1.0-alpha.4`.** In pre mode this bumps every package to `0.1.0-alpha.5`.
+
+  ### New `@whisq/core` API
+  - **`ref<T>()`** primitive + exported `Ref<T>` type — typed signal refs for DOM elements (#18 · #26)
+  - **`bind(signal, options?)`** two-way form-binding helper for `input`/`textarea`/`select` — collapses 3-line controlled-input boilerplate to one spread (#19 · #25)
+  - **`resource()` extensions** — `mutate(value | updater)` for optimistic updates, `source` option for reactive refetches, `initialValue`, `keepPrevious`, and an `AbortSignal` passed to the fetcher so requests cancel on refetch/source-change. Stale responses are dropped; AbortErrors don't leak into `.error()` (#20 · #28)
+  - **`match(...branches, fallback?)`** multi-branch conditional — first-true-wins renderer in the `when`/`each` family (#21 · #30)
+  - **Style prop object form** with per-property reactive subscriptions + new **`sx()`** compositional helper (#22 · #31)
+  - **`signalMap<K, V>` / `signalSet<T>`** reactive collections with per-key/per-value tracking, at sub-path `@whisq/core/collections` to keep the top-level bundle under 5 KB (#23 · #32)
+  - **Event handler type narrowing** — `e.currentTarget` is now correctly typed per element (`HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, `HTMLFormElement`, `HTMLAnchorElement`, `HTMLImageElement`). New dedicated `TextareaProps` interface (textarea was incorrectly reusing `InputProps`) (#24 · #34)
+
+  ### Tooling
+  - **`dist/public-api.json`** manifest shipped inside `@whisq/core` on every build, fetchable via `unpkg.com/@whisq/core@<version>/dist/public-api.json`. Powers the docs-repo drift-check for the AI reference card (#27 · #29)
+
+  ### Notes
+  - Backward compatible with `0.1.0-alpha.4`. No breaking changes.
+  - Bundle size: `@whisq/core` is **4.75 KB gzipped** (under the 5 KB marketing gate).
+  - Test count: 284 in `@whisq/core` (up from ~194 at alpha.4).
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.4",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 // Verifies version consistency across the monorepo:
-//   1. Every `@whisq/*` package in `packages/*` shares the same version.
+//   1. Every `@whisq/*` package AND `create-whisq` in `packages/*` share the same version.
 //   2. Every `@whisq/*` reference inside `packages/create-whisq/src/templates/**/package.json.tmpl`
 //      resolves to that same version. Allowed forms: "X.Y.Z", "^X.Y.Z", "~X.Y.Z", "workspace:*".
+//
+// `create-whisq` is included so the scaffolder and the runtime packages
+// always release together. Enforced by the `fixed` group in
+// `.changeset/config.json` and by this check in CI + /release.
 //
 // Exits non-zero on any drift. Run in CI and as a gate inside /release.
 
@@ -13,7 +17,11 @@ import { fileURLToPath } from "node:url";
 const root = fileURLToPath(new URL("..", import.meta.url));
 const errors = [];
 
-const whisqPackages = readdirSync(join(root, "packages"))
+const RELEASED_PACKAGE_NAMES = new Set(["create-whisq"]);
+const isReleasedPackage = (name) =>
+  Boolean(name) && (name.startsWith("@whisq/") || RELEASED_PACKAGE_NAMES.has(name));
+
+const releasedPackages = readdirSync(join(root, "packages"))
   .map((dir) => {
     const pkgPath = join(root, "packages", dir, "package.json");
     try {
@@ -23,17 +31,17 @@ const whisqPackages = readdirSync(join(root, "packages"))
       return null;
     }
   })
-  .filter((p) => p && p.name?.startsWith("@whisq/"));
+  .filter((p) => p && isReleasedPackage(p.name));
 
-if (whisqPackages.length === 0) {
-  errors.push("No @whisq/* packages found in packages/*");
+if (releasedPackages.length === 0) {
+  errors.push("No released packages found in packages/*");
 }
 
-const referenceVersion = whisqPackages[0]?.version;
-for (const pkg of whisqPackages) {
+const referenceVersion = releasedPackages[0]?.version;
+for (const pkg of releasedPackages) {
   if (pkg.version !== referenceVersion) {
     errors.push(
-      `${pkg.name} is ${pkg.version}, expected ${referenceVersion} (matching ${whisqPackages[0].name})`,
+      `${pkg.name} is ${pkg.version}, expected ${referenceVersion} (matching ${releasedPackages[0].name})`,
     );
   }
 }
@@ -90,5 +98,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `Version consistency OK — ${whisqPackages.length} @whisq/* packages at ${referenceVersion}, ${templateFiles.length} template(s) aligned.`,
+  `Version consistency OK — ${releasedPackages.length} released packages at ${referenceVersion}, ${templateFiles.length} template(s) aligned.`,
 );


### PR DESCRIPTION
## Summary
One-time catch-up: main is still at the initial commit (`fafb790`). This PR brings it up to the current `develop` state which is already at `v0.1.0-alpha.5` (all 9 packages published to npm from the earlier direct-publish iteration).

## What's inside
- All 22 commits merged to `develop` since the initial release
- Version bumps to `0.1.0-alpha.5` across every package
- CHANGELOGs for the retrospective release
- Full release automation (changesets, `WHISQ_BOT` token, prepare + publish workflows, docs, changeset-check gate)

## What happens on merge
Pushing to `main` triggers `.github/workflows/release.yml`. Since `alpha.5` is already on npm, `changeset publish` will log "already published, skipping" for every package, and the back-merge job won't fire (no new publications).

## How to merge
**Use a merge commit** (the dropdown on the green merge button, not the default Squash) — per the convention established in #48, PRs into `main` keep the full feature history. After this sync, future `release/v*` branches do the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)