### PR TITLE
WHISQ-83: clarify match() as predicate chain, not pattern matching

### DIFF
--- a/.changeset/match-api-clarity.md
+++ b/.changeset/match-api-clarity.md
@@ -1,0 +1,16 @@
+---
+"@whisq/core": patch
+"create-whisq": patch
+---
+
+Clarify `match()` as a **predicate chain, not pattern matching**.
+
+Audit finding: `match()` has always had exactly one shape — variadic tuple branches `[predicate, render]` with an optional trailing bare render fn as fallback. The GPT-side alpha.6 feedback flagged "object vs tuple form" confusion, but no object form exists in the code; GPT was pattern-matching against Rust/Scala/Vue conventions where `match(value, { case1, case2 })` is common.
+
+Changes:
+
+- **JSDoc** now leads with _"Predicate-chain conditional renderer — not pattern matching"_ and calls out the canonical shape, first-true-wins ordering, and fallback-position rules explicitly.
+- **Dev-mode validation** (stripped in production builds) throws a `WhisqStructureError` when `match()` receives a plain object (the exact GPT-style confusion), a malformed tuple, or a fallback that isn't in the last position. Production bundle unchanged at 5.25 KB gzipped.
+- **Scaffolded templates** — all four `CLAUDE.md` files now include `match` in the canonical imports line and expand the "Conditional Rendering" section to document `when()` vs `match()` with a ready example. AI-generated code for new projects will reach for `match` instead of nesting `when()`.
+
+Closes #83.

--- a/packages/core/src/__tests__/match.test.ts
+++ b/packages/core/src/__tests__/match.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { signal } from "../reactive.js";
 import { div, p, span, match, mount } from "../elements.js";
+import { WhisqStructureError } from "../dev-errors.js";
 
 let container: HTMLElement;
 let dispose: () => void;
