### PR TITLE
WHISQ-71: document project-structure conventions for AI-generated apps

### DIFF
--- a/.changeset/project-structure-conventions.md
+++ b/.changeset/project-structure-conventions.md
@@ -1,0 +1,11 @@
+---
+"create-whisq": patch
+---
+
+Document project-structure conventions so AI-generated Whisq code matches the scaffolder templates (WHISQ-71).
+
+Every scaffolded project's `CLAUDE.md` now includes the full convention: one component per file in `src/components/`, one domain per file in `src/stores/`, `main.ts` is for mounting and nothing else, `src/lib/` is Whisq-free. Anti-patterns are called out explicitly (single-file apps, `src/lib/index.ts` utility soup, default exports, import-time I/O in stores).
+
+Canonical reference lives in the framework repo at [`packages/core/docs/project-structure.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/project-structure.md). The CLAUDE.md section links to it for deep detail.
+
+`@whisq/core` is unchanged — this is template/docs content only.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Point Claude, ChatGPT, Gemini, Cursor, or any coding assistant at these URLs bef
 - **Compact LLM reference card:** <https://whisq.dev/ai/llm-reference/> — the whole framework in one page
 - **Machine-readable exports manifest:** <https://unpkg.com/@whisq/core@latest/dist/public-api.json> — every named export in the current release, pinned per version
 - **Copy-paste test prompts:** [`docs/AI_TEST_PROMPTS.md`](./docs/AI_TEST_PROMPTS.md) — eight self-contained prompts (todo, signup form, chat UI, markdown editor, live dashboard, router SPA, SSR blog, Snake) that exercise different surfaces of the framework
+- **Project-structure conventions:** [`packages/core/docs/project-structure.md`](./packages/core/docs/project-structure.md) — canonical file layout (one component per file, `main.ts` mounts and nothing else) so AI output matches the scaffolder templates
 
 > **Coming soon:** `whisq.dev/llms.txt` (structured index, [llmstxt.org](https://llmstxt.org) convention) and `whisq.dev/llms-full.txt` (full docs as one plain-text fetch) are merged to docs `develop` and will go live once the docs repo cuts its next release.
 

--- a/docs/AI_TEST_PROMPTS.md
+++ b/docs/AI_TEST_PROMPTS.md
@@ -38,6 +38,16 @@ Whisq rules (hard constraints):
   - Use resource(fetcher, { source, keepPrevious, initialValue }) for async data with cancellation.
   - Use signalMap / signalSet (imported from "@whisq/core/collections") for large keyed state.
 
+Whisq project structure (one-line rule: one component per file; main.ts is for mounting, nothing else):
+  - src/main.ts — ~4 lines, imports App and calls mount(App({}), document.getElementById("app")!). Nothing else.
+  - src/App.ts — top-level component. Owns routing, layout, error boundary. Business logic goes in stores/; reusable UI in components/; route targets in pages/.
+  - src/components/ — reusable UI, one per file. PascalCase filename matches the named export (Button.ts exports Button). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+  - src/pages/ — route targets if using @whisq/router. One file per route.
+  - src/stores/ — shared state, one domain per file (cart.ts, auth.ts). Export signals + mutation helpers. No default exports. No import-time I/O.
+  - src/lib/ — pure utilities, NO Whisq imports. Testable in Node without jsdom.
+  - src/styles.ts — sheet() definitions at module scope.
+  - DON'T ship a single-file app that inlines every component in main.ts for non-trivial projects. Scaffolders and AI output diverge when that happens, and editing turns into whole-file rewrites.
+
 Whisq styling (use Whisq's built-in primitives — do NOT import styled-components, emotion, goober, or any other CSS-in-JS library; do NOT add Tailwind unless specifically asked):
   - sheet({ card: { padding: "1rem", color: "red", "&:hover": { color: "blue" }, "@media (max-width: 640px)": { padding: "0.5rem" } } })
     — scoped CSS classes with nested pseudo/media rules. Returns { card: "whisq-card-a1b2", ... } which you spread into class props. Use this as the DEFAULT for all non-reactive styling. No build step; a <style> tag is injected at runtime.
@@ -57,7 +67,7 @@ Whisq styling (use Whisq's built-in primitives — do NOT import styled-componen
   - Do NOT write raw <style> tags in markup. sheet() handles <style> injection.
   - All of sheet, cx, rcx, sx, theme are imported from "@whisq/core".
 
-Task: Build a todo app as a single-file Whisq component that mounts to #app.
+Task: Build a todo app that mounts to #app, following the project structure rules above.
 
 Features:
   - Text input to add new todos (Enter key or Add button submits).
@@ -100,6 +110,16 @@ Whisq rules (hard constraints):
   - Use match(...) for tri-state/multi-branch conditionals (loading/error/data), not chained when() calls.
   - Use resource(fetcher, { source, keepPrevious, initialValue }) for async data with cancellation.
   - Use signalMap / signalSet (imported from "@whisq/core/collections") for large keyed state.
+
+Whisq project structure (one-line rule: one component per file; main.ts is for mounting, nothing else):
+  - src/main.ts — ~4 lines, imports App and calls mount(App({}), document.getElementById("app")!). Nothing else.
+  - src/App.ts — top-level component. Owns routing, layout, error boundary. Business logic goes in stores/; reusable UI in components/; route targets in pages/.
+  - src/components/ — reusable UI, one per file. PascalCase filename matches the named export (Button.ts exports Button). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+  - src/pages/ — route targets if using @whisq/router. One file per route.
+  - src/stores/ — shared state, one domain per file (cart.ts, auth.ts). Export signals + mutation helpers. No default exports. No import-time I/O.
+  - src/lib/ — pure utilities, NO Whisq imports. Testable in Node without jsdom.
+  - src/styles.ts — sheet() definitions at module scope.
+  - DON'T ship a single-file app that inlines every component in main.ts for non-trivial projects. Scaffolders and AI output diverge when that happens, and editing turns into whole-file rewrites.
 
 Whisq styling (use Whisq's built-in primitives — do NOT import styled-components, emotion, goober, or any other CSS-in-JS library; do NOT add Tailwind unless specifically asked):
   - sheet({ card: { padding: "1rem", color: "red", "&:hover": { color: "blue" }, "@media (max-width: 640px)": { padding: "0.5rem" } } })
@@ -164,6 +184,16 @@ Whisq rules (hard constraints):
   - Use resource(fetcher, { source, keepPrevious, initialValue }) for async data with cancellation.
   - Use signalMap / signalSet (imported from "@whisq/core/collections") for large keyed state.
 
+Whisq project structure (one-line rule: one component per file; main.ts is for mounting, nothing else):
+  - src/main.ts — ~4 lines, imports App and calls mount(App({}), document.getElementById("app")!). Nothing else.
+  - src/App.ts — top-level component. Owns routing, layout, error boundary. Business logic goes in stores/; reusable UI in components/; route targets in pages/.
+  - src/components/ — reusable UI, one per file. PascalCase filename matches the named export (Button.ts exports Button). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+  - src/pages/ — route targets if using @whisq/router. One file per route.
+  - src/stores/ — shared state, one domain per file (cart.ts, auth.ts). Export signals + mutation helpers. No default exports. No import-time I/O.
+  - src/lib/ — pure utilities, NO Whisq imports. Testable in Node without jsdom.
+  - src/styles.ts — sheet() definitions at module scope.
+  - DON'T ship a single-file app that inlines every component in main.ts for non-trivial projects. Scaffolders and AI output diverge when that happens, and editing turns into whole-file rewrites.
+
 Whisq styling (use Whisq's built-in primitives — do NOT import styled-components, emotion, goober, or any other CSS-in-JS library; do NOT add Tailwind unless specifically asked):
   - sheet({ card: { padding: "1rem", color: "red", "&:hover": { color: "blue" }, "@media (max-width: 640px)": { padding: "0.5rem" } } })
     — scoped CSS classes with nested pseudo/media rules. Returns { card: "whisq-card-a1b2", ... } which you spread into class props. Use this as the DEFAULT for all non-reactive styling. No build step; a <style> tag is injected at runtime.
@@ -227,6 +257,16 @@ Whisq rules (hard constraints):
   - Use resource(fetcher, { source, keepPrevious, initialValue }) for async data with cancellation.
   - Use signalMap / signalSet (imported from "@whisq/core/collections") for large keyed state.
 
+Whisq project structure (one-line rule: one component per file; main.ts is for mounting, nothing else):
+  - src/main.ts — ~4 lines, imports App and calls mount(App({}), document.getElementById("app")!). Nothing else.
+  - src/App.ts — top-level component. Owns routing, layout, error boundary. Business logic goes in stores/; reusable UI in components/; route targets in pages/.
+  - src/components/ — reusable UI, one per file. PascalCase filename matches the named export (Button.ts exports Button). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+  - src/pages/ — route targets if using @whisq/router. One file per route.
+  - src/stores/ — shared state, one domain per file (cart.ts, auth.ts). Export signals + mutation helpers. No default exports. No import-time I/O.
+  - src/lib/ — pure utilities, NO Whisq imports. Testable in Node without jsdom.
+  - src/styles.ts — sheet() definitions at module scope.
+  - DON'T ship a single-file app that inlines every component in main.ts for non-trivial projects. Scaffolders and AI output diverge when that happens, and editing turns into whole-file rewrites.
+
 Whisq styling (use Whisq's built-in primitives — do NOT import styled-components, emotion, goober, or any other CSS-in-JS library; do NOT add Tailwind unless specifically asked):
   - sheet({ card: { padding: "1rem", color: "red", "&:hover": { color: "blue" }, "@media (max-width: 640px)": { padding: "0.5rem" } } })
     — scoped CSS classes with nested pseudo/media rules. Returns { card: "whisq-card-a1b2", ... } which you spread into class props. Use this as the DEFAULT for all non-reactive styling. No build step; a <style> tag is injected at runtime.
@@ -287,6 +327,16 @@ Whisq rules (hard constraints):
   - Use resource(fetcher, { source, keepPrevious, initialValue }) for async data with cancellation.
   - Use signalMap / signalSet (imported from "@whisq/core/collections") for large keyed state.
 
+Whisq project structure (one-line rule: one component per file; main.ts is for mounting, nothing else):
+  - src/main.ts — ~4 lines, imports App and calls mount(App({}), document.getElementById("app")!). Nothing else.
+  - src/App.ts — top-level component. Owns routing, layout, error boundary. Business logic goes in stores/; reusable UI in components/; route targets in pages/.
+  - src/components/ — reusable UI, one per file. PascalCase filename matches the named export (Button.ts exports Button). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+  - src/pages/ — route targets if using @whisq/router. One file per route.
+  - src/stores/ — shared state, one domain per file (cart.ts, auth.ts). Export signals + mutation helpers. No default exports. No import-time I/O.
+  - src/lib/ — pure utilities, NO Whisq imports. Testable in Node without jsdom.
+  - src/styles.ts — sheet() definitions at module scope.
+  - DON'T ship a single-file app that inlines every component in main.ts for non-trivial projects. Scaffolders and AI output diverge when that happens, and editing turns into whole-file rewrites.
+
 Whisq styling (use Whisq's built-in primitives — do NOT import styled-components, emotion, goober, or any other CSS-in-JS library; do NOT add Tailwind unless specifically asked):
   - sheet({ card: { padding: "1rem", color: "red", "&:hover": { color: "blue" }, "@media (max-width: 640px)": { padding: "0.5rem" } } })
     — scoped CSS classes with nested pseudo/media rules. Returns { card: "whisq-card-a1b2", ... } which you spread into class props. Use this as the DEFAULT for all non-reactive styling. No build step; a <style> tag is injected at runtime.
@@ -345,6 +395,16 @@ Whisq rules (hard constraints):
   - Use match(...) for tri-state/multi-branch conditionals (loading/error/data), not chained when() calls.
   - Use resource(fetcher, { source, keepPrevious, initialValue }) for async data with cancellation.
   - Use signalMap / signalSet (imported from "@whisq/core/collections") for large keyed state.
+
+Whisq project structure (one-line rule: one component per file; main.ts is for mounting, nothing else):
+  - src/main.ts — ~4 lines, imports App and calls mount(App({}), document.getElementById("app")!). Nothing else.
+  - src/App.ts — top-level component. Owns routing, layout, error boundary. Business logic goes in stores/; reusable UI in components/; route targets in pages/.
+  - src/components/ — reusable UI, one per file. PascalCase filename matches the named export (Button.ts exports Button). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+  - src/pages/ — route targets if using @whisq/router. One file per route.
+  - src/stores/ — shared state, one domain per file (cart.ts, auth.ts). Export signals + mutation helpers. No default exports. No import-time I/O.
+  - src/lib/ — pure utilities, NO Whisq imports. Testable in Node without jsdom.
+  - src/styles.ts — sheet() definitions at module scope.
+  - DON'T ship a single-file app that inlines every component in main.ts for non-trivial projects. Scaffolders and AI output diverge when that happens, and editing turns into whole-file rewrites.
 
 Whisq styling (use Whisq's built-in primitives — do NOT import styled-components, emotion, goober, or any other CSS-in-JS library; do NOT add Tailwind unless specifically asked):
   - sheet({ card: { padding: "1rem", color: "red", "&:hover": { color: "blue" }, "@media (max-width: 640px)": { padding: "0.5rem" } } })
@@ -405,6 +465,16 @@ Whisq rules (hard constraints):
   - Use resource(fetcher, { source, keepPrevious, initialValue }) for async data with cancellation.
   - Use signalMap / signalSet (imported from "@whisq/core/collections") for large keyed state.
 
+Whisq project structure (one-line rule: one component per file; main.ts is for mounting, nothing else):
+  - src/main.ts — ~4 lines, imports App and calls mount(App({}), document.getElementById("app")!). Nothing else.
+  - src/App.ts — top-level component. Owns routing, layout, error boundary. Business logic goes in stores/; reusable UI in components/; route targets in pages/.
+  - src/components/ — reusable UI, one per file. PascalCase filename matches the named export (Button.ts exports Button). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+  - src/pages/ — route targets if using @whisq/router. One file per route.
+  - src/stores/ — shared state, one domain per file (cart.ts, auth.ts). Export signals + mutation helpers. No default exports. No import-time I/O.
+  - src/lib/ — pure utilities, NO Whisq imports. Testable in Node without jsdom.
+  - src/styles.ts — sheet() definitions at module scope.
+  - DON'T ship a single-file app that inlines every component in main.ts for non-trivial projects. Scaffolders and AI output diverge when that happens, and editing turns into whole-file rewrites.
+
 Whisq styling (use Whisq's built-in primitives — do NOT import styled-components, emotion, goober, or any other CSS-in-JS library; do NOT add Tailwind unless specifically asked):
   - sheet({ card: { padding: "1rem", color: "red", "&:hover": { color: "blue" }, "@media (max-width: 640px)": { padding: "0.5rem" } } })
     — scoped CSS classes with nested pseudo/media rules. Returns { card: "whisq-card-a1b2", ... } which you spread into class props. Use this as the DEFAULT for all non-reactive styling. No build step; a <style> tag is injected at runtime.
@@ -458,6 +528,16 @@ Whisq rules (hard constraints):
   - Use match(...) for tri-state/multi-branch conditionals (loading/error/data), not chained when() calls.
   - Use resource(fetcher, { source, keepPrevious, initialValue }) for async data with cancellation.
   - Use signalMap / signalSet (imported from "@whisq/core/collections") for large keyed state.
+
+Whisq project structure (one-line rule: one component per file; main.ts is for mounting, nothing else):
+  - src/main.ts — ~4 lines, imports App and calls mount(App({}), document.getElementById("app")!). Nothing else.
+  - src/App.ts — top-level component. Owns routing, layout, error boundary. Business logic goes in stores/; reusable UI in components/; route targets in pages/.
+  - src/components/ — reusable UI, one per file. PascalCase filename matches the named export (Button.ts exports Button). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+  - src/pages/ — route targets if using @whisq/router. One file per route.
+  - src/stores/ — shared state, one domain per file (cart.ts, auth.ts). Export signals + mutation helpers. No default exports. No import-time I/O.
+  - src/lib/ — pure utilities, NO Whisq imports. Testable in Node without jsdom.
+  - src/styles.ts — sheet() definitions at module scope.
+  - DON'T ship a single-file app that inlines every component in main.ts for non-trivial projects. Scaffolders and AI output diverge when that happens, and editing turns into whole-file rewrites.
 
 Whisq styling (use Whisq's built-in primitives — do NOT import styled-components, emotion, goober, or any other CSS-in-JS library; do NOT add Tailwind unless specifically asked):
   - sheet({ card: { padding: "1rem", color: "red", "&:hover": { color: "blue" }, "@media (max-width: 640px)": { padding: "0.5rem" } } })

--- a/packages/core/docs/project-structure.md
+++ b/packages/core/docs/project-structure.md
@@ -1,0 +1,176 @@
+# Project structure conventions
+
+Canonical file layout for Whisq applications. Every `npm create whisq@latest` template uses this shape; AI-generated code should too.
+
+> **One-line rule:** one component per file. `main.ts` is for mounting, nothing else.
+
+---
+
+## The tree
+
+```
+src/
+  main.ts          # entrypoint — mounts App to #app, nothing else
+  App.ts           # top-level component — routing, layout, error boundaries
+  styles.ts        # sheet() definitions at module scope
+  components/      # reusable UI components
+    Button.ts
+    Card.ts
+    TodoItem.ts
+  pages/           # route targets (if using @whisq/router)
+    Home.ts
+    About.ts
+    TodoDetail.ts
+  stores/          # shared state — one domain per file
+    cart.ts
+    auth.ts
+    session.ts
+  lib/             # pure utilities, NO Whisq imports (testable in isolation)
+    format-date.ts
+    parse-query.ts
+```
+
+This is what the `full-app` template scaffolds. The other templates (`minimal`, `ssr`, `vite-plugin`) are subsets — drop what you don't need, but keep the same layout for what you do use.
+
+---
+
+## Per-file rules
+
+### `src/main.ts` — the entrypoint
+
+Four lines, give or take. Imports the root component, calls `mount`. **Nothing else.** No signals, no helpers, no route definitions.
+
+```ts
+import { mount } from "@whisq/core";
+import { App } from "./App";
+
+mount(App({}), document.getElementById("app")!);
+```
+
+If you feel tempted to put anything else here, it belongs in `App.ts` or a store.
+
+### `src/App.ts` — the top-level component
+
+The application's root component. Owns:
+
+- Routing (wiring up `createRouter` + `RouterView`)
+- Layout (header / nav / main / footer)
+- Global error boundary (via `errorBoundary`)
+- Theme / head setup (`theme()`, `useHead()`)
+
+Does **not** own:
+
+- Business-logic state — that belongs in `stores/`
+- Individual route pages — those belong in `pages/`
+- Reusable UI — that belongs in `components/`
+
+```ts
+import { component, div } from "@whisq/core";
+import { createRouter, RouterView } from "@whisq/router";
+import { Home } from "./pages/Home";
+import { About } from "./pages/About";
+import { Nav } from "./components/Nav";
+import { s } from "./styles";
+
+const router = createRouter({
+  routes: [
+    { path: "/", component: Home },
+    { path: "/about", component: About },
+  ],
+});
+
+export const App = component(() =>
+  div({ class: s.app }, Nav({ router }), RouterView({ router })),
+);
+```
+
+### `src/components/` — reusable UI
+
+- **One component per file.** Named export. PascalCase filename matches the export name: `Button.ts` exports `Button`.
+- Aim for <100 lines including styles and helpers. If you're past 150, it's probably two components.
+- Components that are used in one place only stay inline in their page or parent. Pull them out here when they're reused.
+- No side effects at module scope (no network calls, no timers). Keep the module import-cheap.
+
+### `src/pages/` — route targets
+
+- One file per route. Filename matches the route's purpose (`Home.ts`, `UserProfile.ts`), not its URL.
+- Each page exports one `component()` — that's the route's render target.
+- Pages can own their own page-scoped state via `signal()` at module scope OR inside the component setup. Route-crossing state lives in `stores/`.
+- Dynamic segments (`/user/:id`) read params via `route.params.value.id` inside the page.
+
+### `src/stores/` — shared state
+
+- One domain per file. `cart.ts`, `auth.ts`, `session.ts`, etc. — not `store.ts` or `state.ts`.
+- Each file exports the signals plus the mutation helpers that operate on them. Consumers import both from the same module.
+- No default exports — named exports compose better and name better in stack traces.
+- No top-level I/O at import time. Kick off network calls from the component that needs them (via `resource()`) or from a function the consumer calls.
+
+```ts
+// stores/cart.ts
+import { signal, computed } from "@whisq/core";
+
+export const items = signal<CartItem[]>([]);
+export const total = computed(() =>
+  items.value.reduce((sum, i) => sum + i.price * i.quantity, 0),
+);
+
+export function add(item: CartItem) {
+  items.value = [...items.value, item];
+}
+
+export function remove(id: string) {
+  items.value = items.value.filter((i) => i.id !== id);
+}
+```
+
+### `src/lib/` — pure utilities
+
+- No Whisq imports. No DOM. Testable in Node without jsdom.
+- Each file is a small, focused utility. `format-date.ts`, `parse-query.ts`, `slugify.ts`.
+- If something needs a signal, it belongs in `stores/`, not `lib/`.
+
+### `src/styles.ts` — styling
+
+- `sheet()` definitions at module scope. Import the returned object anywhere as `s` (or `styles`).
+- `theme()` lives here too — called once at module load for design tokens.
+- Per-component one-off styles CAN live in the component file if they're small and local; anything shared goes here.
+
+---
+
+## One component per file, really?
+
+Yes. The single strongest predictor of a Whisq app an AI won't mangle on its second iteration is that every component has a file with its name on it. When an AI is asked to "fix the Card component's padding", it finds `src/components/Card.ts`, edits, done. When Card is inlined at line 412 of main.ts, the AI either rewrites the whole file (losing other changes) or hallucinates a new Card component somewhere else.
+
+**Small local helpers** (a `formatPrice` pure function used only in `Card.ts`) stay inline. **Small sub-components** (a `CardHeader` used only in `Card.ts`) can stay inline. The rule only applies to components that are _reused_ or _conceptually independent_.
+
+### When to split
+
+Pull a sub-component into its own file when **any** of:
+
+- Used in more than one place.
+- Owns its own state or effects that are conceptually independent.
+- Exceeds ~50 lines on its own.
+- Has its own tests (or should).
+
+Otherwise keep it inline.
+
+---
+
+## Anti-patterns
+
+| Anti-pattern                               | Why it hurts                                                                        | Do instead                                  |
+| ------------------------------------------ | ----------------------------------------------------------------------------------- | ------------------------------------------- |
+| Single-file app (everything in `main.ts`)  | Unreadable past 200 lines; AI rewrites the whole file to change anything            | Split per the tree above                    |
+| `src/lib/index.ts` utility soup            | Imports everything; kills tree-shaking; circular-import magnet                      | One utility per file, import specifically   |
+| Default exports                            | Don't compose in stack traces or auto-imports; AI often re-exports them differently | Always named exports                        |
+| `stores/store.ts` holding everything       | Import of one domain drags in all; testing requires the whole graph                 | One domain per file                         |
+| Top-level network calls in a store         | Import-time side effects break SSR and tests                                        | Kick off from `resource()` or a user action |
+| `src/main.ts` doing anything but `mount()` | `main.ts` gets a second responsibility, then a third                                | Move to `App.ts` or a store                 |
+
+---
+
+## See also
+
+- [`reactive-shapes.md`](./reactive-shapes.md) — the four shapes of reactive data flow.
+- [`batch-semantics.md`](./batch-semantics.md) — how `batch()` sequences effect flushes.
+- The `full-app` template at [`packages/create-whisq/src/templates/full-app/`](../../create-whisq/src/templates/full-app/) is a live reference of this structure.

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -272,13 +272,34 @@ import { items, total, addItem } from "./stores/cart";
 
 ## Project Structure
 
+**One-line rule:** one component per file. `main.ts` is for mounting, nothing else.
+
 ```
 src/
-  components/     # Component files
-  stores/         # Shared state (exported signals)
-  pages/          # Route pages (if using @whisq/router)
-  main.ts         # Entry: mount(App({}), document.getElementById("app"))
+  main.ts         # entrypoint — mounts App to #app, nothing else
+  App.ts          # top-level component — routing, layout, error boundaries
+  styles.ts       # sheet() definitions at module scope
+  components/     # reusable UI — one per file, PascalCase, named exports
+    Button.ts
+    Card.ts
+  pages/          # route targets (if using @whisq/router)
+    Home.ts
+    About.ts
+  stores/         # shared state — one domain per file
+    cart.ts
+    auth.ts
+  lib/            # pure utilities, NO Whisq imports (testable in isolation)
 ```
+
+- **`main.ts`** stays ~4 lines: import `App`, call `mount(App({}), ...)`. Nothing else belongs here.
+- **`App.ts`** owns routing, layout, error boundary, head setup. Business logic goes in `stores/`; route pages in `pages/`; reusable UI in `components/`.
+- **One component per file** in `components/`. PascalCase filename matches the named export (`Button.ts` exports `Button`). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+- **Stores** export both the signals and the mutation helpers that operate on them. No default exports. No import-time I/O.
+- **`lib/`** is Whisq-free — if it needs a signal, it belongs in `stores/`.
+
+Anti-patterns to avoid: single-file apps, `src/lib/index.ts` utility soup, default exports, `stores/store.ts` holding everything, top-level network calls in a store, `main.ts` doing anything but `mount()`.
+
+Full convention with examples: [`packages/core/docs/project-structure.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/project-structure.md) (in the framework repo).
 
 ## Git Workflow
 

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -272,13 +272,34 @@ import { items, total, addItem } from "./stores/cart";
 
 ## Project Structure
 
