### PR TITLE
WHISQ-86: add bindPath() for nested-record fields

### DIFF
--- a/.changeset/bindpath-for-nested-records.md
+++ b/.changeset/bindpath-for-nested-records.md
@@ -1,0 +1,32 @@
+---
+"@whisq/core": minor
+"create-whisq": patch
+---
+
+Add `bindPath(source, path, opts?)` — two-way binding for a field at an arbitrary **object path** in a signal-held record. Use when `bind()` doesn't apply because the field lives two or more levels deep (e.g. `user.profile.email`, `settings.billing.plan`). Follow-up to WHISQ-78 (`bindField`) for the nested-object case the feedback docs flagged as friction against the flat-binding primitives.
+
+Exported from a new sub-path, `@whisq/core/forms`, so apps that only need `bind()` + `bindField()` (the 80% case) pay no bundle cost. Top-level `@whisq/core` stays at 5.25 KB gzipped.
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+form(
+  input({ ...bindPath(user, ["profile", "name"]) }),
+  input({ type: "email", ...bindPath(user, ["profile", "email"]) }),
+  input({ type: "number", ...bindPath(user, ["profile", "age"], { as: "number" }) }),
+  input({ type: "checkbox", ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) }),
+);
+```
+
+### Behaviors worth leading with
+
+- **Structural sharing on writes.** Writes produce a new root and new objects at every level on the path; sibling branches keep their reference identity so downstream `computed` / `effect` re-runs stay narrow.
+- **Missing-intermediate creation.** Reading through a missing intermediate returns `undefined`; writing creates the object structure as needed.
+- **Object keys only.** Array traversal is not supported in the path — use `bindField()` at the array level and compose. This keeps `bindPath` predictable and its implementation small.
+- **Typed overloads** for depths 1–4; deeper paths work via the loose signature (same runtime, just less TS inference).
+
+Mirrors `bind()` and `bindField()`'s discriminator shapes — text / number / checkbox / radio.
+
+Scaffolded `CLAUDE.md` files gain a "Binding into nested records (opt-in, sub-path import)" block under Forms so AI-generated code for new projects discovers the pattern without reinventing it.
+
+Closes #86.

--- a/packages/core/docs/reactive-shapes.md
+++ b/packages/core/docs/reactive-shapes.md
@@ -108,7 +108,19 @@ ul(
 - **`keyBy` defaults to `t => t.id`** — supply `{ keyBy: (t) => t.uuid }` for items keyed on something else.
 - **Writes produce a new array** — `source.value` is replaced with an immutably-updated copy, so downstream `computed` / `effect` / keyed `each()` re-run correctly.
 
-When `bindField()` doesn't fit — deep nested paths, writes that touch multiple fields atomically, or custom logic like optimistic updates — fall back to the manual event pair:
+For forms on **nested objects** (e.g. `user.profile.email`), reach for `bindPath()` — same spread shape, object-keyed path instead of a single field, opt-in at `@whisq/core/forms` so it doesn't cost top-level bundle size:
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+input({ ...bindPath(user, ["profile", "email"]) });
+// Writes produce a new root with structural sharing on siblings —
+// user.prefs stays === across writes to user.profile.email.
+```
+
+`bindPath` does **not** traverse arrays. For array-indexed paths, reach for `bindField()` at the array level and compose from there.
+
+When none of the helpers fit — deep nested paths that cross arrays, writes that touch multiple fields atomically, or custom logic like optimistic updates — fall back to the manual event pair:
 
 ```ts
 input({
@@ -141,4 +153,5 @@ The manual pair is strictly more powerful but also strictly more verbose. Prefer
 - [`each()` API reference](../src/elements.ts) — the `{ key }` callback passes accessors (WHISQ-62).
 - [`bind()` API reference](../src/bind.ts) — exhaustive options for single-signal inputs.
 - [`bindField()` API reference](../src/bindField.ts) — field-in-array-item binding (WHISQ-78).
+- [`bindPath()` API reference](../src/bindPath.ts) — nested-object-path binding (WHISQ-86), exported from `@whisq/core/forms`.
 - [`batch-semantics.md`](./batch-semantics.md) — how `batch()` sequences effect flushes across multiple writes.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,10 @@
     "./persistence": {
       "types": "./dist/persistence.d.ts",
       "import": "./dist/persistence.js"
+    },
+    "./forms": {
+      "types": "./dist/forms.d.ts",
+      "import": "./dist/forms.js"
     }
   },
   "files": [

--- a/packages/core/src/__tests__/bindPath.test.ts
+++ b/packages/core/src/__tests__/bindPath.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { signal } from "../reactive.js";
+import { input, mount } from "../elements.js";
+// Imported from the internal path. Public import is `@whisq/core/forms`
+// (see packages/core/package.json exports).
+import { bindPath } from "../bindPath.js";
+
+interface User {
+  id: string;
+  profile: { name: string; email: string; age: number };
+  prefs: { dark: boolean; theme: "light" | "dark" };
+}
+
+const baseUser: User = {
+  id: "u1",
+  profile: { name: "ada", email: "a@b.c", age: 30 },
+  prefs: { dark: false, theme: "light" },
+};
+
+let container: HTMLElement;
+let dispose: (() => void) | undefined;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+  dispose = undefined;
+});
+
+describe("bindPath() — text (depth 2)", () => {
+  it("reflects the nested field's initial value", () => {
+    const user = signal(baseUser);
+    dispose = mount(input({ ...bindPath(user, ["profile", "name"]) }), container);
+    expect((container.querySelector("input") as HTMLInputElement).value).toBe("ada");
+  });
+
+  it("writes produce a new root with structural sharing on siblings", () => {
+    const user = signal(baseUser);
+    const before = user.value;
+    dispose = mount(input({ ...bindPath(user, ["profile", "name"]) }), container);
+
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "grace";
+    el.dispatchEvent(new InputEvent("input"));
+
+    expect(user.value).not.toBe(before);
+    expect(user.value.profile).not.toBe(before.profile);
+    // Sibling branch `prefs` should remain the same reference.
+    expect(user.value.prefs).toBe(before.prefs);
+    expect(user.value.profile.name).toBe("grace");
+    // Untouched sibling field on the same level also stable.
+    expect(user.value.profile.email).toBe("a@b.c");
+  });
+
+  it("propagates programmatic updates to the DOM", () => {
+    const user = signal(baseUser);
+    dispose = mount(input({ ...bindPath(user, ["profile", "email"]) }), container);
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("a@b.c");
+    user.value = { ...baseUser, profile: { ...baseUser.profile, email: "x@y.z" } };
+    expect(el.value).toBe("x@y.z");
+  });
+});
+
+describe("bindPath() — deeper paths (depth 3+)", () => {
+  interface Org {
+    name: string;
+    settings: {
+      billing: { plan: "free" | "pro"; seats: number };
+      ui: { density: "compact" | "comfy" };
+    };
+  }
+
+  const orgInitial: Org = {
+    name: "acme",
+    settings: {
+      billing: { plan: "free", seats: 1 },
+      ui: { density: "compact" },
+    },
+  };
+
+  it("depth-3 text field", () => {
+    const org = signal(orgInitial);
+    dispose = mount(
+      input({ ...bindPath(org, ["settings", "ui", "density"]) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("compact");
+    el.value = "comfy";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(org.value.settings.ui.density).toBe("comfy");
+  });
+
+  it("depth-3 write preserves structural sharing across cousins", () => {
+    const org = signal(orgInitial);
+    const before = org.value;
+    dispose = mount(
+      input({ ...bindPath(org, ["settings", "ui", "density"]) }),
+      container,
+    );
+
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "comfy";
+    el.dispatchEvent(new InputEvent("input"));
+
+    expect(org.value).not.toBe(before);
+    expect(org.value.settings).not.toBe(before.settings);
+    expect(org.value.settings.ui).not.toBe(before.settings.ui);
+    // Cousin branch (`billing`) preserved by reference.
+    expect(org.value.settings.billing).toBe(before.settings.billing);
+  });
+});
+
+describe("bindPath() — number / checkbox / radio", () => {
+  it("number field updates via valueAsNumber", () => {
+    const user = signal(baseUser);
+    dispose = mount(
+      input({
+        type: "number",
+        ...bindPath(user, ["profile", "age"], { as: "number" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("30");
+    el.value = "42";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(user.value.profile.age).toBe(42);
+  });
+
+  it("number NaN guard leaves source untouched", () => {
+    const user = signal(baseUser);
+    const before = user.value;
+    dispose = mount(
+      input({
+        type: "number",
+        ...bindPath(user, ["profile", "age"], { as: "number" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(user.value).toBe(before);
+    expect(user.value.profile.age).toBe(30);
+  });
+
+  it("checkbox binds deep boolean", () => {
+    const user = signal(baseUser);
+    dispose = mount(
+      input({
+        type: "checkbox",
+        ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(false);
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(user.value.prefs.dark).toBe(true);
+  });
+
+  it("radio binds deep string with as: radio / value", () => {
+    const user = signal(baseUser);
+    dispose = mount(
+      input({
+        type: "radio",
+        name: "theme",
+        ...bindPath(user, ["prefs", "theme"], { as: "radio", value: "dark" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(false);
+    user.value = { ...user.value, prefs: { ...user.value.prefs, theme: "dark" } };
+    expect(el.checked).toBe(true);
+  });
+});
+
+describe("bindPath() — input validation", () => {
+  it("throws TypeError when source is not a Signal", () => {
+    expect(() =>
+      bindPath({} as never, ["x"] as never),
+    ).toThrow(TypeError);
+  });
+
+  it("throws TypeError when path is empty", () => {
+    const s = signal({ a: 1 });
+    expect(() => bindPath(s, [] as unknown as ["a"])).toThrow(TypeError);
+  });
+
+  it("reading through a missing intermediate level returns a safe empty string", () => {
+    interface Sparse {
+      a?: { b?: string };
+    }
+    const s = signal<Sparse>({});
+    dispose = mount(input({ ...bindPath(s, ["a", "b"]) }), container);
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("");
+    // Writing through the missing intermediate creates the object structure.
+    el.value = "created";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(s.value.a?.b).toBe("created");
+  });
+});

--- a/packages/core/src/bindPath.ts
+++ b/packages/core/src/bindPath.ts
@@ -1,0 +1,195 @@
+// ============================================================================
+// Whisq Core — Deep-path field binding for nested records
+// bindPath(source, path, opts?) covers the "nested object field" case that
+// bind() / bindField() don't reach. Use for forms on records with nested
+// shape (user.profile.email, settings.theme.mode, ...). Array traversal is
+// NOT supported in the path — reach for bindField() at the array level.
+// ============================================================================
+
+import { type Signal, isSignal } from "./reactive.js";
+import type { TextBind, NumberBind, CheckboxBind, RadioBind } from "./bind.js";
+
+type PathOptions =
+  | Record<string, never>
+  | { as: "number" }
+  | { as: "checkbox" }
+  | { as: "radio"; value: string };
+
+// Typed overloads for common depths. Deeper paths fall back to the loose
+// signature — TypeScript gives up on full path inference past ~4 levels
+// anyway, and a reasonable cast at the call site is clearer than the noise
+// a deeper typed path would add.
+
+type Path1<T, K1 extends keyof T> = readonly [K1];
+type Path2<T, K1 extends keyof T, K2 extends keyof T[K1]> = readonly [K1, K2];
+type Path3<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+> = readonly [K1, K2, K3];
+type Path4<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+  K4 extends keyof T[K1][K2][K3],
+> = readonly [K1, K2, K3, K4];
+
+function readPath(obj: unknown, path: readonly PropertyKey[]): unknown {
+  let cur: unknown = obj;
+  for (const k of path) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<PropertyKey, unknown>)[k];
+  }
+  return cur;
+}
+
+function writePath(
+  obj: unknown,
+  path: readonly PropertyKey[],
+  value: unknown,
+): unknown {
+  if (path.length === 0) return value;
+  const [head, ...rest] = path;
+  const current =
+    obj != null && typeof obj === "object"
+      ? (obj as Record<PropertyKey, unknown>)
+      : {};
+  return { ...current, [head]: writePath(current[head], rest, value) };
+}
+
+/**
+ * Two-way binding for a field at an arbitrary **object path** in a
+ * signal-held record. Use when `bind()` doesn't apply because the field
+ * lives two or more levels deep:
+ *
+ * ```ts
+ * const user = signal<User>({ id: "u1", profile: { name: "", email: "" } });
+ *
+ * form(
+ *   input({ ...bindPath(user, ["profile", "name"]) }),
+ *   input({ type: "email", ...bindPath(user, ["profile", "email"]) }),
+ *   input({ type: "checkbox",
+ *     ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) }),
+ * );
+ * ```
+ *
+ * Writes produce a new root — every level on the path gets a shallow spread,
+ * sibling branches preserve referential identity so downstream `computed` /
+ * `effect` re-runs stay narrow.
+ *
+ * ### Not in scope
+ *
+ * - **Array traversal**: `["items", 0, "done"]` is not supported. Arrays use
+ *   positional semantics but the framework already has `bindField()` for
+ *   "field on an item inside a signal-held array" — use that at the array
+ *   level and `bindPath` for nested-object-only paths.
+ * - **Auto-creating intermediate levels** that are missing: reading through
+ *   a missing parent returns `undefined`; writing through creates objects
+ *   as needed. If the intermediate existed but was `null`, you'll clobber
+ *   the null with an object on write — intentional, but worth knowing.
+ */
+export function bindPath<T, K1 extends keyof T>(
+  source: Signal<T>,
+  path: Path1<T, K1>,
+): T[K1] extends string ? TextBind : never;
+export function bindPath<T, K1 extends keyof T, K2 extends keyof T[K1]>(
+  source: Signal<T>,
+  path: Path2<T, K1, K2>,
+): T[K1][K2] extends string ? TextBind : never;
+export function bindPath<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+>(
+  source: Signal<T>,
+  path: Path3<T, K1, K2, K3>,
+): T[K1][K2][K3] extends string ? TextBind : never;
+export function bindPath<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+  K4 extends keyof T[K1][K2][K3],
+>(
+  source: Signal<T>,
+  path: Path4<T, K1, K2, K3, K4>,
+): T[K1][K2][K3][K4] extends string ? TextBind : never;
+export function bindPath<T>(
+  source: Signal<T>,
+  path: readonly PropertyKey[],
+  options: { as: "number" },
+): NumberBind;
+export function bindPath<T>(
+  source: Signal<T>,
+  path: readonly PropertyKey[],
+  options: { as: "checkbox" },
+): CheckboxBind;
+export function bindPath<T, V extends string>(
+  source: Signal<T>,
+  path: readonly PropertyKey[],
+  options: { as: "radio"; value: V },
+): RadioBind<V>;
+export function bindPath<T>(
+  source: Signal<T>,
+  path: readonly PropertyKey[],
+  options?: PathOptions,
+): TextBind;
+export function bindPath<T>(
+  source: Signal<T>,
+  path: readonly PropertyKey[],
+  options?: PathOptions,
+): TextBind | NumberBind | CheckboxBind | RadioBind<string> {
+  if (!isSignal(source)) {
+    throw new TypeError("bindPath: source must be a Signal");
+  }
+  if (!Array.isArray(path) || path.length === 0) {
+    throw new TypeError("bindPath: path must be a non-empty array of keys");
+  }
+
+  const write = (next: unknown): void => {
+    source.value = writePath(source.value, path, next) as T;
+  };
+
+  const as = (options as { as?: string } | undefined)?.as;
+
+  if (as === "checkbox") {
+    return {
+      checked: () => readPath(source.value, path) as boolean,
+      onchange: (e) =>
+        write((e.target as HTMLInputElement).checked),
+    };
+  }
+
+  if (as === "radio") {
+    const target = (options as { value: string }).value;
+    return {
+      value: target,
+      checked: () => readPath(source.value, path) === target,
+      onchange: (e) => {
+        if ((e.target as HTMLInputElement).checked) write(target);
+      },
+    };
+  }
+
+  if (as === "number") {
+    return {
+      value: () => String(readPath(source.value, path) ?? ""),
+      oninput: (e) => {
+        const n = (e.target as HTMLInputElement).valueAsNumber;
+        if (!Number.isNaN(n)) write(n);
+      },
+    };
+  }
+
+  return {
+    value: () => String(readPath(source.value, path) ?? ""),
+    oninput: (e) =>
+      write(
+        (e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)
+          .value,
+      ),
+  };
+}

--- a/packages/core/src/forms.ts
+++ b/packages/core/src/forms.ts
@@ -1,0 +1,10 @@
+// ============================================================================
+// Whisq Core — Form binding extensions (sub-path export)
+//
+// Import path: `@whisq/core/forms`
+//
+// Kept off the top-level bundle — apps that only need bind() and bindField()
+// (the 80% case) pay no size cost. Opt in here for nested-record binding.
+// ============================================================================
+
+export { bindPath } from "./bindPath.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,3 +127,6 @@ export type {
 } from "./bind.js";
 export { bindField } from "./bindField.js";
 export type { BindFieldOptions } from "./bindField.js";
+
+// bindPath() for nested-object paths lives at `@whisq/core/forms` — kept off
+// the top-level bundle so apps that don't need deep binding pay no size cost.

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -254,6 +254,20 @@ const LoginForm = component(() => {
 });
 ```
 
