### PR TITLE
WHISQ-78: add bindField() for fields in signal-held arrays

### DIFF
--- a/.changeset/bindfield-for-array-items.md
+++ b/.changeset/bindfield-for-array-items.md
@@ -1,0 +1,24 @@
+---
+"@whisq/core": minor
+"create-whisq": patch
+---
+
+Add `bindField(source, item, key, opts?)` — two-way binding for a field on an item inside a signal-held array. Closes the ergonomic gap `bind()` didn't reach: the most common UI shape in real applications (todos, carts, forms-with-rows, CRUD grids).
+
+```ts
+each(() => todos.value, (todo) =>
+  input({
+    type: "checkbox",
+    ...bindField(todos, todo, "done", { as: "checkbox" }),
+  }),
+  { key: (t) => t.id },
+)
+```
+
+Mirrors `bind()`'s discriminator shapes (text / number / checkbox / radio). `keyBy` identifies which item to rewrite — defaults to `t => t.id`; override for items keyed on something else. Writes produce an immutable array update so downstream `computed` / `effect` re-run correctly.
+
+All four scaffolded templates' `CLAUDE.md` reactive-shapes tables now lead with `bindField()` for this case instead of the manual event pair. The decision flow also updates to *"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."*
+
+`@whisq/core` size budget raised from 5 KB to 5.5 KB gzipped (current: 5.08 KB). The README updates "Under 5 KB gzipped" → "~5 KB gzipped" to match. `bindField` is exported from the top-level `@whisq/core` so LLMs and autocompletion discover it alongside `bind()`.
+
+Closes #78.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-5CE0F2" alt="License"></a>
 </p>
 
-Whisq is designed so large language models produce working code on the first try. The complete framework is under 5 KB gzipped and the full API fits in a prompt. No hooks rules. No reactivity caveats. No compile-time magic — just signals for state, functions for UI.
+Whisq is designed so large language models produce working code on the first try. The complete framework is ~5 KB gzipped and the full API fits in a prompt. No hooks rules. No reactivity caveats. No compile-time magic — just signals for state, functions for UI.
 
 ```ts
 import { signal, component, div, button, span, mount } from "@whisq/core";
@@ -51,7 +51,7 @@ Eight copy-paste prompts that exercise different surfaces of the framework (todo
 
 ## For humans
 
-- **Under 5 KB gzipped** — complete framework (core: 4.83 KB).
+- **~5 KB gzipped** — complete framework (core: 5.08 KB).
 - **Zero build step** — runs as plain JavaScript, works with any bundler.
 - **100% TypeScript** — every element function fully typed, inferred through components.
 - **No footguns** — uniform `() => value` reactive pattern, no hooks rules, no dependency arrays, no stale-closure tax.
@@ -71,7 +71,7 @@ Four templates: `minimal`, `full-app` (router + pages + store), `ssr`, `vite-plu
 
 | Package                                      | Description                                  | Size    |
 | -------------------------------------------- | -------------------------------------------- | ------- |
-| [`@whisq/core`](packages/core)               | Signals, elements, components, styling       | 4.83 KB |
+| [`@whisq/core`](packages/core)               | Signals, elements, components, styling       | 5.08 KB |
 | [`@whisq/router`](packages/router)           | Signal-based client-side routing             | 2.85 KB |
 | [`@whisq/ssr`](packages/ssr)                 | Server-side rendering + streaming            | 982 B   |
 | [`@whisq/testing`](packages/testing)         | Render, query, fireEvent, userEvent, waitFor | —       |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "5 KB",
+      "limit": "5.5 KB",
       "gzip": true
     }
   ],

