### PR TITLE
WHISQ-82: add persistedSignal() to @whisq/core/persistence

### DIFF
--- a/.changeset/persisted-signal.md
+++ b/.changeset/persisted-signal.md
@@ -1,0 +1,27 @@
+---
+"@whisq/core": minor
+"create-whisq": patch
+---
+
+Add `persistedSignal(key, initial, opts?)` — a `Signal<T>` backed by `localStorage` / `sessionStorage`, exported from the new sub-path `@whisq/core/persistence` so apps that don't need it pay zero bundle cost.
+
+```ts
+import { persistedSignal } from "@whisq/core/persistence";
+
+export const todos = persistedSignal<Todo[]>("todos", []);
+```
+
+Closes the "every Whisq app reinvents the guarded-localStorage-read-with-effect-writer pattern" problem identified by the alpha.6 feedback. Blessed shape, one import, no hand-rolling.
+
+### Behaviors worth leading with
+
+- **SSR-safe.** On the server (`typeof window === "undefined"`) returns a plain signal initialized to `initial` with no storage subscription.
+- **Schema-validated.** If the stored JSON is malformed, or an optional `schema(raw)` validator throws, the signal falls back to `initial` rather than crashing at mount.
+- **Quota-safe.** If a write throws (`QuotaExceededError`, private mode), logs a warning and keeps the in-memory value — the app keeps working.
+- **Module-scope intent.** Call `persistedSignal` at module scope in your `stores/` file, not inside components — the write effect lives for the module lifetime by design.
+
+Options: `storage: "local" | "session"`, `serialize` / `deserialize` (default JSON), `schema` (validation on load).
+
+Scaffolded templates' `CLAUDE.md` files gain a "Persisted stores (opt-in, sub-path import)" block under Shared State so AI-generated code for new projects can discover the pattern without reinventing it.
+
+Closes #82.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,10 @@
     "./collections": {
       "types": "./dist/collections.d.ts",
       "import": "./dist/collections.js"
+    },
+    "./persistence": {
+      "types": "./dist/persistence.d.ts",
+      "import": "./dist/persistence.js"
     }
   },
   "files": [

--- a/packages/core/src/__tests__/persistence.test.ts
+++ b/packages/core/src/__tests__/persistence.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { effect } from "../reactive.js";
+// Imported from the internal path. Public import is `@whisq/core/persistence`
+// (see packages/core/package.json exports).
+import { persistedSignal } from "../persistence.js";
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+describe("persistedSignal() — initial load", () => {
+  it("returns the initial value when storage is empty", () => {
+    const s = persistedSignal("unset-key", 42);
+    expect(s.value).toBe(42);
+  });
+
+  it("loads a previously persisted value on init", () => {
+    window.localStorage.setItem("count", "7");
+    const s = persistedSignal("count", 0);
+    expect(s.value).toBe(7);
+  });
+
+  it("handles complex JSON values", () => {
+    window.localStorage.setItem("todos", '[{"id":"a","done":true}]');
+    const s = persistedSignal<Array<{ id: string; done: boolean }>>(
+      "todos",
+      [],
+    );
+    expect(s.value).toEqual([{ id: "a", done: true }]);
+  });
+
+  it("falls back to initial when stored JSON is malformed", () => {
+    window.localStorage.setItem("bad", "{not json}");
+    const s = persistedSignal("bad", { ok: true });
+    expect(s.value).toEqual({ ok: true });
+  });
+
+  it("falls back to initial when schema throws", () => {
+    window.localStorage.setItem("user", '{"name":"alice","age":"oops"}');
+    const s = persistedSignal<{ name: string; age: number }>(
+      "user",
+      { name: "anon", age: 0 },
+      {
+        schema: (raw) => {
+          const v = raw as { name: string; age: unknown };
+          if (typeof v.age !== "number") throw new TypeError("age");
+          return v as { name: string; age: number };
+        },
+      },
+    );
+    expect(s.value).toEqual({ name: "anon", age: 0 });
+  });
+});
+
+describe("persistedSignal() — writes", () => {
+  it("persists on .value assignment", async () => {
+    const s = persistedSignal("writes", 0);
+    s.value = 5;
+    // effect is synchronous — storage updates immediately
+    expect(window.localStorage.getItem("writes")).toBe("5");
+  });
+
+  it("persists on .update()", () => {
+    const s = persistedSignal("counter", 10);
+    s.update((n) => n + 1);
+    expect(window.localStorage.getItem("counter")).toBe("11");
+  });
+
+  it("does not overwrite storage with the initial value on init (no-op first run)", () => {
+    window.localStorage.setItem("existing", "99");
+    persistedSignal("existing", 0); // should read 99, NOT write back 0
+    expect(window.localStorage.getItem("existing")).toBe("99");
+  });
+
+  it("warns but does not throw when storage rejects the write", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const orig = Storage.prototype.setItem;
+    Storage.prototype.setItem = function throwingSet() {
+      throw new Error("QuotaExceededError");
+    };
+    try {
+      const s = persistedSignal("quota", "a");
+      expect(() => {
+        s.value = "b";
+      }).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('failed to write "quota"'),
+        expect.any(Error),
+      );
+      expect(s.value).toBe("b"); // in-memory value preserved
+    } finally {
+      Storage.prototype.setItem = orig;
+      warn.mockRestore();
+    }
+  });
+});
+
+describe("persistedSignal() — sessionStorage", () => {
+  it("routes to sessionStorage when storage: 'session'", () => {
+    const s = persistedSignal("tab-state", "init", { storage: "session" });
+    s.value = "changed";
+    expect(window.sessionStorage.getItem("tab-state")).toBe('"changed"');
+    expect(window.localStorage.getItem("tab-state")).toBeNull();
+  });
+
+  it("reads from sessionStorage on init", () => {
+    window.sessionStorage.setItem("read-session", '"pre-existing"');
+    const s = persistedSignal("read-session", "default", {
+      storage: "session",
+    });
+    expect(s.value).toBe("pre-existing");
+  });
+});
+
+describe("persistedSignal() — custom serialize/deserialize", () => {
+  it("uses custom codecs for non-JSON values (Map)", () => {
+    const initial = new Map<string, number>();
+    const s = persistedSignal("map", initial, {
+      serialize: (m) => JSON.stringify(Array.from(m.entries())),
+      deserialize: (raw) => new Map<string, number>(JSON.parse(raw)),
+    });
+
+    s.value = new Map([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    expect(window.localStorage.getItem("map")).toBe('[["a",1],["b",2]]');
+
+    // Re-hydrate from the persisted value
+    const loaded = persistedSignal("map", new Map<string, number>(), {
+      serialize: (m) => JSON.stringify(Array.from(m.entries())),
+      deserialize: (raw) => new Map<string, number>(JSON.parse(raw)),
+    });
+    expect(loaded.value.get("a")).toBe(1);
+    expect(loaded.value.get("b")).toBe(2);
+  });
+});
+
+describe("persistedSignal() — SSR safety", () => {
+  it("returns a plain signal initialized to `initial` when window is undefined", () => {
+    // Jsdom exposes `window` globally — hide it for this test.
+    const originalWindow = globalThis.window;
+    // @ts-expect-error intentional delete for SSR simulation
+    delete (globalThis as { window?: Window }).window;
+    try {
+      const s = persistedSignal("ssr", { count: 0 });
+      expect(s.value).toEqual({ count: 0 });
+      // Writes don't throw even with no storage
+      expect(() => {
+        s.value = { count: 1 };
+      }).not.toThrow();
+      expect(s.value).toEqual({ count: 1 });
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+});
+
+describe("persistedSignal() — reactivity", () => {
+  it("participates in effect tracking like a normal signal", () => {
+    const s = persistedSignal("reactive", 0);
+    const seen: number[] = [];
+    effect(() => {
+      seen.push(s.value);
+    });
+    s.value = 1;
+    s.value = 2;
+    expect(seen).toEqual([0, 1, 2]);
+  });
+});

--- a/packages/core/src/persistence.ts
+++ b/packages/core/src/persistence.ts
@@ -1,0 +1,112 @@
+// ============================================================================
+// Whisq Core — Persisted Signals
+//
+// persistedSignal(key, initial, opts?) returns a Signal<T> backed by
+// localStorage / sessionStorage. SSR-safe (returns initial on the server),
+// schema-validated on load (throws → fall back to initial), quota-safe on
+// write (warns, keeps the in-memory value).
+//
+// Import path: `@whisq/core/persistence` — kept off the top-level bundle so
+// users who don't need it pay no size cost.
+// ============================================================================
+
+import { signal, effect, type Signal } from "./reactive.js";
+
+export interface PersistedSignalOptions<T> {
+  /** Storage backend. "local" (default) persists across tabs and reloads; "session" only for the tab. */
+  storage?: "local" | "session";
+  /** Serialize to the stored string. Default: `JSON.stringify`. */
+  serialize?: (value: T) => string;
+  /** Deserialize from the stored string. Default: `JSON.parse`. */
+  deserialize?: (raw: string) => T;
+  /**
+   * Validate the deserialized value. Return `T` on success; throw to reject
+   * and fall back to `initial`. Useful when the stored shape may have changed.
+   */
+  schema?: (raw: unknown) => T;
+}
+
+const getStorage = (which: "local" | "session"): Storage | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    return which === "session" ? window.sessionStorage : window.localStorage;
+  } catch {
+    // Accessing storage can throw in some privacy modes / cross-origin iframes.
+    return null;
+  }
+};
+
+/**
+ * A signal backed by `localStorage` (or `sessionStorage`).
+ *
+ * ```ts
+ * const todos = persistedSignal<Todo[]>("todos", []);
+ * effect(() => console.log(todos.value));  // logs after each change
+ * todos.value = [...todos.value, newTodo]; // persisted automatically
+ * ```
+ *
+ * ### Behaviors worth leading with
+ *
+ * - **SSR-safe.** On the server (`typeof window === "undefined"`), returns
+ *   a plain signal initialized to `initial` with no storage subscription.
+ * - **Schema-validated.** If `schema` throws or the stored JSON is malformed,
+ *   the signal falls back to `initial` rather than crashing at mount.
+ * - **Quota-safe.** If a write throws (`QuotaExceededError`, private mode),
+ *   logs a warning and keeps the in-memory value — the app keeps working.
+ * - **Module-scope intent.** The write effect lives for the module lifetime.
+ *   Call `persistedSignal` at module scope in your `stores/` file, not inside
+ *   components — the effect has no disposal hook by design.
+ */
+export function persistedSignal<T>(
+  key: string,
+  initial: T,
+  options?: PersistedSignalOptions<T>,
+): Signal<T> {
+  const serialize = options?.serialize ?? JSON.stringify;
+  const deserialize = options?.deserialize ?? JSON.parse;
+  const storage = getStorage(options?.storage ?? "local");
+
+  let starting: T = initial;
+  if (storage) {
+    try {
+      const raw = storage.getItem(key);
+      if (raw !== null) {
+        const parsed = deserialize(raw) as unknown;
+        starting = options?.schema
+          ? options.schema(parsed)
+          : (parsed as T);
+      }
+    } catch {
+      // Parse error, schema rejection, storage-access-error — fall through.
+      starting = initial;
+    }
+  }
+
+  const sig = signal<T>(starting);
+
+  if (storage) {
+    // Subscribe to writes. Intentionally un-disposed — persistence effects
+    // live for the module lifetime. First call runs synchronously and would
+    // overwrite the value we just read with itself, which is a no-op, so
+    // harmless.
+    let first = true;
+    effect(() => {
+      const value = sig.value;
+      if (first) {
+        first = false;
+        return;
+      }
+      try {
+        storage.setItem(key, serialize(value));
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `persistedSignal: failed to write "${key}" to ${options?.storage ?? "local"}Storage.`,
+          error,
+        );
+      }
+    });
+  }
+
+  return sig;
+}

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -260,6 +260,22 @@ export const addItem = (item) => { items.value = [...items.value, item]; };
 import { items, total, addItem } from "./stores/cart";
 ```
 
+### Persisted stores (opt-in, sub-path import)
+
+Use `persistedSignal` when a store should survive reloads. It is in a sub-path export so apps that don't need it pay no bundle cost.
+
+```ts
+// stores/todos.ts
+import { persistedSignal } from "@whisq/core/persistence";
+
+export const todos = persistedSignal<Todo[]>("todos", []);
+// - reads from localStorage on init, writes on change
+// - SSR-safe (returns initial when window is undefined)
+// - falls back to initial on parse/schema error; warns on quota-exceeded
+```
+
+Call at module scope in `stores/` — the write effect lives for the module lifetime by design.
+
 ## Anti-Patterns (DO NOT)
 
 - ❌ `html\`...\`` — use element functions instead (div, span, button...)

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -260,6 +260,22 @@ export const addItem = (item) => { items.value = [...items.value, item]; };
 import { items, total, addItem } from "./stores/cart";
 ```
 
+### Persisted stores (opt-in, sub-path import)
+
+Use `persistedSignal` when a store should survive reloads. It is in a sub-path export so apps that don't need it pay no bundle cost.
+
+```ts
+// stores/todos.ts
+import { persistedSignal } from "@whisq/core/persistence";
+
+export const todos = persistedSignal<Todo[]>("todos", []);
+// - reads from localStorage on init, writes on change
+// - SSR-safe (returns initial when window is undefined)
+// - falls back to initial on parse/schema error; warns on quota-exceeded
+```
+
+Call at module scope in `stores/` — the write effect lives for the module lifetime by design.
+
 ## Anti-Patterns (DO NOT)
 
 - ❌ `html\`...\`` — use element functions instead (div, span, button...)

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -260,6 +260,22 @@ export const addItem = (item) => { items.value = [...items.value, item]; };
 import { items, total, addItem } from "./stores/cart";
 ```
 
+### Persisted stores (opt-in, sub-path import)
+
+Use `persistedSignal` when a store should survive reloads. It is in a sub-path export so apps that don't need it pay no bundle cost.
+
+```ts
+// stores/todos.ts
+import { persistedSignal } from "@whisq/core/persistence";
+
+export const todos = persistedSignal<Todo[]>("todos", []);
+// - reads from localStorage on init, writes on change
+// - SSR-safe (returns initial when window is undefined)
+// - falls back to initial on parse/schema error; warns on quota-exceeded
+```
+
+Call at module scope in `stores/` — the write effect lives for the module lifetime by design.
+
 ## Anti-Patterns (DO NOT)
 
 - ❌ `html\`...\`` — use element functions instead (div, span, button...)

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -260,6 +260,22 @@ export const addItem = (item) => { items.value = [...items.value, item]; };
 import { items, total, addItem } from "./stores/cart";
 ```
 
+### Persisted stores (opt-in, sub-path import)
+
+Use `persistedSignal` when a store should survive reloads. It is in a sub-path export so apps that don't need it pay no bundle cost.
+
+```ts
+// stores/todos.ts
+import { persistedSignal } from "@whisq/core/persistence";
+
+export const todos = persistedSignal<Todo[]>("todos", []);
+// - reads from localStorage on init, writes on change
+// - SSR-safe (returns initial when window is undefined)
+// - falls back to initial on parse/schema error; warns on quota-exceeded
+```
+
+Call at module scope in `stores/` — the write effect lives for the module lifetime by design.
+
 ## Anti-Patterns (DO NOT)
 
 - ❌ `html\`...\`` — use element functions instead (div, span, button...)


### PR DESCRIPTION
Closes #82.

## Summary

A \`Signal<T>\` backed by \`localStorage\` / \`sessionStorage\`. Blessed shape for the "every Whisq app hand-rolls guarded-localStorage-read with a write-effect" pattern that alpha.6 feedback flagged as friction against the project-structure rule forbidding import-time I/O.

\`\`\`ts
import { persistedSignal } from "@whisq/core/persistence";

export const todos = persistedSignal<Todo[]>("todos", []);
// Reads from localStorage on init, writes on change,
// SSR-safe, falls back to initial on parse/schema error,
// warns (not throws) on QuotaExceededError.
\`\`\`

## Scope decisions

- **Sub-path export** (\`@whisq/core/persistence\`), matching the \`@whisq/core/collections\` precedent for \`signalMap\`/\`signalSet\`. Zero bundle-cost for apps that don't use it — top-level \`@whisq/core\` stays at **5.25 KB gzipped, unchanged**. Sub-path itself: ~1.4 KB gzipped.
- **Module-scope intent, not component-scope.** The write effect lives for the module lifetime by design — documented in JSDoc and in the template CLAUDE.md. Callers who need disposable persistence can compose \`effect()\` + \`signal()\` directly.
- **Templates updated.** All four scaffolded \`CLAUDE.md\` files gain a "Persisted stores (opt-in, sub-path import)" block under Shared State so AI-generated code for new projects discovers the pattern without reinventing it.
- **Not in scope**: cross-tab \`storage\` event sync (post-v1), per-component persisted signals with dispose hooks (composition covers it), typed schema DSL (\`schema\` accepts any validator lambda — bring your own Zod/Valibot/etc).

## Behaviors worth leading with

- **SSR-safe.** \`typeof window === "undefined"\` → returns a plain signal at \`initial\`, no storage subscription.
- **Schema-validated.** Malformed JSON or a throwing \`schema(raw)\` → falls back to \`initial\` (no mount crash).
- **Quota-safe.** \`setItem\` failures → warns, keeps in-memory value — the app keeps working.
- **No-overwrite-on-init.** The first effect run doesn't write the read-back value back to storage (prevents stale-to-itself round-trip on hot reloads).

## Test plan

14 new tests in \`packages/core/src/__tests__/persistence.test.ts\`:

- [x] Returns initial when storage is empty
- [x] Loads previously persisted value on init
- [x] Handles complex JSON (arrays of objects)
- [x] Falls back on malformed JSON
- [x] Falls back when schema throws
- [x] Persists on \`.value =\` assignment
- [x] Persists on \`.update()\`
- [x] Does not overwrite storage with initial on init (no-op first run)
- [x] Warns but does not throw when storage rejects the write
- [x] Routes to \`sessionStorage\` when \`storage: "session"\`
- [x] Reads from \`sessionStorage\` on init
- [x] Custom \`serialize\` / \`deserialize\` for non-JSON types (\`Map\`)
- [x] SSR simulation: \`globalThis.window\` deleted → no crash, no storage writes
- [x] Participates in effect tracking like a normal signal

All 346 core tests pass. Top-level \`@whisq/core\` size unchanged at 5.25 KB gzipped (measurement uses production-stripped define). Sub-path \`persistence.js\` is 1.45 KB gzipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)