### PR TITLE
WHISQ-79: document the three reactive access shapes honestly

### DIFF
--- a/.changeset/access-shapes-canonical-doc.md
+++ b/.changeset/access-shapes-canonical-doc.md
@@ -1,0 +1,14 @@
+---
+"create-whisq": patch
+---
+
+Document the three reactive **access shapes** — signal `.value`, keyed-`each` item accessor `()`, `resource()` field `()` — honestly, without papering over the fact that the uniform-`() => value` claim describes the _wrapper_ but not what goes inside it. New canonical framework doc at [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
+Each scaffolded project's `CLAUDE.md` now carries a three-row table and a link to the canonical doc so AI coding assistants don't have to re-derive the rule from scratch on every prompt.
+
+Collateral updates:
+
+- `packages/core/docs/reactive-shapes.md` now cross-links to `access-shapes.md`, drops the "uniform framing undersells" opener (access-shapes.md owns that framing now), and updates shape #4 from "manual event pair" to `bindField()` (shipped in WHISQ-78) with the manual pair demoted to escape-hatch status.
+- Repo README bullet tightened from "uniform `() => value` reactive pattern" to "one reactive wrapper" with a link to the three read shapes.
+
+Closes #79. `@whisq/core` runtime unchanged — pure docs/positioning work.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Eight copy-paste prompts that exercise different surfaces of the framework (todo
 - **~5 KB gzipped** — complete framework (core: 5.08 KB).
 - **Zero build step** — runs as plain JavaScript, works with any bundler.
 - **100% TypeScript** — every element function fully typed, inferred through components.
-- **No footguns** — uniform `() => value` reactive pattern, no hooks rules, no dependency arrays, no stale-closure tax.
+- **One reactive wrapper** — every reactive position accepts `() => …`. No hooks rules, no dependency arrays, no stale-closure tax. ([Three read shapes inside the wrapper](packages/core/docs/access-shapes.md) — signal / keyed-each accessor / resource field.)
 
 ## Get started
 

--- a/packages/core/docs/access-shapes.md
+++ b/packages/core/docs/access-shapes.md
@@ -1,0 +1,128 @@
+# Access shapes — the three read patterns
+
+Canonical reference for **how you read** reactive values. Paired with [`reactive-shapes.md`](./reactive-shapes.md), which covers **where** reactive values are consumed (child / prop / `bind()` / `bindField()`). The two docs intersect at every working call site: pick where to put the reactive thing, then pick how to read from its source.
+
+---
+
+## Is "uniform `() => value`" actually uniform?
+
+The marketing line you'll see on whisq.dev is _"wrap reactive reads in `() => ...` everywhere."_ The **wrapper** is uniform — every reactive position in the API accepts `() => value`. What varies is **what goes inside the wrapper**, because Whisq exposes three different source shapes: plain signals, keyed-`each` accessors, and `resource()` fields.
+
+So the rule to remember is:
+
+> _Wrap reactive reads in `() => ...`. Unwrap the source:_
+> _- Signal → `.value`_
+> _- Keyed-`each` item or `resource()` field → `()` (it's already an accessor)._
+
+Two tokens to remember instead of one, but one consistent wrapper — and _zero_ hidden dependency arrays, stale closures, or re-render caveats.
+
+---
+
+## The three shapes at a glance
+
+| # | Source                    | Outside reactive context              | Inside reactive context (getter) |
+| - | ------------------------- | ------------------------------------- | -------------------------------- |
+| 1 | Plain signal              | `sig.value` / `sig.peek()`            | `() => sig.value`                |
+| 2 | Keyed `each()` item       | _(only exists inside the render fn)_  | `() => todo().text`              |
+| 3 | `resource()` field        | `users.loading()` / `users.data()` …  | `() => users.loading()`          |
+
+---
+
+## Shape 1 — Plain signal: `sig.value` / `() => sig.value`
+
+The source `signal()` returns is a property-shaped object. Read `.value` synchronously outside a reactive context. Inside one — a getter child, a getter prop, an `effect`, a `computed` body — wrap the same read in `() => ...`.
+
+```ts
+const count = signal(0);
+
+// Outside: property access. Not tracked.
+console.log(count.value);         // 0
+count.value = 5;                  // setter
+
+// Inside: wrapped in a getter so the surrounding effect re-runs.
+span(() => count.value);          // re-renders when count changes
+computed(() => count.value * 2);  // re-evaluates when count changes
+effect(() => log(count.value));   // re-runs when count changes
+
+// Peek — one-shot read without tracking (rare; use if you know you want it).
+const snap = count.peek();
+```
+
+- **Common mistake:** passing `count.value` directly as a child → reads once, not reactive.
+- **Writes:** `count.value = n` or `count.set(n)` or `count.update(fn)`.
+
+## Shape 2 — Keyed `each()` item: `todo()`
+
+Inside a keyed `each(items, (item) => …, { key })`, the `item` argument is an **accessor function** — you call it with `()` to get the current value. Wrapping the read in `() => todo().text` is what makes the child re-render when the array is replaced with new objects at the same key. Closing over `todo` and writing `.text` would be stale at the next array replacement (see WHISQ-62 for the fix that introduced this).
+
+```ts
+type Todo = { id: string; text: string; done: boolean };
+const todos = signal<Todo[]>([]);
+
+ul(
+  each(
+    () => todos.value,
+    (todo) =>
+      li(
+        span(() => todo().text),                      // reactive text via accessor
+        input({ type: "checkbox",
+          ...bindField(todos, todo, "done", { as: "checkbox" }) }),
+      ),
+    { key: (t) => t.id },
+  ),
+);
+```
+
+- **`todo` is a function, not an object** — `todo.text` is `undefined`; TypeScript flags this.
+- **Always wrap `todo()` in `() => ...`** for reactive reads — a bare `todo()` outside a getter is a one-shot snapshot.
+- **Writes** go through the source signal, not the accessor. Use `bindField(source, item, key)` for the common "update field on an item" case; fall back to a manual event pair for arbitrary mutations.
+
+Non-keyed `each(items, (item) => …)` (no `{ key }`) still passes plain `T`, because the whole list re-renders on every change — no stale-accessor risk. See [`reactive-shapes.md`](./reactive-shapes.md) for when to reach for `each` keyed vs. non-keyed.
+
+## Shape 3 — `resource()` field: `users.loading()`
+
+`resource(fetcher)` returns an object with function-shaped fields: `loading()`, `data()`, `error()`. They're accessor-shaped for the same reason keyed-each items are: reading through a function lets the reactive graph re-track on each read, so state transitions (loading → data, loading → error, data → refetching) update every consumer without re-plumbing.
+
+```ts
+const users = resource(() => fetch("/api/users").then((r) => r.json()));
+
+div(
+  when(() => users.loading(), () => p("Loading...")),
+  when(() => !!users.error(),
+    () => p({ class: "error" }, () => users.error()!.message)),
+  when(() => !!users.data(),
+    () => ul(each(() => users.data()!, (u) => li(u.name)))),
+);
+```
+
+- **Call the field** — `users.loading()` not `users.loading`.
+- **Wrap in `() =>`** at the reactive position — same pattern as signal reads.
+- **Nullability** — `data()` / `error()` return `undefined` until the fetch completes. Gate with `when(() => users.loading(), ...)` or non-null assert inside a guard.
+
+---
+
+## A note on what stays live across component boundaries
+
+All three access shapes survive being passed as component props, provided you pass **the accessor itself**, not a snapshot.
+
+```ts
+// Good: the child receives an accessor; reads stay live.
+const TodoItem = component((props: { todo: () => Todo }) => {
+  return li(() => props.todo().text);   // shape 2 — still works across boundary
+});
+
+// Bad: a snapshot captured once at parent setup; goes stale on array replacement.
+const TodoItem = component((props: { todo: Todo }) => {
+  return li(props.todo.text);           // frozen at first render
+});
+```
+
+This is the subject of [#80](https://github.com/whisqjs/whisq/issues/80) — the worked example for component-boundary handoffs. If you pass a bare signal (`{ count: sig }` rather than `{ count: () => sig.value }`), children read `.value` inside their own `() =>`. Both work; pick based on what the child needs to do with it.
+
+---
+
+## See also
+
+- [`reactive-shapes.md`](./reactive-shapes.md) — the four _positional_ shapes (where reactive values are consumed).
+- [`batch-semantics.md`](./batch-semantics.md) — how `batch()` sequences multiple writes.
+- [`ref.ts`](../src/ref.ts) — `ElementRef<T>` is a `Signal<T | null>`, so it follows shape 1 (`ref.value`, `() => ref.value`). Documented explicitly per WHISQ-63.

--- a/packages/core/docs/reactive-shapes.md
+++ b/packages/core/docs/reactive-shapes.md
@@ -1,23 +1,25 @@
 # Reactive shapes — the four patterns
 
-Canonical reference for the ways reactive data flows into the UI layer. Pinned here alongside [`batch-semantics.md`](./batch-semantics.md) so the docs site's LLM reference card can port this verbatim.
+Canonical reference for **where** reactive data flows into the UI layer. Pinned here alongside [`batch-semantics.md`](./batch-semantics.md) and [`access-shapes.md`](./access-shapes.md) so the docs site's LLM reference card can port this verbatim.
 
-Whisq's marketing thesis is "uniform value access" — every reactive position accepts `() => value`. That's true, but in practice there are **four subtly different shapes** you pick between. The "uniform" framing undersells the decision tree. This doc enumerates them and tells you when to use each.
+Every reactive position in the API accepts `() => value` — that wrapper is uniform. What you put inside the wrapper depends on the source ([`access-shapes.md`](./access-shapes.md) enumerates those). What you put the wrapper _at_ is one of the four positions below. Pick the access shape first, then the position shape, then wire the two together.
 
 ---
 
 ## The four shapes at a glance
 
-| #   | Shape                 | Example                                                            | Use when                                                                  |
-| --- | --------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------- |
-| 1   | Getter **child**      | `span(() => count.value)`                                          | A signal drives inline text or a nested element                           |
-| 2   | Getter **prop**       | `{ class: () => active.value ? "on" : "off" }`                     | A signal drives an element attribute / style / class                      |
-| 3   | **`bind()`** spread   | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input you own                    |
-| 4   | **Manual event pair** | `{ checked: () => todo().done, onchange: e => toggle(todo().id) }` | A field inside an item inside a signal-backed array (inside keyed `each`) |
+| # | Shape                     | Example                                                                            | Use when                                                                                |
+| - | ------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| 1 | Getter **child**          | `span(() => count.value)`                                                          | A signal drives inline text or a nested element                                         |
+| 2 | Getter **prop**           | `{ class: () => active.value ? "on" : "off" }`                                     | A signal drives an element attribute / style / class                                    |
+| 3 | **`bind()`** spread       | `input({ ...bind(email) })`                                                        | Two-way binding one signal into one form input you own                                  |
+| 4 | **`bindField()`** spread  | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | A field inside an item inside a signal-backed array (inside keyed `each`)               |
+
+Escape hatch: when `bindField()` doesn't fit (deep paths, custom write logic), fall back to a **manual event pair** — `{ checked: () => todo().done, onchange: e => toggle(todo().id) }`. Same idea, more code.
 
 A one-sentence decision flow:
 
-> _"Is the reactive value a single signal you own? → `bind()`. Is it a field inside an item inside a signal-held array? → manual pair, reading through the `each` accessor (`todo()`), not a closed-over reference."_
+> _"Is the reactive value a single signal you own? → `bind()`. Is it a field inside an item inside a signal-held array? → `bindField()`."_
 
 ---
 
@@ -78,19 +80,13 @@ Variants:
 - `bind(sig, { as: "checkbox" })` — binds the `checked` property
 - `bind(sig, { as: "radio", value: "admin" })` — binds a radio group member
 
-## Shape 4 — Manual event pair (inside keyed `each`)
+## Shape 4 — `bindField()` spread (inside keyed `each`)
 
-When the thing you want to update lives as a field on an item inside a signal-backed array, `bind()` doesn't apply. The array is the signal; the field isn't independently addressable. Write the reactive read and the writer separately, and go through the `each` accessor to avoid the stale-snapshot trap.
+When the writable is a field on an item inside a signal-backed array, `bind()` doesn't apply — the array is the signal and the field isn't independently addressable. `bindField()` covers this case with the same spread shape as `bind()`, producing an immutable array update on write and surviving keyed-`each` array replacement.
 
 ```ts
 type Todo = { id: string; text: string; done: boolean };
 const todos = signal<Todo[]>([]);
-
-function toggle(id: string) {
-  todos.value = todos.value.map((t) =>
-    t.id === id ? { ...t, done: !t.done } : t,
-  );
-}
 
 ul(
   each(
@@ -99,20 +95,30 @@ ul(
       li(
         input({
           type: "checkbox",
-          checked: () => todo().done, // reactive read via accessor
-          onchange: () => toggle(todo().id), // writer — reads latest id too
+          ...bindField(todos, todo, "done", { as: "checkbox" }),
         }),
         span(() => todo().text),
-        button({ onclick: () => remove(todo().id) }, "✕"),
       ),
     { key: (t) => t.id },
   ),
 );
 ```
 
-- **Key observation:** `todo` is an **accessor function** (post WHISQ-62) — call it as `todo()` to get the current item, and wrap in `() =>` for reactive reads. Closing over `todo` and writing `todo.done` would be stale the moment you replaced the array with new objects at the same key.
-- **Why the manual pair and not `bind()`:** `bind()` assumes a single signal with a single writable value. Here the writable is a field on an item; updating it requires re-mapping the whole array.
-- **Why not `bind()` on a per-item signal:** you'd have to materialise a signal per field per item. Doable but usually over-engineered for lists that fit in memory.
+- **`todo` is an accessor** (post WHISQ-62) — call it as `todo()` to read the current item. `bindField()` reads it internally to find the target item at write time.
+- **`keyBy` defaults to `t => t.id`** — supply `{ keyBy: (t) => t.uuid }` for items keyed on something else.
+- **Writes produce a new array** — `source.value` is replaced with an immutably-updated copy, so downstream `computed` / `effect` / keyed `each()` re-run correctly.
+
+When `bindField()` doesn't fit — deep nested paths, writes that touch multiple fields atomically, or custom logic like optimistic updates — fall back to the manual event pair:
+
+```ts
+input({
+  type: "checkbox",
+  checked: () => todo().done,                      // reactive read via accessor
+  onchange: () => toggle(todo().id),               // writer — reads latest id
+}),
+```
+
+The manual pair is strictly more powerful but also strictly more verbose. Prefer `bindField()` when it applies.
 
 ---
 
@@ -125,12 +131,14 @@ ul(
 | `input({ value: email.value, oninput: e => email.value = e.target.value })`   | Works but verbose; risks forgetting both sides.                                       | `input({ ...bind(email) })`                         |
 | `each(..., (todo) => li(() => todo.done ? ...))` (closes over a stale `todo`) | `todo` is the accessor — `.done` on a function is `undefined`. TypeScript flags this. | `li(() => todo().done ? ...)`                       |
 | `items.value.push(x)`                                                         | In-place mutation doesn't notify.                                                     | `items.value = [...items.value, x]`                 |
-| `bind(todo, { as: "checkbox" })` inside keyed `each`                          | `todo` is an accessor, not a signal with `.value`.                                    | Manual pair (shape 4).                              |
+| `bind(todo, { as: "checkbox" })` inside keyed `each`                          | `todo` is an accessor, not a signal with `.value`.                                    | `bindField(source, todo, "done", { as: "checkbox" })` (shape 4). |
 
 ---
 
 ## See also
 
-- [`each()` API reference](../src/elements.ts) — the `{ key }` callback now passes accessors (WHISQ-62).
-- [`bind()` API reference](../src/bind.ts) — exhaustive options.
+- [`access-shapes.md`](./access-shapes.md) — **how** you read reactive values (signal, keyed-each accessor, resource field). Paired with this doc.
+- [`each()` API reference](../src/elements.ts) — the `{ key }` callback passes accessors (WHISQ-62).
+- [`bind()` API reference](../src/bind.ts) — exhaustive options for single-signal inputs.
+- [`bindField()` API reference](../src/bindField.ts) — field-in-array-item binding (WHISQ-78).
 - [`batch-semantics.md`](./batch-semantics.md) — how `batch()` sequences effect flushes across multiple writes.

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -83,6 +83,18 @@ Four shapes cover every reactive position. The one-line decision flow: *"single 
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 
+#### Three ways to read inside a getter
+
+The `() => …` wrapper is uniform; what goes **inside** it depends on the source.
+
+| Source              | Read inside getter       |
+| ------------------- | ------------------------ |
+| Plain signal        | `() => sig.value`      |
+| Keyed `each` item | `() => todo().text`    |
+| `resource()` field | `() => users.loading()` |
+
+Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
 ### Events
 
 ```ts

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -83,6 +83,18 @@ Four shapes cover every reactive position. The one-line decision flow: *"single 
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 
+#### Three ways to read inside a getter
+
+The `() => …` wrapper is uniform; what goes **inside** it depends on the source.
+
+| Source              | Read inside getter       |
+| ------------------- | ------------------------ |
+| Plain signal        | `() => sig.value`      |
+| Keyed `each` item | `() => todo().text`    |
+| `resource()` field | `() => users.loading()` |
+
+Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
 ### Events
 
 ```ts

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -83,6 +83,18 @@ Four shapes cover every reactive position. The one-line decision flow: *"single 
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 
+#### Three ways to read inside a getter
+
+The `() => …` wrapper is uniform; what goes **inside** it depends on the source.
+
+| Source              | Read inside getter       |
+| ------------------- | ------------------------ |
+| Plain signal        | `() => sig.value`      |
+| Keyed `each` item | `() => todo().text`    |
+| `resource()` field | `() => users.loading()` |
+
+Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
 ### Events
 
 ```ts

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -83,6 +83,18 @@ Four shapes cover every reactive position. The one-line decision flow: *"single 
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 
+#### Three ways to read inside a getter
+
+The `() => …` wrapper is uniform; what goes **inside** it depends on the source.
+
+| Source              | Read inside getter       |
+| ------------------- | ------------------------ |
+| Plain signal        | `() => sig.value`      |
+| Keyed `each` item | `() => todo().text`    |
+| `resource()` field | `() => users.loading()` |
+
+Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
 ### Events
 
 ```ts


### PR DESCRIPTION
Closes #79.

## Summary

The alpha.6 feedback called out marketing drift: the framework ships with _\"wrap reactive reads in \`() => ...\`\"_ as its uniformity thesis, but in practice there are **three different things that go inside that wrapper** depending on the source:

| Source              | Read inside getter       |
| ------------------- | ------------------------ |
| Plain signal        | \`() => sig.value\`      |
| Keyed \`each\` item | \`() => todo().text\`    |
| \`resource()\` field | \`() => users.loading()\` |

The **wrapper is uniform**. What goes inside it isn't. This PR stops papering over that and documents both truths honestly.

## What shipped

- **New canonical doc** [\`packages/core/docs/access-shapes.md\`](packages/core/docs/access-shapes.md) — enumerates the three read shapes, tells the "is it really uniform?" story with both halves (yes: wrapper; no: innards), covers component-boundary handoff (foreshadows the fix for #80), and cross-links to \`reactive-shapes.md\`.
- **\`reactive-shapes.md\` brought up to date** — drops the "uniform framing undersells" opener (access-shapes.md owns that framing now), updates shape #4 from "manual event pair" to **\`bindField()\`** now that the helper exists (WHISQ-78). The manual pair is demoted to escape-hatch status.
- **All four template \`CLAUDE.md\` files** gain a "Three ways to read inside a getter" table right after the reactive-shapes section, with a link to \`access-shapes.md\` as the canonical source. Scaffolded AI-context stays lean; AI assistants get the rule from the first prompt.
- **Repo README** — bullet softened from _"uniform \`() => value\` reactive pattern"_ to _"one reactive wrapper"_ with a link to the three shapes.

## Scope decisions

- **Docs-only** — framework runtime unchanged. This ships Option A / D from the issue (docs fix now; evaluate making signals callable as a v0.2 design round separately).
- **No whisq.dev changes** — [whisqjs/whisq.dev#80](https://github.com/whisqjs/whisq.dev/issues/80) ("unify 'accessor' vs 'getter' terminology") tracks the docs-site port. The canonical framework doc here is the source of truth that site can copy from.
- **Not in scope**: making signals callable (Option B). That's a separate v0.2 API change with type-level implications.

## Test plan

- [x] Full monorepo test suite (555 tests across 9 packages) — all pass; no framework code changed.
- [x] All internal doc cross-links verified by hand (\`access-shapes.md\` ↔ \`reactive-shapes.md\`, README → framework doc, template CLAUDE.md → framework doc).
- [x] Changeset added — \`create-whisq\` patch (templates updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)