### PR TITLE
chore(ci): ignore semver-major bumps for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,9 +52,9 @@ updates:
       prefix: chore
       include: scope
     ignore:
-      # pnpm/action-setup@v6 installs a newer pnpm whose lockfile parser
-      # rejects lockfiles written by pnpm@9.x (ERR_PNPM_BROKEN_LOCKFILE).
-      # Revisit after we regenerate the lockfile on pnpm@10 or @11.
-      - dependency-name: "pnpm/action-setup"
+      # Don't churn on major bumps — open those manually with a migration plan.
+      # Matches the ignore in the npm section above so every ecosystem has the
+      # same rule (avoids surprises like actions/create-github-app-token@v1→v3).
+      - dependency-name: "*"
         update-types:
           - version-update:semver-major


### PR DESCRIPTION
## Summary
Small follow-up to the two Dependabot PRs merged just now (#52, #51).

The `dependabot.yml` already ignored semver-major bumps in the **npm** ecosystem, but the **github-actions** block only ignored `pnpm/action-setup` majors. That's why #51 (`actions/create-github-app-token v1→v3`) auto-opened as a PR instead of being a manual decision.

This generalises the ignore to `"*"` across github-actions, matching the npm section. Major bumps still land — just manually with a short migration check rather than being auto-proposed.

## Test plan
- [ ] CI passes (repo tooling, `skip-changeset` label)
- [ ] Next weekly Dependabot run doesn't propose github-actions majors

🤖 Generated with [Claude Code](https://claude.com/claude-code)