### PR TITLE
WHISQ-33: dispatch docs on release via actions/github-script

### DIFF
--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -1,19 +1,46 @@
 name: Notify docs on release
 
-# TEMPORARY DIAGNOSTIC — see whisqjs/whisq#33.
+# Fires a repository_dispatch event at whisqjs/whisq.dev whenever a
+# release is published here. The receiver over there
+# (.github/workflows/on-framework-release.yml) opens a tracking issue
+# with the release notes and a docs checklist.
 #
-# Probe 2: app-token + repository-dispatch with a hardcoded payload.
-# Isolates whether peter-evans/repository-dispatch is the startup-failure
-# source vs. something in the env / jq step.
+# Design: whisqjs/whisq.dev#21 and companion #33 here.
+#
+# Implementation notes:
+#
+# - Uses actions/github-script rather than peter-evans/repository-dispatch
+#   because this repo's Actions allowlist only permits GitHub-owned,
+#   verified-publisher, pnpm/action-setup@*, and changesets/action@*. A
+#   github-script one-liner does the same job without expanding the list.
+#
+# - The App token (minted via actions/create-github-app-token) is scoped
+#   to whisq.dev via `repositories: whisq.dev`. The WHISQ_BOT App must be
+#   installed there with Contents: write permission.
 
 on:
+  release:
+    types: [published]
+  # Manual override for end-to-end testing without cutting a release.
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to simulate (e.g. v0.1.0-alpha.5)
+        required: true
+        type: string
+        default: test-dispatch
+      body:
+        description: Release notes markdown (optional)
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
 
 jobs:
-  probe:
+  dispatch:
+    name: Dispatch to docs
     runs-on: ubuntu-latest
     steps:
       - name: Mint WHISQ_BOT app token
@@ -25,10 +52,44 @@ jobs:
           owner: whisqjs
           repositories: whisq.dev
 
-      - name: Send hardcoded dispatch
-        uses: peter-evans/repository-dispatch@v4
+      - name: Send repository_dispatch
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_BODY: ${{ inputs.body }}
         with:
-          token: ${{ steps.app-token.outputs.token }}
-          repository: whisqjs/whisq.dev
-          event-type: framework-release
-          client-payload: '{"tag":"test-dispatch","name":"probe","body":"probe","html_url":""}'
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const tag = process.env.RELEASE_TAG || process.env.INPUT_TAG;
+            if (!tag) {
+              core.setFailed('No release tag and no input tag — nothing to dispatch.');
+              return;
+            }
+
+            const clientPayload = {
+              tag,
+              name: process.env.RELEASE_NAME || tag,
+              body: process.env.RELEASE_BODY || process.env.INPUT_BODY || '',
+              html_url: process.env.RELEASE_URL || '',
+            };
+
+            await github.rest.repos.createDispatchEvent({
+              owner: 'whisqjs',
+              repo: 'whisq.dev',
+              event_type: 'framework-release',
+              client_payload: clientPayload,
+            });
+
+            core.notice(`Dispatched framework-release for ${tag} to whisqjs/whisq.dev`);
+            core.summary
+              .addHeading('Dispatched to whisqjs/whisq.dev')
+              .addList([
+                `tag: \`${clientPayload.tag}\``,
+                `name: \`${clientPayload.name}\``,
+                `html_url: ${clientPayload.html_url || '(none)'}`,
+              ])
+              .write();


### PR DESCRIPTION
Root cause of every startup_failure on `notify-docs-on-release.yml` (#35, #36, #54, #55): repo Actions allowlist excludes `peter-evans/repository-dispatch`. Verified via `gh api repos/whisqjs/whisq/actions/permissions/selected-actions` — only `pnpm/action-setup@*` and `changesets/action@*` are pattern-allowed beyond GitHub-owned/verified.

Fix: call `github.rest.repos.createDispatchEvent` directly from `actions/github-script` (which IS allowed). Functionally equivalent, drops a third-party action dependency.

Restores the full dispatcher logic: dual trigger on `release:published` + `workflow_dispatch`, full payload (`tag`/`name`/`body`/`html_url`), App-token minting scoped to whisq.dev.

After merge: `gh workflow run notify-docs-on-release.yml --repo whisqjs/whisq --ref develop -f tag=test-dispatch -f body='smoke test'` should dispatch cleanly and produce a `[TEST] Document test-dispatch` issue on whisqjs/whisq.dev.

`skip-changeset`.