### PR TITLE
WHISQ-75: coalesce notify-docs dispatch to @whisq/core releases

### DIFF
--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -41,6 +41,12 @@ permissions:
 jobs:
   dispatch:
     name: Dispatch to docs
+    # Changesets publishes each @whisq/* package as its own GitHub release, so
+    # a single release cycle fires `release: published` ~9 times. We dispatch
+    # only on the @whisq/core release (the canonical "framework shipped" event)
+    # and on manual workflow_dispatch runs, so docs tracking issues don't
+    # multiply per package. See whisqjs/whisq#75.
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '@whisq/core@') }}
     runs-on: ubuntu-latest
     steps:
       - name: Mint WHISQ_BOT app token


### PR DESCRIPTION
Closes #75.

## Summary

- Changesets publishes each `@whisq/*` package as its own GitHub release, so `release: published` fires ~9 times per release cycle — producing 9 essentially identical `Document @whisq/<pkg>@...` tracking issues on `whisqjs/whisq.dev` per cut (see [whisqjs/whisq.dev#49–#57](https://github.com/whisqjs/whisq.dev/issues?q=is%3Aissue+label%3Adocumentation+0.1.0-alpha.6)).
- Implements **Option A** from the issue: a job-level `if:` on `dispatch` that fires only when the release tag starts with `@whisq/core@` (the canonical "framework shipped" event) OR when triggered via `workflow_dispatch` (preserved for end-to-end testing).
- Non-core package releases now skip the whole job — including the WHISQ_BOT token mint — so no dispatch leaks out.

```yaml
if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '@whisq/core@') }}
```

## Test plan

- [ ] **YAML parses** — `node -e "require('yaml').parse(...)"` succeeded locally; GitHub Actions will reject malformed workflows on push.
- [ ] **End-to-end verification deferred to next release cut** (per issue AC): the next prerelease should produce exactly one `Document @whisq/core@<tag>` issue on `whisqjs/whisq.dev`, not 9.
- [ ] **Manual dispatch still works** — `workflow_dispatch` branch of the `if:` preserves the existing manual-test path with arbitrary `inputs.tag`.

## Labels

- `skip-changeset` (workflow-only change, no API surface) — per issue AC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)