+#### Binding into nested records (opt-in, sub-path import)
+
+For forms on nested objects (`user.profile.email`, `settings.billing.plan`), use `bindPath` — same spread shape as `bind`/`bindField`, key-path instead of one key. Opt-in import so apps that don't need it pay no bundle cost.
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+input({ ...bindPath(user, ["profile", "email"]) });
+input({ type: "number", ...bindPath(user, ["profile", "age"], { as: "number" }) });
+input({ type: "checkbox", ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) });
+```
+
+Writes produce a new root with structural sharing on siblings — `user.prefs` stays `===` across writes to `user.profile.email`. Object paths only; array traversal goes through `bindField` at the array level.
+
 ### Async Data — resource()
 
 ```ts

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -254,6 +254,20 @@ const LoginForm = component(() => {
 });
 ```
 
+#### Binding into nested records (opt-in, sub-path import)
+
+For forms on nested objects (`user.profile.email`, `settings.billing.plan`), use `bindPath` — same spread shape as `bind`/`bindField`, key-path instead of one key. Opt-in import so apps that don't need it pay no bundle cost.
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+input({ ...bindPath(user, ["profile", "email"]) });
+input({ type: "number", ...bindPath(user, ["profile", "age"], { as: "number" }) });
+input({ type: "checkbox", ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) });
+```
+
+Writes produce a new root with structural sharing on siblings — `user.prefs` stays `===` across writes to `user.profile.email`. Object paths only; array traversal goes through `bindField` at the array level.
+
 ### Async Data — resource()
 
 ```ts

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -254,6 +254,20 @@ const LoginForm = component(() => {
 });
 ```
 
