### PR TITLE
WHISQ-33: probe WHISQ_BOT app install on whisq.dev

### DIFF
--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -1,27 +1,27 @@
 name: Notify docs on release
 
+# TEMPORARY DIAGNOSTIC STEP — see whisqjs/whisq#33.
+#
+# Minimal version that only mints an App token scoped to whisq.dev and
+# echoes its length. This isolates whether the WHISQ_BOT App is actually
+# installed on whisqjs/whisq.dev — a successful run proves installation,
+# a startup_failure proves the App needs to be installed there before the
+# full dispatcher logic can work.
+#
+# Will be replaced with the full framework→docs repository_dispatch
+# flow once installation is confirmed.
+
 on:
-  release:
-    types: [published]
   workflow_dispatch:
-    inputs:
-      tag:
-        description: Tag
-        required: true
-        default: test-dispatch
-      body:
-        description: Body
-        required: false
-        default: ""
 
 permissions:
   contents: read
 
 jobs:
-  dispatch:
+  probe:
     runs-on: ubuntu-latest
     steps:
-      - name: Mint app token
+      - name: Mint WHISQ_BOT app token scoped to whisq.dev
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
@@ -30,37 +30,13 @@ jobs:
           owner: whisqjs
           repositories: whisq.dev
 
-      - name: Build payload
-        id: payload
+      - name: Report token presence
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_NAME: ${{ github.event.release.name }}
-          RELEASE_BODY: ${{ github.event.release.body }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
-          INPUT_TAG: ${{ inputs.tag }}
-          INPUT_BODY: ${{ inputs.body }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          set -euo pipefail
-          TAG="${RELEASE_TAG:-$INPUT_TAG}"
-          NAME="${RELEASE_NAME:-}"
-          BODY="${RELEASE_BODY:-${INPUT_BODY:-}}"
-          URL="${RELEASE_URL:-}"
-          PAYLOAD=$(jq -nc \
-            --arg tag "$TAG" \
-            --arg name "$NAME" \
-            --arg body "$BODY" \
-            --arg html_url "$URL" \
-            '{tag: $tag, name: $name, body: $body, html_url: $html_url}')
-          {
-            echo "payload<<EOF"
-            echo "$PAYLOAD"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Send repository_dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          repository: whisqjs/whisq.dev
-          event-type: framework-release
-          client-payload: ${{ steps.payload.outputs.payload }}
+          if [ -n "$TOKEN" ]; then
+            echo "OK: token minted (length=${#TOKEN})"
+          else
+            echo "::error::no token minted — App likely not installed on whisqjs/whisq.dev"
+            exit 1
+          fi


### PR DESCRIPTION
Diagnostic PR for #33. Dispatcher currently startup-fails on every real release and every manual dispatch. This minimal workflow strips everything except the App-token-mint step scoped to whisq.dev and echoes token length — a successful run proves the App is installed on whisq.dev and the earlier failures come from somewhere else in the workflow; startup_failure here proves the App needs to be installed on whisq.dev first.

Lands with `skip-changeset` since it only touches CI. Full dispatcher logic will come back in a follow-up PR once we know which failure mode we're in.