@@ -117,5 +118,64 @@ describe("match()", () => {
     const node = div(match(() => p("only the fallback")));
     dispose = mount(node, container);
     expect(container.querySelector("p")!.textContent).toBe("only the fallback");
+  });
+});
+
+// ── dev-mode validation (WHISQ-83) ─────────────────────────────────────────
+
+describe("match() — dev-mode input validation", () => {
+  it("throws WhisqStructureError for the object-dispatch shape GPT expected", () => {
+    expect(() => {
+      match(
+        // User reaching for pattern-matching on a value with an object map.
+        // `match` is a predicate chain — object dispatch isn't supported.
+        { loading: () => p("Loading") } as never,
+      );
+    }).toThrow(WhisqStructureError);
+
+    try {
+      match({ loading: () => p("Loading") } as never);
+    } catch (err) {
+      expect((err as Error).message).toMatch(/predicate chain/);
+      expect((err as WhisqStructureError).element).toBe("match");
+    }
+  });
+
+  it("throws when a branch tuple has the wrong arity or non-function members", () => {
+    expect(() => {
+      match([() => true, () => p("ok"), "extra"] as never);
+    }).toThrow(/branch tuple/);
+
+    expect(() => {
+      match([true, () => p("ok")] as never);
+    }).toThrow(/branch tuple/);
+  });
+
+  it("throws when the fallback is not in the last position", () => {
+    expect(() => {
+      match(
+        [() => true, () => p("a")],
+        () => p("fallback out of place"),
+        [() => false, () => p("b")],
+      );
+    }).toThrow(/fallback render.*last/);
+  });
+
+  it("does NOT throw for the canonical shape (regression guard)", () => {
+    expect(() => {
+      match(
+        [() => true, () => p("a")],
+        [() => false, () => p("b")],
+        () => p("fallback"),
+      );
+    }).not.toThrow();
+
+    expect(() => {
+      match([() => true, () => p("only")]);
+    }).not.toThrow();
+
+    expect(() => {
+      match();
+    }).not.toThrow();
   });
 });

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -564,10 +564,13 @@ type MatchRender = () => WhisqNode | string | null;
 type MatchBranch = readonly [() => boolean, MatchRender];
 
 /**
- * Multi-branch conditional renderer. Evaluates branches in order and renders
- * the first whose predicate returns truthy. An optional trailing fallback
- * (a bare render function, not wrapped in a tuple) renders when no branch
- * matches. Re-evaluates reactively like other children.
+ * **Predicate-chain** conditional renderer — _not_ pattern matching.
+ * Evaluates an `if / else-if` chain of `[() => predicate, () => render]` tuples
+ * and renders the first whose predicate returns truthy. An optional trailing
+ * **bare render function** (not a tuple) is the fallback, rendered only when
+ * every predicate is falsy. Returns `null` if no branch matches and no
+ * fallback is given. Re-evaluates reactively on any signal read inside the
+ * predicates.
  *
  * ```ts
  * div(
@@ -575,16 +578,63 @@ type MatchBranch = readonly [() => boolean, MatchRender];
  *     [() => users.loading(),    () => p("Loading...")],
  *     [() => !!users.error(),    () => p({ class: "error" }, users.error()!.message)],
  *     [() => !!users.data(),     () => List({ items: users.data()! })],
- *     () => p("No data yet."), // fallback
+ *     () => p("No data yet."), // fallback — bare fn, no tuple
  *   ),
  * )
  * ```
  *
- * First-true-wins: if two predicates are true, only the earlier branch renders.
+ * - **Shape**: every branch is a tuple `[() => boolean, () => WhisqNode | string | null]`.
+ *   No object form (e.g. `match({ loading: ..., error: ... })`) — this is a
+ *   predicate chain, not a value-dispatch table. For value dispatch, use a
+ *   plain getter with a switch: `() => { switch (status.value) { ... } }`.
+ * - **First-true-wins**: if two predicates are true, only the earlier branch
+ *   renders. Order branches from most specific to least.
+ * - **Fallback position**: bare render fn goes _last_. Putting it in the
+ *   middle is a bug — in dev mode it throws a `WhisqStructureError`.
  */
 export function match(...branches: MatchBranch[]): () => Child;
 export function match(...args: [...MatchBranch[], MatchRender]): () => Child;
 export function match(...args: Array<MatchBranch | MatchRender>): () => Child {
+  if (process.env.NODE_ENV !== "production") {
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      const isLast = i === args.length - 1;
+      if (Array.isArray(arg)) {
+        if (
+          arg.length !== 2 ||
+          typeof arg[0] !== "function" ||
+          typeof arg[1] !== "function"
+        ) {
+          throw new WhisqStructureError({
+            element: "match",
+            expected: "a branch tuple `[() => boolean, () => WhisqNode]`",
+            received: describeValue(arg),
+            hint: "Each branch must be a two-element tuple of functions. If you were reaching for pattern matching on a value, use `() => { switch (value.value) { ... } }` inside a getter child instead.",
+          });
+        }
+      } else if (typeof arg === "function") {
+        if (!isLast) {
+          throw new WhisqStructureError({
+            element: "match",
+            expected: "fallback render (bare function) to be the last argument",
+            received: `fallback at position ${i} of ${args.length}`,
+            hint: "Only one fallback is allowed, and it must come after every tuple branch. Reorder so the bare render function is last.",
+          });
+        }
+      } else {
+        throw new WhisqStructureError({
+          element: "match",
+          expected: "a branch tuple or a trailing fallback render function",
+          received: describeValue(arg),
+          hint:
+            typeof arg === "object" && arg !== null
+              ? "`match()` is a predicate chain, not a value-dispatch table. Plain objects like `{ loading: ..., error: ... }` aren't accepted — write tuples: `[() => state.value === 'loading', () => ...]`."
+              : "Each argument must be `[() => boolean, () => WhisqNode]` or (in the last position) a bare `() => WhisqNode` fallback.",
+        });
+      }
+    }
+  }
+
   const last = args[args.length - 1];
   const hasFallback = typeof last === "function";
   const fallback = hasFallback ? (last as MatchRender) : undefined;

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -12,7 +12,7 @@ import {
   div, span, h1, h2, h3, p, button, input, textarea, select, option,
   a, img, ul, ol, li, table, thead, tbody, tr, th, td, form, label,
   header, footer, nav, main, section, article, aside, strong, em,
-  h, raw, when, each, mount,
+  h, raw, when, match, each, mount,
   component, onMount, onCleanup, resource,
 } from "@whisq/core";
 ```
@@ -127,9 +127,10 @@ div({ onmouseenter: () => hovered.value = true })
 input({ onkeydown: (e) => e.key === "Enter" && submit() })
 ```
 