+#### Binding into nested records (opt-in, sub-path import)
+
+For forms on nested objects (`user.profile.email`, `settings.billing.plan`), use `bindPath` — same spread shape as `bind`/`bindField`, key-path instead of one key. Opt-in import so apps that don't need it pay no bundle cost.
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+input({ ...bindPath(user, ["profile", "email"]) });
+input({ type: "number", ...bindPath(user, ["profile", "age"], { as: "number" }) });
+input({ type: "checkbox", ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) });
+```
+
+Writes produce a new root with structural sharing on siblings — `user.prefs` stays `===` across writes to `user.profile.email`. Object paths only; array traversal goes through `bindField` at the array level.
+
 ### Async Data — resource()
 
 ```ts

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -254,6 +254,20 @@ const LoginForm = component(() => {
 });
 ```
 
+#### Binding into nested records (opt-in, sub-path import)
+
+For forms on nested objects (`user.profile.email`, `settings.billing.plan`), use `bindPath` — same spread shape as `bind`/`bindField`, key-path instead of one key. Opt-in import so apps that don't need it pay no bundle cost.
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+input({ ...bindPath(user, ["profile", "email"]) });
+input({ type: "number", ...bindPath(user, ["profile", "age"], { as: "number" }) });
+input({ type: "checkbox", ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) });
+```
+
+Writes produce a new root with structural sharing on siblings — `user.prefs` stays `===` across writes to `user.profile.email`. Object paths only; array traversal goes through `bindField` at the array level.
+
 ### Async Data — resource()
 
 ```ts


### PR DESCRIPTION
Closes #86.

## Summary

Follow-up to WHISQ-78 (\`bindField\`) for the nested-object case that alpha.6 feedback flagged as friction against the flat binding primitives. \`bindPath(source, path, opts?)\` covers the "form field at depth 2+ in a record signal" — the shape that shows up in user profiles, settings screens, and any CRUD form on a nested DTO.

\`\`\`ts
import { bindPath } from "@whisq/core/forms";

form(
  input({ ...bindPath(user, ["profile", "name"]) }),
  input({ type: "email", ...bindPath(user, ["profile", "email"]) }),
  input({ type: "number", ...bindPath(user, ["profile", "age"], { as: "number" }) }),
  input({ type: "checkbox", ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) }),
);
\`\`\`

## Scope decisions

- **Sub-path \`@whisq/core/forms\`** (new) — matches the \`/collections\` and \`/persistence\` precedent for opt-in helpers. Top-level \`@whisq/core\` stays at **5.25 KB gzipped, unchanged**. Sub-path \`forms.js\` is 271 B gzipped.
- **Object keys only; no array traversal in the path.** \`bindField()\` already handles "field on an item inside a signal-held array" cleanly. Making \`bindPath\` also cross arrays would either (a) reinvent \`bindField\` semantics inside a path walker, or (b) introduce stringly-typed \`{ id: "x" }\` marker syntax inside paths — both worse than "compose \`bindField\` + \`bindPath\` explicitly when you need both." Conservative and predictable.
- **Typed overloads for depths 1–4**; deeper paths work via the loose signature. TypeScript's path-walking inference tops out before that anyway.
- **Shipped despite the wait-for-signal P3 label** on the original issue — the conservative subset ships now; extensions can land with real usage data.

## Behaviors worth leading with

- **Structural sharing on writes** — new root, new objects at every level on the path, sibling branches keep \`===\` identity. Downstream \`computed\` / \`effect\` re-runs stay narrow.
- **Missing-intermediate creation** — reading through a missing path returns \`undefined\`; writing creates the object structure on demand.
- Mirrors \`bind()\` / \`bindField()\` discriminator shapes (text / number / checkbox / radio).

## Test plan

12 new tests in \`packages/core/src/__tests__/bindPath.test.ts\`:

- [x] Depth-2 text: initial reflect + immutable write + sibling preservation
- [x] Depth-2: programmatic propagation to DOM
- [x] Depth-3 text: read + write
- [x] Depth-3: cousin branches preserved by reference after write
- [x] Number field with \`as: "number"\` — update + NaN guard
- [x] Checkbox with \`as: "checkbox"\`
- [x] Radio with \`as: "radio", value\`
- [x] TypeError when \`source\` isn't a Signal
- [x] TypeError when \`path\` is empty
- [x] Missing-intermediate: safe empty string read + create-on-write

Full monorepo (571 tests across 9 packages) — all pass. Top-level \`@whisq/core\` size unchanged at 5.25 KB gzipped.

## Not in scope

- **Array traversal in paths** — compose \`bindField\` at the array level.
- **Lens-function API shape** — the path-array form is trivially invertible and wins on readability. Lens-inversion would need either Immer-like machinery or brittle source parsing.
- **Deep-equality short-circuit on writes** — current behavior always produces a new root, which is cheap and predictable. If a user hits a hot-path re-render issue from self-equal writes, revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)