+**One-line rule:** one component per file. `main.ts` is for mounting, nothing else.
+
 ```
 src/
-  components/     # Component files
-  stores/         # Shared state (exported signals)
-  pages/          # Route pages (if using @whisq/router)
-  main.ts         # Entry: mount(App({}), document.getElementById("app"))
+  main.ts         # entrypoint — mounts App to #app, nothing else
+  App.ts          # top-level component — routing, layout, error boundaries
+  styles.ts       # sheet() definitions at module scope
+  components/     # reusable UI — one per file, PascalCase, named exports
+    Button.ts
+    Card.ts
+  pages/          # route targets (if using @whisq/router)
+    Home.ts
+    About.ts
+  stores/         # shared state — one domain per file
+    cart.ts
+    auth.ts
+  lib/            # pure utilities, NO Whisq imports (testable in isolation)
 ```
+
+- **`main.ts`** stays ~4 lines: import `App`, call `mount(App({}), ...)`. Nothing else belongs here.
+- **`App.ts`** owns routing, layout, error boundary, head setup. Business logic goes in `stores/`; route pages in `pages/`; reusable UI in `components/`.
+- **One component per file** in `components/`. PascalCase filename matches the named export (`Button.ts` exports `Button`). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+- **Stores** export both the signals and the mutation helpers that operate on them. No default exports. No import-time I/O.
+- **`lib/`** is Whisq-free — if it needs a signal, it belongs in `stores/`.
+
+Anti-patterns to avoid: single-file apps, `src/lib/index.ts` utility soup, default exports, `stores/store.ts` holding everything, top-level network calls in a store, `main.ts` doing anything but `mount()`.
+
+Full convention with examples: [`packages/core/docs/project-structure.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/project-structure.md) (in the framework repo).
 
 ## Git Workflow
 

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -272,13 +272,34 @@ import { items, total, addItem } from "./stores/cart";
 
 ## Project Structure
 
+**One-line rule:** one component per file. `main.ts` is for mounting, nothing else.
+
 ```
 src/
-  components/     # Component files
-  stores/         # Shared state (exported signals)
-  pages/          # Route pages (if using @whisq/router)
-  main.ts         # Entry: mount(App({}), document.getElementById("app"))
+  main.ts         # entrypoint — mounts App to #app, nothing else
+  App.ts          # top-level component — routing, layout, error boundaries
+  styles.ts       # sheet() definitions at module scope
+  components/     # reusable UI — one per file, PascalCase, named exports
+    Button.ts
+    Card.ts
+  pages/          # route targets (if using @whisq/router)
+    Home.ts
+    About.ts
+  stores/         # shared state — one domain per file
+    cart.ts
+    auth.ts
+  lib/            # pure utilities, NO Whisq imports (testable in isolation)
 ```
+
+- **`main.ts`** stays ~4 lines: import `App`, call `mount(App({}), ...)`. Nothing else belongs here.
+- **`App.ts`** owns routing, layout, error boundary, head setup. Business logic goes in `stores/`; route pages in `pages/`; reusable UI in `components/`.
+- **One component per file** in `components/`. PascalCase filename matches the named export (`Button.ts` exports `Button`). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+- **Stores** export both the signals and the mutation helpers that operate on them. No default exports. No import-time I/O.
+- **`lib/`** is Whisq-free — if it needs a signal, it belongs in `stores/`.
+
+Anti-patterns to avoid: single-file apps, `src/lib/index.ts` utility soup, default exports, `stores/store.ts` holding everything, top-level network calls in a store, `main.ts` doing anything but `mount()`.
+
+Full convention with examples: [`packages/core/docs/project-structure.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/project-structure.md) (in the framework repo).
 
 ## Git Workflow
 

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -272,13 +272,34 @@ import { items, total, addItem } from "./stores/cart";
 
 ## Project Structure
 