-### Conditional Rendering — when()
+### Conditional Rendering — when() / match()
 
 ```ts
+// when() — two-way (if / else). Third arg is the else branch.
 div(
   when(() => loggedIn.value,
     () => p("Welcome back!"),
@@ -141,7 +142,21 @@ div(
 div(
   () => isError.value ? p({ class: "error" }, "Something broke") : null,
 )
+
+// match() — predicate chain (if / else-if / ...). First-true-wins.
+// NOT pattern matching — branches are tuples [() => predicate, () => render].
+// Optional trailing bare function is the fallback.
+div(
+  match(
+    [() => users.loading(),  () => p("Loading...")],
+    [() => !!users.error(),  () => p({ class: "error" }, () => users.error().message)],
+    [() => !!users.data(),   () => List({ items: users.data() })],
+    () => p("No data yet."), // fallback — last position only
+  ),
+)
 ```
+
+Use `when()` for if/else, `match()` for if / else-if chains. For value dispatch (switch on a signal), use an inline getter: `() => { switch (status.value) { case "ready": return ReadyView(); /* ... */ } }` — that's a different shape from `match`.
 
 ### List Rendering — each()
 

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -12,7 +12,7 @@ import {
   div, span, h1, h2, h3, p, button, input, textarea, select, option,
   a, img, ul, ol, li, table, thead, tbody, tr, th, td, form, label,
   header, footer, nav, main, section, article, aside, strong, em,
-  h, raw, when, each, mount,
+  h, raw, when, match, each, mount,
   component, onMount, onCleanup, resource,
 } from "@whisq/core";
 ```
@@ -127,9 +127,10 @@ div({ onmouseenter: () => hovered.value = true })
 input({ onkeydown: (e) => e.key === "Enter" && submit() })
 ```
 
-### Conditional Rendering — when()
+### Conditional Rendering — when() / match()
 
 ```ts
+// when() — two-way (if / else). Third arg is the else branch.
 div(
   when(() => loggedIn.value,
     () => p("Welcome back!"),
@@ -141,7 +142,21 @@ div(
 div(
   () => isError.value ? p({ class: "error" }, "Something broke") : null,
 )
+
+// match() — predicate chain (if / else-if / ...). First-true-wins.
+// NOT pattern matching — branches are tuples [() => predicate, () => render].
+// Optional trailing bare function is the fallback.
+div(
+  match(
+    [() => users.loading(),  () => p("Loading...")],
+    [() => !!users.error(),  () => p({ class: "error" }, () => users.error().message)],
+    [() => !!users.data(),   () => List({ items: users.data() })],
+    () => p("No data yet."), // fallback — last position only
+  ),
+)
 ```
+
+Use `when()` for if/else, `match()` for if / else-if chains. For value dispatch (switch on a signal), use an inline getter: `() => { switch (status.value) { case "ready": return ReadyView(); /* ... */ } }` — that's a different shape from `match`.
 
 ### List Rendering — each()
 

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -12,7 +12,7 @@ import {
   div, span, h1, h2, h3, p, button, input, textarea, select, option,
   a, img, ul, ol, li, table, thead, tbody, tr, th, td, form, label,
   header, footer, nav, main, section, article, aside, strong, em,
-  h, raw, when, each, mount,
+  h, raw, when, match, each, mount,
   component, onMount, onCleanup, resource,
 } from "@whisq/core";
 ```
@@ -127,9 +127,10 @@ div({ onmouseenter: () => hovered.value = true })
 input({ onkeydown: (e) => e.key === "Enter" && submit() })
 ```
 
-### Conditional Rendering — when()
+### Conditional Rendering — when() / match()
 
 ```ts
+// when() — two-way (if / else). Third arg is the else branch.
 div(
   when(() => loggedIn.value,
     () => p("Welcome back!"),
@@ -141,7 +142,21 @@ div(
 div(
   () => isError.value ? p({ class: "error" }, "Something broke") : null,
 )
+
+// match() — predicate chain (if / else-if / ...). First-true-wins.
+// NOT pattern matching — branches are tuples [() => predicate, () => render].
+// Optional trailing bare function is the fallback.
+div(
+  match(
+    [() => users.loading(),  () => p("Loading...")],
+    [() => !!users.error(),  () => p({ class: "error" }, () => users.error().message)],
+    [() => !!users.data(),   () => List({ items: users.data() })],
+    () => p("No data yet."), // fallback — last position only
+  ),
+)
 ```
