### PR TITLE
WHISQ-81: friendlier runtime errors for malformed children / structure

### DIFF
--- a/.changeset/friendlier-runtime-errors.md
+++ b/.changeset/friendlier-runtime-errors.md
@@ -1,0 +1,18 @@
+---
+"@whisq/core": minor
+---
+
+Dev-mode runtime errors now tell you what's wrong and how to fix it. `div(...)`, `each()`, and `component()` validate their inputs at the boundary and throw a new `WhisqStructureError` with an expected/received mismatch plus a short hint when malformed children, non-array `each()` items, or invalid component return values show up.
+
+Where the old behaviors were "`Uncaught TypeError: .for is not iterable`" or a silent drop, you now see:
+
+```
+each: expected items() to return an array, received undefined.
+Hint: Data hasn't loaded yet. Gate the list with `when(() => data(), () => ul(each(...)))` or return `[]` while loading.
+```
+
+The guard code is wrapped in `if (process.env.NODE_ENV !== "production")` blocks so bundlers (Vite, Rollup, webpack, esbuild) strip it from production bundles — `@whisq/core` size-limit is measured with the same define and stays under budget at 5.25 KB gzipped.
+
+Public surface: `WhisqStructureError` (class) and `WhisqStructureErrorFields` (type) are both exported so apps can `instanceof`-check and render friendly error boundaries.
+
+Closes #81.

--- a/packages/core/.size-limit.cjs
+++ b/packages/core/.size-limit.cjs
@@ -1,0 +1,20 @@
+// Size-limit config for @whisq/core. Uses a JS file (rather than the
+// "size-limit" field in package.json) so we can pass a `define` to esbuild —
+// this strips dev-only validators (`if (process.env.NODE_ENV !== "production")
+// { ... }`) before measuring, giving a size number that matches what users'
+// production bundlers will actually ship.
+
+module.exports = [
+  {
+    path: "dist/index.js",
+    limit: "5.5 KB",
+    gzip: true,
+    modifyEsbuildConfig(config) {
+      config.define = {
+        ...(config.define ?? {}),
+        "process.env.NODE_ENV": '"production"',
+      };
+      return config;
+    },
+  },
+];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,13 +50,6 @@
   },
   "homepage": "https://whisq.dev",
   "sideEffects": false,