+**One-line rule:** one component per file. `main.ts` is for mounting, nothing else.
+
 ```
 src/
-  components/     # Component files
-  stores/         # Shared state (exported signals)
-  pages/          # Route pages (if using @whisq/router)
-  main.ts         # Entry: mount(App({}), document.getElementById("app"))
+  main.ts         # entrypoint — mounts App to #app, nothing else
+  App.ts          # top-level component — routing, layout, error boundaries
+  styles.ts       # sheet() definitions at module scope
+  components/     # reusable UI — one per file, PascalCase, named exports
+    Button.ts
+    Card.ts
+  pages/          # route targets (if using @whisq/router)
+    Home.ts
+    About.ts
+  stores/         # shared state — one domain per file
+    cart.ts
+    auth.ts
+  lib/            # pure utilities, NO Whisq imports (testable in isolation)
 ```
+
+- **`main.ts`** stays ~4 lines: import `App`, call `mount(App({}), ...)`. Nothing else belongs here.
+- **`App.ts`** owns routing, layout, error boundary, head setup. Business logic goes in `stores/`; route pages in `pages/`; reusable UI in `components/`.
+- **One component per file** in `components/`. PascalCase filename matches the named export (`Button.ts` exports `Button`). Pull a sub-component into its own file when it is reused OR owns independent state OR exceeds ~50 lines.
+- **Stores** export both the signals and the mutation helpers that operate on them. No default exports. No import-time I/O.
+- **`lib/`** is Whisq-free — if it needs a signal, it belongs in `stores/`.
+
+Anti-patterns to avoid: single-file apps, `src/lib/index.ts` utility soup, default exports, `stores/store.ts` holding everything, top-level network calls in a store, `main.ts` doing anything but `mount()`.
+
+Full convention with examples: [`packages/core/docs/project-structure.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/project-structure.md) (in the framework repo).
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

AIs writing Whisq code often inline everything in `main.ts` — the scaffolder templates follow a clean `main.ts → App.ts → components/ → pages/ → stores/ → lib/` layout, but until now that convention wasn't spelled out as a rule. This PR makes it explicit and teachable everywhere an AI looks: the canonical framework-repo doc, the scaffolder's `CLAUDE.md`, the AI test prompts, and the top-level README.

## The rule

> **One-line rule:** one component per file. `main.ts` is for mounting, nothing else.

Plus per-folder rules (main.ts is 4 lines; App.ts owns routing/layout/errors; `components/` one-per-file PascalCase; `stores/` one domain per file with named exports only; `lib/` is Whisq-free), a "when to split" guideline (reused OR independent state OR >50 lines), and a 6-row anti-patterns table (single-file apps, utility soup, default exports, import-time I/O in stores, etc.).

## Changes

- **New** `packages/core/docs/project-structure.md` — canonical doc (175 lines). Matches the `batch-semantics.md` / `reactive-shapes.md` pattern established by #59 / #65.
- **Edit** `packages/create-whisq/src/templates/{full-app,minimal,ssr,vite-plugin}/CLAUDE.md` — the existing thin "Project Structure" section grows into the full convention with per-folder rules + anti-patterns. Links to the canonical doc for deep detail.
- **Edit** `docs/AI_TEST_PROMPTS.md` — new "Whisq project structure" block added to every prompt's rules section (bulk replace across 8 prompts). Prompt 1's task line dropped "as a single-file Whisq component" because the structure rule supersedes it.
- **Edit** `README.md` — extra bullet in the "Entry points for AI assistants" block linking to the canonical doc.
- **New** `.changeset/project-structure-conventions.md` — `create-whisq: patch`. `@whisq/core` is unchanged (pure docs).

## Test plan

- [x] `pnpm -r test` → 306 pass unchanged (docs only)
- [x] `pnpm -r build` / `tsc --noEmit` / `prettier --check` clean
- [x] Bundle size unchanged
- [ ] CI green (incl. `changeset-check` — the new `.md` satisfies it)

## Cross-repo follow-up (separate)

The LLM reference card on `whisqjs/whisq.dev` should port a compact version of this convention. I'll file an issue there once this merges.

## Out of scope

- Changing the actual template source trees (they already match — this issue is about making it explicit, not about refactoring).
- ESLint rules or tooling to enforce the structure.
- Generating the structure from an AI agent.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)