--- a/packages/core/src/__tests__/bindField.test.ts
+++ b/packages/core/src/__tests__/bindField.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { signal } from "../reactive.js";
+import { input, mount, each, ul } from "../elements.js";
+import { bindField } from "../bindField.js";
+
+interface Todo {
+  id: string;
+  text: string;
+  done: boolean;
+  priority: number;
+}
+
+let container: HTMLElement;
+let dispose: () => void;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+});
+
+describe("bindField() — checkbox (field inside array item)", () => {
+  it("reflects the field's initial value on the DOM", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: true, priority: 0 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "checkbox",
+              ...bindField(todos, todo, "done", { as: "checkbox" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(true);
+  });
+
+  it("writes an immutable array update when the user toggles", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+      { id: "b", text: "y", done: false, priority: 0 },
+    ]);
+    const before = todos.value;
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "checkbox",
+              ...bindField(todos, todo, "done", { as: "checkbox" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const [first] = container.querySelectorAll("input");
+    (first as HTMLInputElement).checked = true;
+    first.dispatchEvent(new Event("change"));
+
+    expect(todos.value).not.toBe(before);
+    expect(todos.value[0]).not.toBe(before[0]);
+    expect(todos.value[1]).toBe(before[1]);
+    expect(todos.value[0]).toEqual({
+      id: "a",
+      text: "x",
+      done: true,
+      priority: 0,
+    });
+  });
+
+  it("propagates programmatic field updates back to the DOM", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "checkbox",
+              ...bindField(todos, todo, "done", { as: "checkbox" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(false);
+    todos.value = todos.value.map((t) =>
+      t.id === "a" ? { ...t, done: true } : t,
+    );
+    expect(el.checked).toBe(true);
+  });
+
+  it("survives keyed array replacement (items reordered)", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+      { id: "b", text: "y", done: true, priority: 0 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "checkbox",
+              ...bindField(todos, todo, "done", { as: "checkbox" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    // Reorder — keyed each should retain DOM nodes but swap positions.
+    todos.value = [todos.value[1], todos.value[0]];
+    const [first, second] = container.querySelectorAll("input");
+    expect((first as HTMLInputElement).checked).toBe(true); // was b
+    expect((second as HTMLInputElement).checked).toBe(false); // was a
+
+    // Write to the newly-first checkbox — must still target item "b".
+    (first as HTMLInputElement).checked = false;
+    first.dispatchEvent(new Event("change"));
+    expect(todos.value.find((t) => t.id === "b")?.done).toBe(false);
+    expect(todos.value.find((t) => t.id === "a")?.done).toBe(false);
+  });
+});
+
+describe("bindField() — text / number / radio", () => {
+  it("handles text fields via oninput", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "old", done: false, priority: 0 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) => input({ ...bindField(todos, todo, "text") }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("old");
+    el.value = "new";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(todos.value[0].text).toBe("new");
+  });
+
+  it("handles numeric fields with as: number", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 3 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "number",
+              ...bindField(todos, todo, "priority", { as: "number" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("3");
+    el.value = "9";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(todos.value[0].priority).toBe(9);
+  });
+
+  it("ignores NaN on numeric write (no source mutation)", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 3 },
+    ]);
+    const before = todos.value;
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "number",
+              ...bindField(todos, todo, "priority", { as: "number" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(todos.value).toBe(before);
+    expect(todos.value[0].priority).toBe(3);
+  });
+
+  it("handles radio with as: radio", () => {
+    interface Row {
+      id: string;
+      role: "admin" | "user";
+    }
+    const rows = signal<Row[]>([{ id: "a", role: "user" }]);
+    dispose = mount(
+      ul(
+        each(
+          () => rows.value,
+          (row) =>
+            input({
+              type: "radio",
+              name: "role",
+              ...bindField(rows, row, "role", {
+                as: "radio",
+                value: "admin",
+              }),
+            }),
+          { key: (r) => r.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(false);
+    rows.value = [{ id: "a", role: "admin" }];
+    expect(el.checked).toBe(true);
+  });
+});
+
+describe("bindField() — keyBy", () => {
+  it("defaults to .id for item matching", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "checkbox",
+              ...bindField(todos, todo, "done", { as: "checkbox" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(todos.value[0].done).toBe(true);
+  });
+
+  it("accepts a custom keyBy when items are keyed on something other than id", () => {
+    interface Row {
+      uuid: string;
+      done: boolean;
+    }
+    const rows = signal<Row[]>([{ uuid: "x-1", done: false }]);
+    dispose = mount(
+      ul(
+        each(
+          () => rows.value,
+          (row) =>
+            input({
+              type: "checkbox",
+              ...bindField(rows, row, "done", {
+                as: "checkbox",
+                keyBy: (r) => r.uuid,
+              }),
+            }),
+          { key: (r) => r.uuid },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(rows.value[0].done).toBe(true);
+  });
+
+  it("warns and discards the write when no item matches", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+    ]);
+    // Access the item, then remove it from the source, then attempt a write.
+    const accessor = () => todos.value[0] ?? { id: "missing" };
+    const props = bindField(todos, accessor as () => Todo, "done", {
+      as: "checkbox",
+    });
+    todos.value = []; // item gone
+    (props as { onchange: (e: Event) => void }).onchange({
+      target: { checked: true } as HTMLInputElement,
+    } as unknown as Event);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("no item in source matched"),
+    );
+    expect(todos.value).toEqual([]);
+    warn.mockRestore();
+  });
+});
+
+describe("bindField() — input validation", () => {
+  it("throws TypeError when source is not a signal", () => {
+    expect(() =>
+      bindField(
+        {} as never,
+        (() => ({})) as unknown as () => { id: string },
+        "id",
+      ),
+    ).toThrow(TypeError);
+  });
+
+  it("throws TypeError when item is not a function", () => {
+    const todos = signal<Todo[]>([]);
+    expect(() =>
+      bindField(todos, "not a function" as unknown as () => Todo, "done"),
+    ).toThrow(TypeError);
+  });
+});

--- a/packages/core/src/bindField.ts
+++ b/packages/core/src/bindField.ts
@@ -1,0 +1,142 @@
+// ============================================================================
+// Whisq Core — Field binding for items inside signal-held arrays
+// bindField(source, item, key, opts?) covers the "field inside an item inside
+// a keyed each()" shape that bind() doesn't reach. Sibling to bind() — same
+// discriminator shapes (text/number/checkbox/radio); write produces an
+// immutable array update on `source`.
+// ============================================================================
+
+import { type Signal, isSignal } from "./reactive.js";
+import type { TextBind, NumberBind, CheckboxBind, RadioBind } from "./bind.js";
+
+interface Common<T> {
+  keyBy?: (item: T) => unknown;
+}
+
+export type BindFieldOptions<T> =
+  | Common<T>
+  | ({ as: "number" } & Common<T>)
+  | ({ as: "checkbox" } & Common<T>)
+  | ({ as: "radio"; value: string } & Common<T>);
+
+/**
+ * Two-way binding for a field on an item inside a signal-held array.
+ *
+ * ```ts
+ * each(() => todos.value, (todo) =>
+ *   input({
+ *     type: "checkbox",
+ *     ...bindField(todos, todo, "done", { as: "checkbox" }),
+ *   }),
+ *   { key: (t) => t.id },
+ * )
+ * ```
+ *
+ * `keyBy` (default: `t => t.id`) identifies which item to rewrite. Writes
+ * produce a new array so downstream `computed` / `effect` re-run correctly.
+ */
+export function bindField<T, K extends keyof T>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+): TextBind;
+export function bindField<T, K extends keyof T>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+  options: { as: "number" } & Common<T>,
+): NumberBind;
+export function bindField<T, K extends keyof T>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+  options: { as: "checkbox" } & Common<T>,
+): CheckboxBind;
+export function bindField<T, K extends keyof T, V extends string>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+  options: { as: "radio"; value: V } & Common<T>,
+): RadioBind<V>;
+export function bindField<T, K extends keyof T>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+  options?: Common<T>,
+): TextBind;
+export function bindField<T, K extends keyof T>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+  options?: BindFieldOptions<T>,
+): TextBind | NumberBind | CheckboxBind | RadioBind<string> {
+  if (!isSignal(source)) throw new TypeError("bindField: source must be Signal");
+  if (typeof item !== "function")
+    throw new TypeError("bindField: item must be a function");
+
+  const keyBy =
+    (options as Common<T>)?.keyBy ??
+    ((t: T) => (t as { id?: unknown }).id);
+
+  const write = (next: T[K]): void => {
+    const target = keyBy(item());
+    let matched = false;
+    const arr = source.value.map((t) => {
+      if (keyBy(t) === target) {
+        matched = true;
+        return { ...t, [key]: next };
+      }
+      return t;
+    });
+    if (!matched) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `bindField: no item in source matched ${String(target)}; write to "${String(key)}" discarded.`,
+      );
+      return;
+    }
+    source.value = arr;
+  };
+
+  const as = (options as { as?: string } | undefined)?.as;
+
+  if (as === "checkbox") {
+    return {
+      checked: () => item()[key] as unknown as boolean,
+      onchange: (e) => write(
+        (e.target as HTMLInputElement).checked as unknown as T[K],
+      ),
+    };
+  }
+
+  if (as === "radio") {
+    const target = (options as { value: string }).value;
+    return {
+      value: target,
+      checked: () => (item()[key] as unknown) === target,
+      onchange: (e) => {
+        if ((e.target as HTMLInputElement).checked)
+          write(target as unknown as T[K]);
+      },
+    };
+  }
+
+  if (as === "number") {
+    return {
+      value: () => String(item()[key] as unknown),
+      oninput: (e) => {
+        const n = (e.target as HTMLInputElement).valueAsNumber;
+        if (!Number.isNaN(n)) write(n as unknown as T[K]);
+      },
+    };
+  }
+
+  return {
+    value: () => String(item()[key] as unknown),
+    oninput: (e) =>
+      write(
+        (e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)
+          .value as unknown as T[K],
+      ),
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,3 +121,5 @@ export type {
   RadioBind,
   BindOptions,
 } from "./bind.js";
+export { bindField } from "./bindField.js";
+export type { BindFieldOptions } from "./bindField.js";

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -72,14 +72,14 @@ div({ hidden: () => !visible.value }, "Now you see me")
 
 #### Reactive shapes — pick the right one
 
-Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → manual event pair."*
+Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."*
 
 | Shape            | Example                                                            | Use when                                             |
 | ---------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
 | Getter child     | `span(() => count.value)`                                          | A signal drives inline text                          |
 | Getter prop      | `{ class: () => active.value ? "on" : "off" }`                      | A signal drives an element attribute / class / style |
 | `bind()` spread  | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input       |
-| Manual event pair | `{ checked: () => todo().done, onchange: () => toggle(todo().id) }` | Field inside an item inside a keyed `each`          |
+| `bindField()` spread | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | Field inside an item inside a keyed `each`           |
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -72,14 +72,14 @@ div({ hidden: () => !visible.value }, "Now you see me")
 
 #### Reactive shapes — pick the right one
 
-Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → manual event pair."*
+Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."*
 
 | Shape            | Example                                                            | Use when                                             |
 | ---------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
 | Getter child     | `span(() => count.value)`                                          | A signal drives inline text                          |
 | Getter prop      | `{ class: () => active.value ? "on" : "off" }`                      | A signal drives an element attribute / class / style |
 | `bind()` spread  | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input       |
-| Manual event pair | `{ checked: () => todo().done, onchange: () => toggle(todo().id) }` | Field inside an item inside a keyed `each`          |
+| `bindField()` spread | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | Field inside an item inside a keyed `each`           |
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -72,14 +72,14 @@ div({ hidden: () => !visible.value }, "Now you see me")
 
 #### Reactive shapes — pick the right one
 
-Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → manual event pair."*
+Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."*
 
 | Shape            | Example                                                            | Use when                                             |
 | ---------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
 | Getter child     | `span(() => count.value)`                                          | A signal drives inline text                          |
 | Getter prop      | `{ class: () => active.value ? "on" : "off" }`                      | A signal drives an element attribute / class / style |
 | `bind()` spread  | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input       |
-| Manual event pair | `{ checked: () => todo().done, onchange: () => toggle(todo().id) }` | Field inside an item inside a keyed `each`          |
+| `bindField()` spread | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | Field inside an item inside a keyed `each`           |
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -72,14 +72,14 @@ div({ hidden: () => !visible.value }, "Now you see me")
 
 #### Reactive shapes — pick the right one
 
-Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → manual event pair."*
+Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."*
 
 | Shape            | Example                                                            | Use when                                             |
 | ---------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
 | Getter child     | `span(() => count.value)`                                          | A signal drives inline text                          |
 | Getter prop      | `{ class: () => active.value ? "on" : "off" }`                      | A signal drives an element attribute / class / style |
 | `bind()` spread  | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input       |
-| Manual event pair | `{ checked: () => todo().done, onchange: () => toggle(todo().id) }` | Field inside an item inside a keyed `each`          |
+| `bindField()` spread | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | Field inside an item inside a keyed `each`           |
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 


### PR DESCRIPTION
Closes #78.

## Summary

Closes the ergonomic gap `bind()` didn't reach: two-way binding for a field on an item inside a signal-held array — the most common UI shape in real apps (todos, carts, forms-with-rows, CRUD grids).

Both alpha.6 feedback reviewers (GPT and Claude, `dev/whisq_framework_feedback_GPT.md` / `dev/FRAMEWORK_FEEDBACK_CLAUDE.md`) independently flagged this as friction: `bind()` handled "one signal, one input" cleanly, but for per-item controls developers fell back to a manual event pair, forcing two shapes for the same conceptual operation inside a single todo app.

### API

```ts
each(() => todos.value, (todo) =>
  input({
    type: "checkbox",
    ...bindField(todos, todo, "done", { as: "checkbox" }),
  }),
  { key: (t) => t.id },
)
```

Mirrors `bind()`'s discriminator shapes (text / number / checkbox / radio) and adds a `keyBy` option (default `t => t.id`) for items keyed on something else. Writes produce an immutable array update on `source`, so downstream `computed` / `effect` / keyed `each` re-run correctly. No-match writes warn and discard rather than corrupting state.

### Scope decisions

- **Top-level export**, not sub-path. Per AC: _"LLM reference card lists the new helper alongside `bind()`."_ Burying it in `@whisq/core/forms` would hurt AI discoverability.
- **Size budget raised** 5 KB → 5.5 KB gzipped (current: **5.08 KB**). README "Under 5 KB gzipped" → "~5 KB gzipped" to keep the claim honest.
- **Templates updated**: all four `CLAUDE.md` reactive-shapes tables now lead with `bindField()` for this case; the one-line decision flow updates to _"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."_ Manual event pair demoted to escape-hatch status.
- **Not in scope** (follow-ups): whisq.dev docs-site update (cross-repo), `bindPath()` for arbitrary-depth paths, overloading `bind()` itself.

### Test plan

13 new tests in `packages/core/src/__tests__/bindField.test.ts`:

- [x] Initial field value reflects into DOM
- [x] User toggle produces immutable array update (new ref, old items preserved where possible)
- [x] Programmatic field updates propagate back to DOM
- [x] Survives keyed array replacement (reordering — accessor still targets the right item)
- [x] Text fields via `oninput`
- [x] Number fields with `as: "number"`
- [x] NaN guard (empty numeric input leaves source untouched)
- [x] Radio with `as: "radio"; value: string`
- [x] `keyBy` defaults to `.id`
- [x] Custom `keyBy` for items without `.id` field
- [x] No-match write warns and discards
- [x] TypeError when `source` isn't a Signal
- [x] TypeError when `item` isn't a function

Size / build / full monorepo test suite all green. `public-api.json` manifest now lists `bindField` + `BindFieldOptions` (bumps to 93 exports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)