### PR TITLE
WHISQ-63: export ElementRef<T> alias + harden ref() accessor docs

### DIFF
--- a/.changeset/clarify-ref-accessor.md
+++ b/.changeset/clarify-ref-accessor.md
@@ -1,0 +1,34 @@
+---
+"@whisq/core": minor
+---
+
+Clarify the `ref()` accessor and export a named `ElementRef<T>` type alias (WHISQ-63).
+
+Addresses the feedback from real app-building: "which accessor on which container-shaped primitive?" The answer for refs has always been `.value` (refs are plain Whisq signals), but the type `Signal<T | null>` surfaced in editor tooltips didn't name the concept, and React's `.current` priors caused a guessing step.
+
+**Changes:**
+
+- **New** `ElementRef<T>` type alias exported from `@whisq/core`. Structurally identical to `Signal<T | null>`; the alias exists purely so tooltips read `ElementRef<HTMLInputElement>` and LLMs get a stronger prior for the concept.
+- **`ref<T>()`** now declares its return type as `ElementRef<T>` instead of `Signal<T | null>`. No runtime change.
+- **JSDoc tightened** on both `ref()` and `Ref<T>` to say explicitly: _"read it with `.value`, not `.current`"_.
+
+**Usage:**
+
+```ts
+import { ref } from "@whisq/core";
+import type { ElementRef } from "@whisq/core";
+
+const inputEl = ref<HTMLInputElement>(); // ElementRef<HTMLInputElement>
+input({ ref: inputEl });
+onMount(() => inputEl.value?.focus()); // .value — not .current
+
+// Naming a prop / field that holds a ref:
+type FormRefs = {
+  email: ElementRef<HTMLInputElement>;
+  submitBtn: ElementRef<HTMLButtonElement>;
+};
+```
+
+5 new tests in `ref.test.ts` pin: no `.current` property exists, the return value passes `isSignal()`, `subscribe()` fires on mount + unmount, and `ElementRef<T>` is assignable both to the `Ref` prop type and to a `Signal<T | null>` slot.
+
+Backward compatible. The underlying type is still `Signal<T | null>`; code that declared `Signal<HTMLInputElement | null>` for a ref still works.

--- a/packages/core/src/__tests__/ref.test.ts
+++ b/packages/core/src/__tests__/ref.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { signal, isSignal } from "../reactive.js";
 import { div, input, button, mount } from "../elements.js";
 import { ref } from "../ref.js";
+import type { ElementRef } from "../ref.js";
 
 let container: HTMLElement;
 let dispose: () => void;
