### PR TITLE
WHISQ-33: probe 3 — repository-dispatch @v4

### DIFF
--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -26,7 +26,7 @@ jobs:
           repositories: whisq.dev
 
       - name: Send hardcoded dispatch
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: whisqjs/whisq.dev


### PR DESCRIPTION
Probe 2 (#54) with `peter-evans/repository-dispatch@v3` startup_failed. That version uses the `node20` runner; `@v4` uses `node24`. Testing whether the v3 node20 runner has been deprecated on ubuntu-latest. `skip-changeset`.