+
+Use `when()` for if/else, `match()` for if / else-if chains. For value dispatch (switch on a signal), use an inline getter: `() => { switch (status.value) { case "ready": return ReadyView(); /* ... */ } }` — that's a different shape from `match`.
 
 ### List Rendering — each()
 

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -12,7 +12,7 @@ import {
   div, span, h1, h2, h3, p, button, input, textarea, select, option,
   a, img, ul, ol, li, table, thead, tbody, tr, th, td, form, label,
   header, footer, nav, main, section, article, aside, strong, em,
-  h, raw, when, each, mount,
+  h, raw, when, match, each, mount,
   component, onMount, onCleanup, resource,
 } from "@whisq/core";
 ```
@@ -127,9 +127,10 @@ div({ onmouseenter: () => hovered.value = true })
 input({ onkeydown: (e) => e.key === "Enter" && submit() })
 ```
 
-### Conditional Rendering — when()
+### Conditional Rendering — when() / match()
 
 ```ts
+// when() — two-way (if / else). Third arg is the else branch.
 div(
   when(() => loggedIn.value,
     () => p("Welcome back!"),
@@ -141,7 +142,21 @@ div(
 div(
   () => isError.value ? p({ class: "error" }, "Something broke") : null,
 )
+
+// match() — predicate chain (if / else-if / ...). First-true-wins.
+// NOT pattern matching — branches are tuples [() => predicate, () => render].
+// Optional trailing bare function is the fallback.
+div(
+  match(
+    [() => users.loading(),  () => p("Loading...")],
+    [() => !!users.error(),  () => p({ class: "error" }, () => users.error().message)],
+    [() => !!users.data(),   () => List({ items: users.data() })],
+    () => p("No data yet."), // fallback — last position only
+  ),
+)
 ```
+
+Use `when()` for if/else, `match()` for if / else-if chains. For value dispatch (switch on a signal), use an inline getter: `() => { switch (status.value) { case "ready": return ReadyView(); /* ... */ } }` — that's a different shape from `match`.
 
 ### List Rendering — each()
 


### PR DESCRIPTION
Closes #83.

## Summary

Audit finding: \`match()\` has always had exactly one shape — variadic tuple branches \`[predicate, render]\` with an optional trailing bare render fn as fallback. The GPT-side alpha.6 feedback flagged "object vs tuple form" confusion, but no object form exists in the code; GPT was pattern-matching against Rust/Scala/Vue conventions where \`match(value, { case1, case2 })\` is common.

Full [audit comment on the issue](https://github.com/whisqjs/whisq/issues/83#issuecomment-4289450397).

## What shipped

- **JSDoc tightened** — leads with _"Predicate-chain conditional renderer — not pattern matching"_; calls out canonical shape, first-true-wins ordering, and fallback-position rules explicitly.
- **Dev-mode validation** via \`WhisqStructureError\` (from WHISQ-81). Catches:
  - The exact GPT-style mistake — plain object dispatch table: \`match({ loading: ..., error: ... })\` → "plain objects like \`{ loading: ..., error: ... }\` aren't accepted; match() is a predicate chain, not a value-dispatch table."
  - Malformed tuple: wrong arity, non-function members.
  - Out-of-place fallback: bare render fn not in the last position.
  All stripped in production — size unchanged at 5.25 KB gzipped.
- **Scaffolded templates** — all four \`CLAUDE.md\` files:
  - \`match\` now appears in the canonical imports line (was missing entirely — AI reading scaffolded project context had no way to discover it).
  - "Conditional Rendering" section expands to document \`when()\` vs \`match()\` side-by-side with a ready-to-use tri-state example (loading/error/data). Also points at inline getter-switch for value dispatch, steering away from match-as-pattern-match.

## Scope decisions

- **Kept the current signature** — no breaking API change. The overload structure (\`match(...branches)\` / \`match(...branches, fallback)\`) works; the confusion was docs-/discoverability-level.
- **No new form added** — deliberately not adding an object-dispatch overload. That's a different primitive (value switch) and should be composed with an inline getter + \`switch\`, not bolted onto \`match\`.

## Test plan

Four new tests in \`match.test.ts\`:

- [x] Throws \`WhisqStructureError\` for the object-dispatch shape GPT expected (canonical GPT mistake)
- [x] Throws for malformed tuples (wrong arity, non-function members)
- [x] Throws when fallback is not in the last position
- [x] Regression guard: canonical shapes don't throw (three variants)

Plus all 9 pre-existing \`match()\` tests still pass. Monorepo full suite (559 tests across 9 packages) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)