@@ -133,5 +134,61 @@ describe("ref() helper", () => {
     const r = ref();
     dispose = mount(div({ ref: r }), container);
     expect(r.value).toBeInstanceOf(HTMLDivElement);
+  });
+
+  // ── Accessor contract (WHISQ-63) ──────────────────────────────────────
+
+  it("uses .value as the accessor — not .current", () => {
+    const r = ref<HTMLInputElement>();
+    // `.current` is React's convention, not Whisq's. Verify the property
+    // doesn't exist so it's loud if anyone ever adds it.
+    expect("current" in r).toBe(false);
+    // The documented accessors all exist on a regular Signal.
+    expect(typeof r.value === "object" || r.value === null).toBe(true);
+    expect(typeof r.peek).toBe("function");
+    expect(typeof r.subscribe).toBe("function");
+  });
+
+  it("returns a signal, so isSignal(ref()) === true", () => {
+    const r = ref<HTMLInputElement>();
+    expect(isSignal(r)).toBe(true);
+  });
+
+  it("subscribe() fires on mount and unmount", () => {
+    const r = ref<HTMLInputElement>();
+    const seen: (HTMLInputElement | null)[] = [];
+    const unsubscribe = r.subscribe((v) => seen.push(v));
+
+    dispose = mount(input({ ref: r }), container);
+    dispose();
+    unsubscribe();
+
+    // Initial immediate null + populate on mount + reset to null on unmount.
+    expect(seen.length).toBeGreaterThanOrEqual(3);
+    expect(seen[0]).toBeNull();
+    expect(seen.find((v) => v instanceof HTMLInputElement)).toBeInstanceOf(
+      HTMLInputElement,
+    );
+    expect(seen[seen.length - 1]).toBeNull();
+  });
+});
+
+// ── ElementRef<T> type alias (WHISQ-63) ────────────────────────────────
+
+describe("ElementRef<T>", () => {
+  it("is assignable to the Ref prop type (signal form)", () => {
+    // Compile-time assertion: declaring via the alias produces a value
+    // that satisfies the element `ref` prop.
+    const r: ElementRef<HTMLInputElement> = ref<HTMLInputElement>();
+    dispose = mount(input({ ref: r }), container);
+    expect(r.value).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it("is structurally identical to Signal<T | null>", () => {
+    const r: ElementRef<HTMLInputElement> = signal<HTMLInputElement | null>(
+      null,
+    );
+    dispose = mount(input({ ref: r }), container);
+    expect(r.value).toBeInstanceOf(HTMLInputElement);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,7 +106,7 @@ export type {
 
 // Refs
 export { ref } from "./ref.js";
-export type { Ref } from "./ref.js";
+export type { Ref, ElementRef } from "./ref.js";
 
 // Styling
 export { sheet, styles, cx, rcx, sx, theme } from "./styling.js";

--- a/packages/core/src/ref.ts
+++ b/packages/core/src/ref.ts
@@ -6,25 +6,51 @@
 import { signal, type Signal } from "./reactive.js";
 
 /**
- * A ref accepts either a Signal that will be populated with the element,
- * or a callback invoked with the element (and later with null on unmount).
+ * A ref target accepts either a signal that will be populated with the
+ * element, or a callback invoked with the element (and later with `null`
+ * on unmount). Passed to the `ref` prop on any element.
+ *
+ * Use `ref<T>()` to create the signal variant; the callback variant is an
+ * inline `(el) => void` arrow.
  */
 export type Ref<T extends HTMLElement = HTMLElement> =
   | Signal<T | null>
   | ((el: T | null) => void);
 
 /**
- * Create a typed signal ref for a DOM element.
+ * A ref to a DOM element, created by `ref<T>()`. It is a regular Whisq
+ * `Signal<T | null>` — **read it with `.value`, not `.current`**. The
+ * framework populates it after the element mounts and resets it to `null`
+ * on unmount. Use `.peek()` for a non-tracking read, `.subscribe()` to
+ * observe changes without an `effect()`, and write to `.value` is
+ * allowed but rarely useful (the framework overwrites it on mount).
  *
- * The signal starts at `null` and is populated with the element after mount;
- * it is reset to `null` on unmount.
+ * Equivalent to `Signal<T | null>`; the named alias exists so editor
+ * tooltips on a `ref()` return surface read "`ElementRef<HTMLInputElement>`"
+ * rather than the raw signal type.
+ */
+export type ElementRef<T extends HTMLElement = HTMLElement> = Signal<T | null>;
+
+/**
+ * Create an element ref for imperative DOM access.
+ *
+ * Returns an `ElementRef<T>` — a regular signal whose `.value` is `null`
+ * until the element mounts, and returns to `null` after unmount. Read with
+ * `.value` like any signal. `currentTarget`-style `.current` is **not** the
+ * Whisq idiom.
  *
  * ```ts
  * const inputEl = ref<HTMLInputElement>();
- * input({ ref: inputEl });
+ *
+ * input({ ref: inputEl, type: "text" });
+ *
+ * // Imperative, on next microtask after mount:
  * onMount(() => inputEl.value?.focus());
+ *
+ * // Reactive, in a getter:
+ * div({ hidden: () => inputEl.value == null }, "loading...")
  * ```
  */
-export function ref<T extends HTMLElement = HTMLElement>(): Signal<T | null> {
+export function ref<T extends HTMLElement = HTMLElement>(): ElementRef<T> {
   return signal<T | null>(null);
 }


### PR DESCRIPTION
## Summary
Refs have always been plain Whisq signals — read with `.value`, not `.current`. This PR makes that obvious at every surface so the next developer (or LLM) doesn't have to rediscover it.

### Changes
- **New** `ElementRef<T>` — exported type alias, structurally identical to `Signal<T | null>`. `ref<T>()`'s return type now names itself `ElementRef<T>` instead of the raw signal type, so IDE tooltips read `ElementRef<HTMLInputElement>` and the concept surfaces by name.
- **`ref()` JSDoc tightened**: now explicitly says *"read it with `.value`, not `.current`"* — calls out the React convention by name so an LLM trained on React code has an immediate corrective anchor.
- **`Ref<T>` JSDoc** also gets the "use `ref<T>()` for the signal variant" nudge.

### Why an alias, not a rename
Keeping `ref()` as a regular signal preserves Whisq's invariant: *every container-shaped reactive primitive uses `.value`.* Introducing a separate `.current` accessor would fracture that. The alias gives the concept a name without changing the semantics.

## Test plan
- [x] `pnpm --filter @whisq/core test -- src/__tests__/ref.test.ts` → 17 pass (12 existing + 5 new)
- [x] `pnpm -r test` all green
- [x] `pnpm -r build` / `tsc --noEmit` clean
- [x] `prettier --check` clean
- [x] `pnpm --filter @whisq/core size` → 4.83 KB gzipped (unchanged — type-only)

### New tests pin
1. No `.current` property exists on a ref (loud canary if anyone adds it).
2. `isSignal(ref())` is `true`.
3. `subscribe()` fires on both mount and unmount.
4. `ElementRef<T>` assigns to the element `ref` prop.
5. `ElementRef<T>` is structurally interchangeable with `Signal<T | null>`.

## Backward compat
100%. Code that typed refs as `Signal<T | null>` continues to typecheck. The underlying type is unchanged; `ElementRef<T>` is purely a named re-export.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)