-  "size-limit": [
-    {
-      "path": "dist/index.js",
-      "limit": "5.5 KB",
-      "gzip": true
-    }
-  ],
   "devDependencies": {
     "@size-limit/preset-small-lib": "^11.2.0",
     "jsdom": "^29.0.2",

--- a/packages/core/src/__tests__/dev-errors.test.ts
+++ b/packages/core/src/__tests__/dev-errors.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { signal } from "../reactive.js";
+import { div, each, ul, mount, component } from "../elements.js";
+import { WhisqStructureError, describeValue } from "../dev-errors.js";
+import { component as makeComponent } from "../component.js";
+
+// Re-export `component` works either way — the `component` is re-exported
+// from elements in some builds. Use `makeComponent` in tests for clarity.
+void component;
+
+let container: HTMLElement;
+let dispose: (() => void) | undefined;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+  dispose = undefined;
+});
+
+describe("WhisqStructureError — describeValue", () => {
+  it("names primitives by type + value", () => {
+    expect(describeValue(null)).toBe("null");
+    expect(describeValue(undefined)).toBe("undefined");
+    expect(describeValue(42)).toContain("42");
+    expect(describeValue(true)).toContain("true");
+    expect(describeValue("hi")).toContain("hi");
+    expect(describeValue(() => {})).toBe("function");
+  });
+
+  it("names arrays by length", () => {
+    expect(describeValue([1, 2, 3])).toBe("array (length 3)");
+    expect(describeValue([])).toBe("array (length 0)");
+  });
+
+  it("names plain objects and class instances distinctly", () => {
+    expect(describeValue({ a: 1 })).toBe("plain object");
+    class Foo {}
+    expect(describeValue(new Foo())).toBe("Foo instance");
+  });
+});
+
+describe("WhisqStructureError — message shape", () => {
+  it("composes element + expected + received + hint", () => {
+    const err = new WhisqStructureError({
+      element: "each",
+      expected: "items() to return an array",
+      received: "undefined",
+      hint: "Gate the list with when().",
+    });
+    expect(err.name).toBe("WhisqStructureError");
+    expect(err.message).toContain("each");
+    expect(err.message).toContain("items() to return an array");
+    expect(err.message).toContain("undefined");
+    expect(err.message).toContain("Hint: Gate the list with when().");
+  });
+
+  it("preserves structured fields for programmatic handling", () => {
+    const err = new WhisqStructureError({
+      element: "div",
+      expected: "WhisqNode",
+      received: "plain object",
+    });
+    expect(err.element).toBe("div");
+    expect(err.expected).toBe("WhisqNode");
+    expect(err.received).toBe("plain object");
+    expect(err.hint).toBeUndefined();
+  });
+});
+
+// ── Fixture 1: each() with non-array items() return ────────────────────────
+
+describe("each() — items() must return an array", () => {
+  it("throws a friendly WhisqStructureError when items() returns undefined (was: .map is not a function)", () => {
+    const maybe = signal<number[] | undefined>(undefined);
+    let caught: unknown;
+    try {
+      dispose = mount(
+        ul(
+          each(
+            () => maybe.value as unknown as number[],
+            (n) => ul(String(n)),
+          ),
+        ),
+        container,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WhisqStructureError);
+    expect((caught as WhisqStructureError).element).toBe("each");
+    expect((caught as WhisqStructureError).received).toBe("undefined");
+    expect((caught as Error).message).toMatch(/items\(\) to return an array/);
+    expect((caught as Error).message).toMatch(/Hint:/);
+  });
+
+  it("throws when items() returns a plain object (e.g., user passed a Map)", () => {
+    expect(() => {
+      dispose = mount(
+        ul(
+          each(
+            () => ({ a: 1, b: 2 }) as unknown as number[],
+            (n) => ul(String(n)),
+          ),
+        ),
+        container,
+      );
+    }).toThrow(WhisqStructureError);
+  });
+
+  it("throws when items is not a function (user passed the array directly)", () => {
+    expect(() => {
+      each([1, 2, 3] as unknown as () => number[], (n) => ul(String(n)));
+    }).toThrow(/items to be a function/);
+  });
+
+  it("accepts a valid items() return (sanity check — no throw)", () => {
+    const items = signal([1, 2, 3]);
+    expect(() => {
+      dispose = mount(
+        ul(
+          each(
+            () => items.value,
+            (n) => ul(String(n)),
+          ),
+        ),
+        container,
+      );
+    }).not.toThrow();
+  });
+});
+
+// ── Fixture 2: malformed child (plain object) ──────────────────────────────
+
+describe("appendChildren — plain-object child", () => {
+  it("throws a friendly WhisqStructureError naming the element (was: silent drop)", () => {
+    let caught: unknown;
+    try {
+      // Simulate a user who forgot to call the component: `div({}, MyComponent)`
+      // where MyComponent is a plain object rather than a function / WhisqNode.
+      dispose = mount(
+        div({} as never, { not: "a whisq node" } as never),
+        container,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WhisqStructureError);
+    expect((caught as WhisqStructureError).element).toBe("div");
+    expect((caught as WhisqStructureError).received).toBe("plain object");
+    expect((caught as Error).message).toMatch(/Plain objects can't be rendered/);
+  });
+});
+
+// ── Fixture 3: component setup returns wrong shape ─────────────────────────
+
+describe("component — setup must return a WhisqNode", () => {
+  it("throws a friendly WhisqStructureError when setup returns null (was: downstream crash at dispose)", () => {
+    const Broken = makeComponent(() => null as never);
+    let caught: unknown;
+    try {
+      dispose = mount(Broken({}), container);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WhisqStructureError);
+    expect((caught as WhisqStructureError).element).toBe("component");
+    expect((caught as WhisqStructureError).received).toBe("null");
+    expect((caught as Error).message).toMatch(/return a WhisqNode/);
+  });
+
+  it("throws when setup returns a bare string", () => {
+    const Stringly = makeComponent(() => "just a string" as never);
+    expect(() => {
+      dispose = mount(Stringly({}), container);
+    }).toThrow(WhisqStructureError);
+  });
+
+  it("does not throw for valid components (regression guard)", () => {
+    const Good = makeComponent(() => div("hi"));
+    expect(() => {
+      dispose = mount(Good({}), container);
+    }).not.toThrow();
+  });
+});

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -6,6 +6,7 @@
 
 import { signal, effect } from "./reactive.js";
 import type { WhisqTemplate } from "./template.js";
+import { WhisqStructureError, describeValue } from "./dev-errors.js";
 
 type CleanupFn = () => void;
 
@@ -85,6 +86,22 @@ export function component<P extends Record<string, any> = {}>(
       template = setup(props);
     } finally {
       contextStack.pop();
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+      if (
+        template == null ||
+        typeof template !== "object" ||
+        !("el" in template) ||
+        !("dispose" in template)
+      ) {
+        throw new WhisqStructureError({
+          element: "component",
+          expected: "setup to return a WhisqNode (an element call like `div(...)`)",
+          received: describeValue(template),
+          hint: "Return the root element from your setup function: `return div(...)`. Bare strings, numbers, arrays, and null aren't valid component roots — wrap them in an element.",
+        });
+      }
     }
 
     // Run mount callbacks on next microtask (after DOM insertion)

--- a/packages/core/src/dev-errors.ts
+++ b/packages/core/src/dev-errors.ts
@@ -1,0 +1,69 @@
+// ============================================================================
+// Whisq Core — Developer-friendly structural error
+// Thrown by dev-mode validators on malformed children / structure. Guarded by
+// `process.env.NODE_ENV !== "production"` at call sites so prod bundlers
+// tree-shake the validation code away.
+// ============================================================================
+
+
+export interface WhisqStructureErrorFields {
+  /** What the framework expected at this position. */
+  expected: string;
+  /** What it actually received — human-readable. */
+  received: string;
+  /** Element or API surface where the mismatch happened (e.g. "div", "each", "component"). */
+  element: string;
+  /** Short "how to fix" hint for the most common cause. */
+  hint?: string;
+  /** Optional call-site info (file:line). Not yet populated; reserved. */
+  callsite?: string;
+}
+
+/**
+ * Thrown in dev mode when a Whisq API receives a value it can't render.
+ * Catch this to turn framework-level "structural" bugs into friendly UI.
+ * Production builds strip the throw sites — this class exists at runtime
+ * but is never instantiated outside of development / test.
+ */
+export class WhisqStructureError extends Error {
+  readonly expected: string;
+  readonly received: string;
+  readonly element: string;
+  readonly hint?: string;
+  readonly callsite?: string;
+
+  constructor(fields: WhisqStructureErrorFields) {
+    const parts = [
+      `${fields.element}: expected ${fields.expected}, received ${fields.received}.`,
+    ];
+    if (fields.hint) parts.push(`Hint: ${fields.hint}`);
+    if (fields.callsite) parts.push(`At: ${fields.callsite}`);
+    super(parts.join(" "));
+    this.name = "WhisqStructureError";
+    this.expected = fields.expected;
+    this.received = fields.received;
+    this.element = fields.element;
+    this.hint = fields.hint;
+    this.callsite = fields.callsite;
+  }
+}
+
+/**
+ * Short human description of any value — used for the `received` field of a
+ * structure error. Deliberately terse so the composed message stays short.
+ */
+export function describeValue(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (Array.isArray(value)) return `array (length ${value.length})`;
+  const t = typeof value;
+  if (t === "string") return `string ${JSON.stringify((value as string).slice(0, 40))}`;
+  if (t === "number" || t === "boolean" || t === "bigint") return `${t} ${String(value)}`;
+  if (t === "function") return "function";
+  if (t === "symbol") return "symbol";
+  if (t === "object") {
+    const ctor = (value as object).constructor?.name;
+    return ctor && ctor !== "Object" ? `${ctor} instance` : "plain object";
+  }
+  return t;
+}

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -14,6 +14,7 @@
 import { effect, isSignal, setEffectErrorHandler } from "./reactive.js";
 import { reconcileKeyed, type KeyedEntry } from "./reconcile.js";
 import type { Ref } from "./ref.js";
+import { WhisqStructureError, describeValue } from "./dev-errors.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -635,11 +636,45 @@ export function each<T>(
     | ((item: () => T, index: () => number) => WhisqNode),
   options?: { key: (item: T) => unknown },
 ): (() => Child[]) | WhisqNode {
+  if (process.env.NODE_ENV !== "production") {
+    if (typeof items !== "function") {
+      throw new WhisqStructureError({
+        element: "each",
+        expected: "items to be a function `() => T[]`",
+        received: describeValue(items),
+        hint: "Pass a getter, not the array itself: `each(() => todos.value, ...)` not `each(todos.value, ...)`.",
+      });
+    }
+    if (typeof render !== "function") {
+      throw new WhisqStructureError({
+        element: "each",
+        expected: "render to be a function",
+        received: describeValue(render),
+      });
+    }
+  }
+
+  const getItems = (): T[] => {
+    const result = items();
+    if (process.env.NODE_ENV !== "production" && !Array.isArray(result)) {
+      throw new WhisqStructureError({
+        element: "each",
+        expected: "items() to return an array",
+        received: describeValue(result),
+        hint:
+          result == null
+            ? "Data hasn't loaded yet. Gate the list with `when(() => data(), () => ul(each(...)))` or return `[]` while loading."
+            : "Return an array from the items getter — objects and maps need to be converted first (e.g. `Object.values(users.value)`).",
+      });
+    }
+    return result;
+  };
+
   if (!options?.key) {
     // Non-keyed: simple map — items are snapshots per render, no staleness
     // issue because nodes are recreated on every source change.
     const renderSnapshot = render as (item: T, index: number) => WhisqNode;
-    return () => items().map((item, i) => renderSnapshot(item, i));
+    return () => getItems().map((item, i) => renderSnapshot(item, i));
   }
 
   // Keyed: return a WhisqNode that manages its own reconciliation.
@@ -661,7 +696,7 @@ export function each<T>(
   fragment.appendChild(marker);
 
   const dispose = effect(() => {
-    const newItems = items();
+    const newItems = getItems();
     const parent = marker.parentNode;
     if (!parent) return;
 
@@ -1032,6 +1067,19 @@ function appendChildren(
     disposers.push(dispose);
     return;
   }
+
+  if (process.env.NODE_ENV !== "production") {
+    throw new WhisqStructureError({
+      element: (parent as Element).tagName?.toLowerCase() ?? "element",
+      expected:
+        "WhisqNode | string | number | boolean | null | undefined | function | array",
+      received: describeValue(child),
+      hint:
+        typeof child === "object" && !Array.isArray(child)
+          ? "Plain objects can't be rendered as children. Did you forget to call a component (`MyComponent({})` not `MyComponent`), or wrap a signal read in `() => signal.value`?"
+          : undefined,
+    });
+  }
 }
 
 function renderChild(
@@ -1067,5 +1115,18 @@ function renderChild(
     tracker.push(child.el);
     disposers.push(() => child.dispose());
     return;
+  }
+
+  if (process.env.NODE_ENV !== "production") {
+    throw new WhisqStructureError({
+      element: (parent as Element).nodeName?.toLowerCase() ?? "element",
+      expected:
+        "WhisqNode | string | number | boolean | null | undefined | array",
+      received: describeValue(child),
+      hint:
+        typeof child === "function"
+          ? "A reactive child `() => value` returned another function. Did you wrap a getter twice (`() => () => sig.value`)?"
+          : "Plain objects can't be rendered. If this came from a signal, wrap the read in `() => ...`; if it's a component, call it: `MyComponent({})`.",
+    });
   }
 }

--- a/packages/core/src/globals.d.ts
+++ b/packages/core/src/globals.d.ts
@@ -1,0 +1,6 @@
+// Minimal ambient declaration so dev-mode guards
+// (`if (process.env.NODE_ENV !== "production") { ... }`) type-check without
+// pulling in @types/node. The literal `process.env.NODE_ENV` reference at
+// every guard site lets bundlers (Vite, Rollup, webpack, esbuild) replace it
+// and dead-code-strip the development branch in production builds.
+declare const process: { env: { NODE_ENV?: string } };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,10 @@ export type { Ref, ElementRef } from "./ref.js";
 export { sheet, styles, cx, rcx, sx, theme } from "./styling.js";
 export type { StyleObject } from "./elements.js";
 
+// Dev-mode diagnostics
+export { WhisqStructureError } from "./dev-errors.js";
+export type { WhisqStructureErrorFields } from "./dev-errors.js";
+
 // Forms
 export { bind } from "./bind.js";
 export type {


### PR DESCRIPTION
Closes #81.

## Summary

Dev-mode validators at the four input boundaries where shape mismatches previously produced either silent drops (plain-object children) or unhelpful TypeError chains (\`Uncaught TypeError: .for is not iterable\`). New \`WhisqStructureError\` carries \`{ expected, received, element, hint?, callsite? }\` for both human and programmatic use.

### Before / after

**Before** — calling \`each(() => users.value, ...)\` while \`users.value\` is \`undefined\`:
\`\`\`
Uncaught TypeError: .for is not iterable
\`\`\`

**After**:
\`\`\`
each: expected items() to return an array, received undefined.
Hint: Data hasn't loaded yet. Gate the list with \`when(() => data(), () => ul(each(...)))\` or return \`[]\` while loading.
\`\`\`

### Guard sites

- \`appendChildren\` fall-through (plain-object child → throw, was silent drop)
- \`renderChild\` fall-through (reactive-child re-render returning malformed value)
- \`each(items, render, opts?)\` — \`items\` must be a function, return must be an array
- \`component((props) => template)\` — setup must return a WhisqNode-shaped object

### Production stripping

Every guard is wrapped in \`if (process.env.NODE_ENV !== \"production\") { ... }\` so bundlers (Vite, Rollup, webpack, esbuild) dead-code-strip it. Size-limit now uses \`.size-limit.cjs\` with a matching \`modifyEsbuildConfig\` define so the measured number reflects what users actually ship: **5.25 KB gzipped**, under the 5.5 KB cap.

### Public surface

- \`WhisqStructureError\` class — catch for friendly error boundaries
- \`WhisqStructureErrorFields\` type — for typed construction
- \`describeValue()\` — internal, not exported (tree-shakes in prod)

### Scope

- Covered three fixture transitions called out in the issue AC (\`each\`→undefined, child→plain-object, component→null).
- **Not in scope** (Option B from the issue — source-map-anchored callsite): the \`callsite?\` field is reserved but not populated. Follow-up issue once there's demand.
- **Not in scope**: per-element validators beyond the central \`appendChildren\` / \`renderChild\` paths — those cover every element function uniformly.

## Test plan

13 new tests in \`packages/core/src/__tests__/dev-errors.test.ts\`:

- [x] \`WhisqStructureError\` message composition (element, expected, received, hint)
- [x] Structured field preservation for programmatic handling
- [x] \`describeValue\` for primitives / arrays / plain objects / class instances / functions
- [x] Fixture 1: \`each()\` throws friendly error when \`items()\` returns undefined
- [x] Fixture 1b: \`each()\` throws when \`items()\` returns a plain object
- [x] Fixture 1c: \`each()\` throws when \`items\` is not a function (user passed array directly)
- [x] Fixture 1d regression guard: valid \`items\` doesn't throw
- [x] Fixture 2: plain-object child throws friendly error with element name + hint
- [x] Fixture 3: \`component()\` throws when setup returns null
- [x] Fixture 3b: \`component()\` throws when setup returns a bare string
- [x] Fixture 3c regression guard: valid component doesn't throw

All 332 core tests plus monorepo suites (router / ssr / testing / bindField / bind / ref / ... ) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)