### PR TITLE
Release v0.1.0-alpha.7

### DIFF
--- a/.changeset/access-shapes-canonical-doc.md
+++ b/.changeset/access-shapes-canonical-doc.md
@@ -1,0 +1,14 @@
+---
+"create-whisq": patch
+---
+
+Document the three reactive **access shapes** — signal `.value`, keyed-`each` item accessor `()`, `resource()` field `()` — honestly, without papering over the fact that the uniform-`() => value` claim describes the _wrapper_ but not what goes inside it. New canonical framework doc at [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
+Each scaffolded project's `CLAUDE.md` now carries a three-row table and a link to the canonical doc so AI coding assistants don't have to re-derive the rule from scratch on every prompt.
+
+Collateral updates:
+
+- `packages/core/docs/reactive-shapes.md` now cross-links to `access-shapes.md`, drops the "uniform framing undersells" opener (access-shapes.md owns that framing now), and updates shape #4 from "manual event pair" to `bindField()` (shipped in WHISQ-78) with the manual pair demoted to escape-hatch status.
+- Repo README bullet tightened from "uniform `() => value` reactive pattern" to "one reactive wrapper" with a link to the three read shapes.
+
+Closes #79. `@whisq/core` runtime unchanged — pure docs/positioning work.

--- a/.changeset/accessor-boundaries-docs.md
+++ b/.changeset/accessor-boundaries-docs.md
@@ -1,0 +1,16 @@
+---
+"create-whisq": patch
+---
+
+Document **accessors across component boundaries** — the silent-staleness bug that alpha.6 feedback called the single most uncertain moment in building a todo app.
+
+[`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md) gains a full "Accessors across component boundaries" section with:
+
+- A worked parent + child example where the child takes `{ todo: () => Todo }` and reads `props.todo()` inside getters.
+- A counter-example showing the exact snapshot-at-setup pattern that silently breaks (row renders, never updates, stale `.id` after reorder).
+- A variant table mapping parent source type (`Signal<T>`, keyed-`each` accessor, `resource()` field) to prop shapes and child read patterns.
+- A mistakes table naming the four most common footguns (calling the accessor at the parent, snapshotting inside child setup, destructuring props, passing `.value[0]`).
+
+All four scaffolded `CLAUDE.md` files gain the short version inline — parent + child skeleton + the "don't snapshot" rule — with a link to the canonical doc for depth.
+
+Closes #80. Runtime-warning AC deferred to a P3 follow-up — static analysis (eslint / tsc) is a better fit than runtime instrumentation once real usage demands detection.

--- a/.changeset/bindfield-for-array-items.md
+++ b/.changeset/bindfield-for-array-items.md
@@ -1,0 +1,24 @@
+---
+"@whisq/core": minor
+"create-whisq": patch
+---
+
+Add `bindField(source, item, key, opts?)` — two-way binding for a field on an item inside a signal-held array. Closes the ergonomic gap `bind()` didn't reach: the most common UI shape in real applications (todos, carts, forms-with-rows, CRUD grids).
+
+```ts
+each(() => todos.value, (todo) =>
+  input({
+    type: "checkbox",
+    ...bindField(todos, todo, "done", { as: "checkbox" }),
+  }),
+  { key: (t) => t.id },
+)
+```
+
+Mirrors `bind()`'s discriminator shapes (text / number / checkbox / radio). `keyBy` identifies which item to rewrite — defaults to `t => t.id`; override for items keyed on something else. Writes produce an immutable array update so downstream `computed` / `effect` re-run correctly.
+
+All four scaffolded templates' `CLAUDE.md` reactive-shapes tables now lead with `bindField()` for this case instead of the manual event pair. The decision flow also updates to *"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."*
+
+`@whisq/core` size budget raised from 5 KB to 5.5 KB gzipped (current: 5.08 KB). The README updates "Under 5 KB gzipped" → "~5 KB gzipped" to match. `bindField` is exported from the top-level `@whisq/core` so LLMs and autocompletion discover it alongside `bind()`.
+
+Closes #78.

--- a/.changeset/bindpath-for-nested-records.md
+++ b/.changeset/bindpath-for-nested-records.md
@@ -1,0 +1,32 @@
+---
+"@whisq/core": minor
+"create-whisq": patch
+---
+
+Add `bindPath(source, path, opts?)` — two-way binding for a field at an arbitrary **object path** in a signal-held record. Use when `bind()` doesn't apply because the field lives two or more levels deep (e.g. `user.profile.email`, `settings.billing.plan`). Follow-up to WHISQ-78 (`bindField`) for the nested-object case the feedback docs flagged as friction against the flat-binding primitives.
+
+Exported from a new sub-path, `@whisq/core/forms`, so apps that only need `bind()` + `bindField()` (the 80% case) pay no bundle cost. Top-level `@whisq/core` stays at 5.25 KB gzipped.
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+form(
+  input({ ...bindPath(user, ["profile", "name"]) }),
+  input({ type: "email", ...bindPath(user, ["profile", "email"]) }),
+  input({ type: "number", ...bindPath(user, ["profile", "age"], { as: "number" }) }),
+  input({ type: "checkbox", ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) }),
+);
+```
+
+### Behaviors worth leading with
+
+- **Structural sharing on writes.** Writes produce a new root and new objects at every level on the path; sibling branches keep their reference identity so downstream `computed` / `effect` re-runs stay narrow.
+- **Missing-intermediate creation.** Reading through a missing intermediate returns `undefined`; writing creates the object structure as needed.
+- **Object keys only.** Array traversal is not supported in the path — use `bindField()` at the array level and compose. This keeps `bindPath` predictable and its implementation small.
+- **Typed overloads** for depths 1–4; deeper paths work via the loose signature (same runtime, just less TS inference).
+
+Mirrors `bind()` and `bindField()`'s discriminator shapes — text / number / checkbox / radio.
+
+Scaffolded `CLAUDE.md` files gain a "Binding into nested records (opt-in, sub-path import)" block under Forms so AI-generated code for new projects discovers the pattern without reinventing it.
+
+Closes #86.

--- a/.changeset/friendlier-runtime-errors.md
+++ b/.changeset/friendlier-runtime-errors.md
@@ -1,0 +1,18 @@
+---
+"@whisq/core": minor
+---
+
+Dev-mode runtime errors now tell you what's wrong and how to fix it. `div(...)`, `each()`, and `component()` validate their inputs at the boundary and throw a new `WhisqStructureError` with an expected/received mismatch plus a short hint when malformed children, non-array `each()` items, or invalid component return values show up.
+
+Where the old behaviors were "`Uncaught TypeError: .for is not iterable`" or a silent drop, you now see:
+
+```
+each: expected items() to return an array, received undefined.
+Hint: Data hasn't loaded yet. Gate the list with `when(() => data(), () => ul(each(...)))` or return `[]` while loading.
+```
+
+The guard code is wrapped in `if (process.env.NODE_ENV !== "production")` blocks so bundlers (Vite, Rollup, webpack, esbuild) strip it from production bundles — `@whisq/core` size-limit is measured with the same define and stays under budget at 5.25 KB gzipped.
+
+Public surface: `WhisqStructureError` (class) and `WhisqStructureErrorFields` (type) are both exported so apps can `instanceof`-check and render friendly error boundaries.
+
+Closes #81.

--- a/.changeset/match-api-clarity.md
+++ b/.changeset/match-api-clarity.md
@@ -1,0 +1,16 @@
+---
+"@whisq/core": patch
+"create-whisq": patch
+---
+
+Clarify `match()` as a **predicate chain, not pattern matching**.
+
+Audit finding: `match()` has always had exactly one shape — variadic tuple branches `[predicate, render]` with an optional trailing bare render fn as fallback. The GPT-side alpha.6 feedback flagged "object vs tuple form" confusion, but no object form exists in the code; GPT was pattern-matching against Rust/Scala/Vue conventions where `match(value, { case1, case2 })` is common.
+
+Changes:
+
+- **JSDoc** now leads with _"Predicate-chain conditional renderer — not pattern matching"_ and calls out the canonical shape, first-true-wins ordering, and fallback-position rules explicitly.
+- **Dev-mode validation** (stripped in production builds) throws a `WhisqStructureError` when `match()` receives a plain object (the exact GPT-style confusion), a malformed tuple, or a fallback that isn't in the last position. Production bundle unchanged at 5.25 KB gzipped.
+- **Scaffolded templates** — all four `CLAUDE.md` files now include `match` in the canonical imports line and expand the "Conditional Rendering" section to document `when()` vs `match()` with a ready example. AI-generated code for new projects will reach for `match` instead of nesting `when()`.
+
+Closes #83.

--- a/.changeset/persisted-signal.md
+++ b/.changeset/persisted-signal.md
@@ -1,0 +1,27 @@
+---
+"@whisq/core": minor
+"create-whisq": patch
+---
+
+Add `persistedSignal(key, initial, opts?)` — a `Signal<T>` backed by `localStorage` / `sessionStorage`, exported from the new sub-path `@whisq/core/persistence` so apps that don't need it pay zero bundle cost.
+
+```ts
+import { persistedSignal } from "@whisq/core/persistence";
+
+export const todos = persistedSignal<Todo[]>("todos", []);
+```
+
+Closes the "every Whisq app reinvents the guarded-localStorage-read-with-effect-writer pattern" problem identified by the alpha.6 feedback. Blessed shape, one import, no hand-rolling.
+
+### Behaviors worth leading with
+
+- **SSR-safe.** On the server (`typeof window === "undefined"`) returns a plain signal initialized to `initial` with no storage subscription.
+- **Schema-validated.** If the stored JSON is malformed, or an optional `schema(raw)` validator throws, the signal falls back to `initial` rather than crashing at mount.
+- **Quota-safe.** If a write throws (`QuotaExceededError`, private mode), logs a warning and keeps the in-memory value — the app keeps working.
+- **Module-scope intent.** Call `persistedSignal` at module scope in your `stores/` file, not inside components — the write effect lives for the module lifetime by design.
+
+Options: `storage: "local" | "session"`, `serialize` / `deserialize` (default JSON), `schema` (validation on load).
+
+Scaffolded templates' `CLAUDE.md` files gain a "Persisted stores (opt-in, sub-path import)" block under Shared State so AI-generated code for new projects can discover the pattern without reinventing it.
+
+Closes #82.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,10 +13,17 @@
     "@whisq/vite-plugin": "0.1.0-alpha.4"
   },
   "changesets": [
+    "access-shapes-canonical-doc",
+    "accessor-boundaries-docs",
     "alpha-5-batch",
+    "bindfield-for-array-items",
+    "bindpath-for-nested-records",
     "clarify-ref-accessor",
     "each-keyed-accessor-callback",
     "export-event-types",
+    "friendlier-runtime-errors",
+    "match-api-clarity",
+    "persisted-signal",
     "project-structure-conventions",
     "reactive-shapes-taxonomy"
   ]

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,6 +13,11 @@
     "@whisq/vite-plugin": "0.1.0-alpha.4"
   },
   "changesets": [
-    "alpha-5-batch"
+    "alpha-5-batch",
+    "clarify-ref-accessor",
+    "each-keyed-accessor-callback",
+    "export-event-types",
+    "project-structure-conventions",
+    "reactive-shapes-taxonomy"
   ]
 }

--- a/.github/workflows/notify-docs-on-release.yml
+++ b/.github/workflows/notify-docs-on-release.yml
@@ -41,6 +41,12 @@ permissions:
 jobs:
   dispatch:
     name: Dispatch to docs
+    # Changesets publishes each @whisq/* package as its own GitHub release, so
+    # a single release cycle fires `release: published` ~9 times. We dispatch
+    # only on the @whisq/core release (the canonical "framework shipped" event)
+    # and on manual workflow_dispatch runs, so docs tracking issues don't
+    # multiply per package. See whisqjs/whisq#75.
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, '@whisq/core@') }}
     runs-on: ubuntu-latest
     steps:
       - name: Mint WHISQ_BOT app token

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Eight copy-paste prompts that exercise different surfaces of the framework (todo
 - **~5 KB gzipped** — complete framework (core: 5.08 KB).
 - **Zero build step** — runs as plain JavaScript, works with any bundler.
 - **100% TypeScript** — every element function fully typed, inferred through components.
-- **No footguns** — uniform `() => value` reactive pattern, no hooks rules, no dependency arrays, no stale-closure tax.
+- **One reactive wrapper** — every reactive position accepts `() => …`. No hooks rules, no dependency arrays, no stale-closure tax. ([Three read shapes inside the wrapper](packages/core/docs/access-shapes.md) — signal / keyed-each accessor / resource field.)
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-5CE0F2" alt="License"></a>
 </p>
 
-Whisq is designed so large language models produce working code on the first try. The complete framework is under 5 KB gzipped and the full API fits in a prompt. No hooks rules. No reactivity caveats. No compile-time magic — just signals for state, functions for UI.
+Whisq is designed so large language models produce working code on the first try. The complete framework is ~5 KB gzipped and the full API fits in a prompt. No hooks rules. No reactivity caveats. No compile-time magic — just signals for state, functions for UI.
 
 ```ts
 import { signal, component, div, button, span, mount } from "@whisq/core";
@@ -51,7 +51,7 @@ Eight copy-paste prompts that exercise different surfaces of the framework (todo
 
 ## For humans
 
-- **Under 5 KB gzipped** — complete framework (core: 4.83 KB).
+- **~5 KB gzipped** — complete framework (core: 5.08 KB).
 - **Zero build step** — runs as plain JavaScript, works with any bundler.
 - **100% TypeScript** — every element function fully typed, inferred through components.
 - **No footguns** — uniform `() => value` reactive pattern, no hooks rules, no dependency arrays, no stale-closure tax.
@@ -71,7 +71,7 @@ Four templates: `minimal`, `full-app` (router + pages + store), `ssr`, `vite-plu
 
 | Package                                      | Description                                  | Size    |
 | -------------------------------------------- | -------------------------------------------- | ------- |
-| [`@whisq/core`](packages/core)               | Signals, elements, components, styling       | 4.83 KB |
+| [`@whisq/core`](packages/core)               | Signals, elements, components, styling       | 5.08 KB |
 | [`@whisq/router`](packages/router)           | Signal-based client-side routing             | 2.85 KB |
 | [`@whisq/ssr`](packages/ssr)                 | Server-side rendering + streaming            | 982 B   |
 | [`@whisq/testing`](packages/testing)         | Render, query, fireEvent, userEvent, waitFor | —       |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-5CE0F2" alt="License"></a>
 </p>
 
+Whisq is designed so large language models produce working code on the first try. The complete framework is under 5 KB gzipped and the full API fits in a prompt. No hooks rules. No reactivity caveats. No compile-time magic — just signals for state, functions for UI.
+
 ```ts
 import { signal, component, div, button, span, mount } from "@whisq/core";
 
@@ -34,14 +36,27 @@ const App = component(() => {
 mount(App({}), document.getElementById("app")!);
 ```
 
-## Why Whisq?
+## For AI assistants
 
-- **Under 5 KB gzipped** — the complete framework
-- **Zero build step** — runs as plain JavaScript, works with any bundler
-- **AI-native** — entire API fits in under 5,000 tokens. AI gets it right the first time.
-- **100% TypeScript** — every element function is fully typed
+Point Claude, Cursor, Copilot, or any coding assistant at one of these before it writes Whisq:
 
-## Get Started
+- **[`whisq.dev/llms.txt`](https://whisq.dev/llms.txt)** — structured site index per the [llmstxt.org](https://llmstxt.org) convention.
+- **[`whisq.dev/llms-full.txt`](https://whisq.dev/llms-full.txt)** — every docs page concatenated into one plain-text fetch (~165 KB, 66 pages).
+- **[`whisq.dev/ai/llm-reference`](https://whisq.dev/ai/llm-reference/)** — compact reference card: the whole framework in one page, two copy-paste tiers (~600 tokens minimum, ~1.7 K complete).
+- **[`unpkg.com/@whisq/core@latest/dist/public-api.json`](https://unpkg.com/@whisq/core@latest/dist/public-api.json)** — machine-readable manifest of every named export, pinned per release.
+
+Need deeper tooling? [`@whisq/mcp-server`](packages/mcp-server) exposes scaffold, validate, query-API, and analyze tools via the Model Context Protocol.
+
+Eight copy-paste prompts that exercise different surfaces of the framework (todo, signup form, chat UI, markdown editor, live dashboard, router SPA, SSR blog, Snake) live in [`docs/AI_TEST_PROMPTS.md`](./docs/AI_TEST_PROMPTS.md).
+
+## For humans
+
+- **Under 5 KB gzipped** — complete framework (core: 4.83 KB).
+- **Zero build step** — runs as plain JavaScript, works with any bundler.
+- **100% TypeScript** — every element function fully typed, inferred through components.
+- **No footguns** — uniform `() => value` reactive pattern, no hooks rules, no dependency arrays, no stale-closure tax.
+
+## Get started
 
 ```bash
 npm create whisq@latest my-app
@@ -50,79 +65,29 @@ npm install
 npm run dev
 ```
 
-Four templates available: `minimal`, `full-app` (router + pages + store), `ssr`, `vite-plugin` (file-based routing).
-
-## Core API
-
-```ts
-// State
-signal(value)              // reactive value
-computed(fn)               // derived value
-effect(fn)                 // side effect (returns dispose)
-batch(fn)                  // batch multiple updates
-
-// Elements — every HTML tag is a function
-div(props?, ...children)
-button(props?, ...children)
-input(props?)
-h1(), h2(), p(), span(), ul(), li(), a(), img(), form(), ...
-
-// Rendering
-when(condition, then, else) // conditional rendering
-each(items, renderFn)       // list rendering
-raw(htmlString)             // raw HTML (trusted content only)
-mount(node, element)        // mount to DOM (returns dispose)
-
-// Components
-component(setupFn)         // function component
-onMount(fn)                // lifecycle — runs after mount
-onCleanup(fn)              // lifecycle — runs on unmount
-resource(fetchFn)          // async data loading
-
-// Styling
-sheet(rules)               // scoped CSS-in-JS
-theme(tokens)              // design tokens as CSS custom properties
-```
+Four templates: `minimal`, `full-app` (router + pages + store), `ssr`, `vite-plugin` (file-based routing).
 
 ## Packages
 
-| Package                                      | Description                                  | Size   |
-| -------------------------------------------- | -------------------------------------------- | ------ |
-| [`@whisq/core`](packages/core)               | Signals, elements, components, styling       | 4.2 KB |
-| [`@whisq/router`](packages/router)           | Signal-based client-side routing             | 2.7 KB |
-| [`@whisq/ssr`](packages/ssr)                 | Server-side rendering + streaming            | 1.0 KB |
-| [`@whisq/testing`](packages/testing)         | Render, query, fireEvent, userEvent, waitFor | —      |
-| [`@whisq/vite-plugin`](packages/vite-plugin) | File-based routing, HMR, code splitting      | —      |
-| [`@whisq/mcp-server`](packages/mcp-server)   | AI tool integration (MCP protocol)           | —      |
-| [`@whisq/devtools`](packages/devtools)       | Signal inspection and component viewer       | —      |
-| [`@whisq/sandbox`](packages/sandbox)         | Isolated code execution                      | —      |
-| [`create-whisq`](packages/create-whisq)      | Project scaffolding CLI                      | —      |
-
-## AI Integration
-
-Whisq is designed for AI-assisted development:
-
-- **MCP Server** — `@whisq/mcp-server` provides scaffold, validate, query API, and analyze tools
-- **Small API surface** — the entire framework fits in <5% of a 200K context window
-- **No footguns** — uniform `() => value` pattern, no hooks rules, no reactivity caveats
-
-### Entry points for AI assistants
-
-Point Claude, ChatGPT, Gemini, Cursor, or any coding assistant at these URLs before it writes Whisq code:
-
-- **Compact LLM reference card:** <https://whisq.dev/ai/llm-reference/> — the whole framework in one page
-- **Machine-readable exports manifest:** <https://unpkg.com/@whisq/core@latest/dist/public-api.json> — every named export in the current release, pinned per version
-- **Copy-paste test prompts:** [`docs/AI_TEST_PROMPTS.md`](./docs/AI_TEST_PROMPTS.md) — eight self-contained prompts (todo, signup form, chat UI, markdown editor, live dashboard, router SPA, SSR blog, Snake) that exercise different surfaces of the framework
-- **Project-structure conventions:** [`packages/core/docs/project-structure.md`](./packages/core/docs/project-structure.md) — canonical file layout (one component per file, `main.ts` mounts and nothing else) so AI output matches the scaffolder templates
-
-> **Coming soon:** `whisq.dev/llms.txt` (structured index, [llmstxt.org](https://llmstxt.org) convention) and `whisq.dev/llms-full.txt` (full docs as one plain-text fetch) are merged to docs `develop` and will go live once the docs repo cuts its next release.
+| Package                                      | Description                                  | Size    |
+| -------------------------------------------- | -------------------------------------------- | ------- |
+| [`@whisq/core`](packages/core)               | Signals, elements, components, styling       | 4.83 KB |
+| [`@whisq/router`](packages/router)           | Signal-based client-side routing             | 2.85 KB |
+| [`@whisq/ssr`](packages/ssr)                 | Server-side rendering + streaming            | 982 B   |
+| [`@whisq/testing`](packages/testing)         | Render, query, fireEvent, userEvent, waitFor | —       |
+| [`@whisq/vite-plugin`](packages/vite-plugin) | File-based routing, HMR, code splitting      | —       |
+| [`@whisq/mcp-server`](packages/mcp-server)   | AI tool integration (MCP protocol)           | —       |
+| [`@whisq/devtools`](packages/devtools)       | Signal inspection and component viewer       | —       |
+| [`@whisq/sandbox`](packages/sandbox)         | Isolated code execution                      | —       |
+| [`create-whisq`](packages/create-whisq)      | Project scaffolding CLI                      | —       |
 
 ## Documentation
 
+- **[whisq.dev](https://whisq.dev)** — full documentation site
 - [Getting Started](https://whisq.dev/getting-started/introduction/) — installation, quick start, first component
 - [Core Concepts](https://whisq.dev/core-concepts/signals/) — signals, elements, components, styling
-- [API Reference](https://whisq.dev/api/signal/) — complete API docs
-- [Guides](https://whisq.dev/guides/routing/) — routing, SSR, forms, testing, data fetching
+- [API Reference](https://whisq.dev/api/signal/) — every named export
+- [Guides](https://whisq.dev/guides/routing/) — routing, SSR, forms, data fetching, testing
 - [Examples](https://whisq.dev/examples/counter/) — counter, todo, dashboard, forms
 - [Playground](https://whisq.dev/playground/) — try Whisq in the browser
 

--- a/packages/core/.size-limit.cjs
+++ b/packages/core/.size-limit.cjs
@@ -1,0 +1,20 @@
+// Size-limit config for @whisq/core. Uses a JS file (rather than the
+// "size-limit" field in package.json) so we can pass a `define` to esbuild —
+// this strips dev-only validators (`if (process.env.NODE_ENV !== "production")
+// { ... }`) before measuring, giving a size number that matches what users'
+// production bundlers will actually ship.
+
+module.exports = [
+  {
+    path: "dist/index.js",
+    limit: "5.5 KB",
+    gzip: true,
+    modifyEsbuildConfig(config) {
+      config.define = {
+        ...(config.define ?? {}),
+        "process.env.NODE_ENV": '"production"',
+      };
+      return config;
+    },
+  },
+];

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,101 @@
 # @whisq/core
 
+## 0.1.0-alpha.6
+
+### Minor Changes
+
+- 4f557c9: Clarify the `ref()` accessor and export a named `ElementRef<T>` type alias (WHISQ-63).
+
+  Addresses the feedback from real app-building: "which accessor on which container-shaped primitive?" The answer for refs has always been `.value` (refs are plain Whisq signals), but the type `Signal<T | null>` surfaced in editor tooltips didn't name the concept, and React's `.current` priors caused a guessing step.
+
+  **Changes:**
+  - **New** `ElementRef<T>` type alias exported from `@whisq/core`. Structurally identical to `Signal<T | null>`; the alias exists purely so tooltips read `ElementRef<HTMLInputElement>` and LLMs get a stronger prior for the concept.
+  - **`ref<T>()`** now declares its return type as `ElementRef<T>` instead of `Signal<T | null>`. No runtime change.
+  - **JSDoc tightened** on both `ref()` and `Ref<T>` to say explicitly: _"read it with `.value`, not `.current`"_.
+
+  **Usage:**
+
+  ```ts
+  import { ref } from "@whisq/core";
+  import type { ElementRef } from "@whisq/core";
+
+  const inputEl = ref<HTMLInputElement>(); // ElementRef<HTMLInputElement>
+  input({ ref: inputEl });
+  onMount(() => inputEl.value?.focus()); // .value — not .current
+
+  // Naming a prop / field that holds a ref:
+  type FormRefs = {
+    email: ElementRef<HTMLInputElement>;
+    submitBtn: ElementRef<HTMLButtonElement>;
+  };
+  ```
+
+  5 new tests in `ref.test.ts` pin: no `.current` property exists, the return value passes `isSignal()`, `subscribe()` fires on mount + unmount, and `ElementRef<T>` is assignable both to the `Ref` prop type and to a `Signal<T | null>` slot.
+
+  Backward compatible. The underlying type is still `Signal<T | null>`; code that declared `Signal<HTMLInputElement | null>` for a ref still works.
+
+- 6978011: **Breaking change to keyed `each()` render callbacks.** (In alpha pre-mode this still lands as an `alpha.N → alpha.N+1` bump.)
+
+  Fixes [#62](https://github.com/whisqjs/whisq/issues/62) — the stale-snapshot problem in keyed `each()` where field reads on an item inside the render callback pointed at the old object reference when the source array was replaced.
+
+  ### What changed
+
+  When `each(..., { key })` is used, the render callback now receives **accessor functions** instead of plain values:
+
+  ```ts
+  // Before
+  each(
+    () => todos.value,
+    (todo, index) => li({ class: () => (todo.done ? "done" : "") }, todo.text),
+    { key: (t) => t.id },
+  );
+
+  // After
+  each(
+    () => todos.value,
+    (todo, index) =>
+      li({ class: () => (todo().done ? "done" : "") }, () => todo().text),
+    { key: (t) => t.id },
+  );
+  ```
+
+  `todo()` / `index()` read from per-entry signals the reconciler updates when a same-keyed item is replaced. Wrap them in `() => todo().field` to get a reactive getter that re-runs on source changes; call them as `todo().field` for a one-shot snapshot at render time.
+
+  Non-keyed `each()` (no `options.key`) is **unchanged** — it keeps the `(item: T, index: number) => WhisqNode` signature because it recreates nodes on every source change, so staleness isn't possible there.
+
+  ### Migration
+
+  For every call site that passes `{ key }`, change `item.X` to `item().X` (and `index` to `index()`). TypeScript catches this as a type error — `item` is now `() => T`, so property access on it fails to compile.
+
+  ### Why
+
+  The old behavior required users to re-plumb a reactive lookup inside every keyed callback (`computed(() => todos.value.find(t => t.id === todo.id))`) to get correct field updates. That's the exact shape of code LLMs silently get wrong — plausible-looking output that only breaks on interaction. Shipping accessor-style callbacks aligns with Solid's idiom (which LLMs have strong priors for) and makes the reactive edge observable in the call shape.
+
+  Covered by 6 new tests in `packages/core/src/__tests__/each.test.ts`: field-read reactivity, snapshot read (non-reactive opt-out), index reflow on reorder, event-handler accessor read, and DOM node identity preservation across same-key replacement.
+
+- ea8d760: Export two type aliases for extracted event handlers (WHISQ-64).
+  - `EventHandler<E, T>` — previously internal, now public. Narrows `event.currentTarget` to `T` via intersection.
+  - `WhisqEvent<K, T>` — new. Looks up the event type from `HTMLElementEventMap` by name (e.g. `"keydown"`, `"submit"`) and narrows `currentTarget` to `T`. Complementary to `EventHandler`: `WhisqEvent<K, T>` produces the exact event shape you'd otherwise spell out as `KeyboardEvent & { currentTarget: HTMLInputElement }`.
+
+  ```ts
+  import type { WhisqEvent, EventHandler } from "@whisq/core";
+
+  // Named extracted handler — event + element in one type parameter.
+  function onSearchKey(e: WhisqEvent<"keydown", HTMLInputElement>) {
+    if (e.key === "Enter") submit();
+  }
+  input({ onkeydown: onSearchKey });
+
+  // Or use EventHandler for higher-order handlers.
+  const onSubmit: EventHandler<SubmitEvent, HTMLFormElement> = (e) => {
+    e.preventDefault();
+    e.currentTarget.reset();
+  };
+  form({ onsubmit: onSubmit });
+  ```
+
+  No runtime change. Type-only addition — bundle size unchanged.
+
 ## 0.1.0-alpha.5
 
 ### Minor Changes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,114 @@
 # @whisq/core
 
+## 0.1.0-alpha.7
+
+### Minor Changes
+
+- 757049d: Add `bindField(source, item, key, opts?)` — two-way binding for a field on an item inside a signal-held array. Closes the ergonomic gap `bind()` didn't reach: the most common UI shape in real applications (todos, carts, forms-with-rows, CRUD grids).
+
+  ```ts
+  each(
+    () => todos.value,
+    (todo) =>
+      input({
+        type: "checkbox",
+        ...bindField(todos, todo, "done", { as: "checkbox" }),
+      }),
+    { key: (t) => t.id },
+  );
+  ```
+
+  Mirrors `bind()`'s discriminator shapes (text / number / checkbox / radio). `keyBy` identifies which item to rewrite — defaults to `t => t.id`; override for items keyed on something else. Writes produce an immutable array update so downstream `computed` / `effect` re-run correctly.
+
+  All four scaffolded templates' `CLAUDE.md` reactive-shapes tables now lead with `bindField()` for this case instead of the manual event pair. The decision flow also updates to _"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."_
+
+  `@whisq/core` size budget raised from 5 KB to 5.5 KB gzipped (current: 5.08 KB). The README updates "Under 5 KB gzipped" → "~5 KB gzipped" to match. `bindField` is exported from the top-level `@whisq/core` so LLMs and autocompletion discover it alongside `bind()`.
+
+  Closes #78.
+
+- 34a2c7a: Add `bindPath(source, path, opts?)` — two-way binding for a field at an arbitrary **object path** in a signal-held record. Use when `bind()` doesn't apply because the field lives two or more levels deep (e.g. `user.profile.email`, `settings.billing.plan`). Follow-up to WHISQ-78 (`bindField`) for the nested-object case the feedback docs flagged as friction against the flat-binding primitives.
+
+  Exported from a new sub-path, `@whisq/core/forms`, so apps that only need `bind()` + `bindField()` (the 80% case) pay no bundle cost. Top-level `@whisq/core` stays at 5.25 KB gzipped.
+
+  ```ts
+  import { bindPath } from "@whisq/core/forms";
+
+  form(
+    input({ ...bindPath(user, ["profile", "name"]) }),
+    input({ type: "email", ...bindPath(user, ["profile", "email"]) }),
+    input({
+      type: "number",
+      ...bindPath(user, ["profile", "age"], { as: "number" }),
+    }),
+    input({
+      type: "checkbox",
+      ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }),
+    }),
+  );
+  ```
+
+  ### Behaviors worth leading with
+  - **Structural sharing on writes.** Writes produce a new root and new objects at every level on the path; sibling branches keep their reference identity so downstream `computed` / `effect` re-runs stay narrow.
+  - **Missing-intermediate creation.** Reading through a missing intermediate returns `undefined`; writing creates the object structure as needed.
+  - **Object keys only.** Array traversal is not supported in the path — use `bindField()` at the array level and compose. This keeps `bindPath` predictable and its implementation small.
+  - **Typed overloads** for depths 1–4; deeper paths work via the loose signature (same runtime, just less TS inference).
+
+  Mirrors `bind()` and `bindField()`'s discriminator shapes — text / number / checkbox / radio.
+
+  Scaffolded `CLAUDE.md` files gain a "Binding into nested records (opt-in, sub-path import)" block under Forms so AI-generated code for new projects discovers the pattern without reinventing it.
+
+  Closes #86.
+
+- 97203c8: Dev-mode runtime errors now tell you what's wrong and how to fix it. `div(...)`, `each()`, and `component()` validate their inputs at the boundary and throw a new `WhisqStructureError` with an expected/received mismatch plus a short hint when malformed children, non-array `each()` items, or invalid component return values show up.
+
+  Where the old behaviors were "`Uncaught TypeError: .for is not iterable`" or a silent drop, you now see:
+
+  ```
+  each: expected items() to return an array, received undefined.
+  Hint: Data hasn't loaded yet. Gate the list with `when(() => data(), () => ul(each(...)))` or return `[]` while loading.
+  ```
+
+  The guard code is wrapped in `if (process.env.NODE_ENV !== "production")` blocks so bundlers (Vite, Rollup, webpack, esbuild) strip it from production bundles — `@whisq/core` size-limit is measured with the same define and stays under budget at 5.25 KB gzipped.
+
+  Public surface: `WhisqStructureError` (class) and `WhisqStructureErrorFields` (type) are both exported so apps can `instanceof`-check and render friendly error boundaries.
+
+  Closes #81.
+
+- c84e495: Add `persistedSignal(key, initial, opts?)` — a `Signal<T>` backed by `localStorage` / `sessionStorage`, exported from the new sub-path `@whisq/core/persistence` so apps that don't need it pay zero bundle cost.
+
+  ```ts
+  import { persistedSignal } from "@whisq/core/persistence";
+
+  export const todos = persistedSignal<Todo[]>("todos", []);
+  ```
+
+  Closes the "every Whisq app reinvents the guarded-localStorage-read-with-effect-writer pattern" problem identified by the alpha.6 feedback. Blessed shape, one import, no hand-rolling.
+
+  ### Behaviors worth leading with
+  - **SSR-safe.** On the server (`typeof window === "undefined"`) returns a plain signal initialized to `initial` with no storage subscription.
+  - **Schema-validated.** If the stored JSON is malformed, or an optional `schema(raw)` validator throws, the signal falls back to `initial` rather than crashing at mount.
+  - **Quota-safe.** If a write throws (`QuotaExceededError`, private mode), logs a warning and keeps the in-memory value — the app keeps working.
+  - **Module-scope intent.** Call `persistedSignal` at module scope in your `stores/` file, not inside components — the write effect lives for the module lifetime by design.
+
+  Options: `storage: "local" | "session"`, `serialize` / `deserialize` (default JSON), `schema` (validation on load).
+
+  Scaffolded templates' `CLAUDE.md` files gain a "Persisted stores (opt-in, sub-path import)" block under Shared State so AI-generated code for new projects can discover the pattern without reinventing it.
+
+  Closes #82.
+
+### Patch Changes
+
+- 3a31d18: Clarify `match()` as a **predicate chain, not pattern matching**.
+
+  Audit finding: `match()` has always had exactly one shape — variadic tuple branches `[predicate, render]` with an optional trailing bare render fn as fallback. The GPT-side alpha.6 feedback flagged "object vs tuple form" confusion, but no object form exists in the code; GPT was pattern-matching against Rust/Scala/Vue conventions where `match(value, { case1, case2 })` is common.
+
+  Changes:
+  - **JSDoc** now leads with _"Predicate-chain conditional renderer — not pattern matching"_ and calls out the canonical shape, first-true-wins ordering, and fallback-position rules explicitly.
+  - **Dev-mode validation** (stripped in production builds) throws a `WhisqStructureError` when `match()` receives a plain object (the exact GPT-style confusion), a malformed tuple, or a fallback that isn't in the last position. Production bundle unchanged at 5.25 KB gzipped.
+  - **Scaffolded templates** — all four `CLAUDE.md` files now include `match` in the canonical imports line and expand the "Conditional Rendering" section to document `when()` vs `match()` with a ready example. AI-generated code for new projects will reach for `match` instead of nesting `when()`.
+
+  Closes #83.
+
 ## 0.1.0-alpha.6
 
 ### Minor Changes

--- a/packages/core/docs/access-shapes.md
+++ b/packages/core/docs/access-shapes.md
@@ -1,0 +1,128 @@
+# Access shapes — the three read patterns
+
+Canonical reference for **how you read** reactive values. Paired with [`reactive-shapes.md`](./reactive-shapes.md), which covers **where** reactive values are consumed (child / prop / `bind()` / `bindField()`). The two docs intersect at every working call site: pick where to put the reactive thing, then pick how to read from its source.
+
+---
+
+## Is "uniform `() => value`" actually uniform?
+
+The marketing line you'll see on whisq.dev is _"wrap reactive reads in `() => ...` everywhere."_ The **wrapper** is uniform — every reactive position in the API accepts `() => value`. What varies is **what goes inside the wrapper**, because Whisq exposes three different source shapes: plain signals, keyed-`each` accessors, and `resource()` fields.
+
+So the rule to remember is:
+
+> _Wrap reactive reads in `() => ...`. Unwrap the source:_
+> _- Signal → `.value`_
+> _- Keyed-`each` item or `resource()` field → `()` (it's already an accessor)._
+
+Two tokens to remember instead of one, but one consistent wrapper — and _zero_ hidden dependency arrays, stale closures, or re-render caveats.
+
+---
+
+## The three shapes at a glance
+
+| # | Source                    | Outside reactive context              | Inside reactive context (getter) |
+| - | ------------------------- | ------------------------------------- | -------------------------------- |
+| 1 | Plain signal              | `sig.value` / `sig.peek()`            | `() => sig.value`                |
+| 2 | Keyed `each()` item       | _(only exists inside the render fn)_  | `() => todo().text`              |
+| 3 | `resource()` field        | `users.loading()` / `users.data()` …  | `() => users.loading()`          |
+
+---
+
+## Shape 1 — Plain signal: `sig.value` / `() => sig.value`
+
+The source `signal()` returns is a property-shaped object. Read `.value` synchronously outside a reactive context. Inside one — a getter child, a getter prop, an `effect`, a `computed` body — wrap the same read in `() => ...`.
+
+```ts
+const count = signal(0);
+
+// Outside: property access. Not tracked.
+console.log(count.value);         // 0
+count.value = 5;                  // setter
+
+// Inside: wrapped in a getter so the surrounding effect re-runs.
+span(() => count.value);          // re-renders when count changes
+computed(() => count.value * 2);  // re-evaluates when count changes
+effect(() => log(count.value));   // re-runs when count changes
+
+// Peek — one-shot read without tracking (rare; use if you know you want it).
+const snap = count.peek();
+```
+
+- **Common mistake:** passing `count.value` directly as a child → reads once, not reactive.
+- **Writes:** `count.value = n` or `count.set(n)` or `count.update(fn)`.
+
+## Shape 2 — Keyed `each()` item: `todo()`
+
+Inside a keyed `each(items, (item) => …, { key })`, the `item` argument is an **accessor function** — you call it with `()` to get the current value. Wrapping the read in `() => todo().text` is what makes the child re-render when the array is replaced with new objects at the same key. Closing over `todo` and writing `.text` would be stale at the next array replacement (see WHISQ-62 for the fix that introduced this).
+
+```ts
+type Todo = { id: string; text: string; done: boolean };
+const todos = signal<Todo[]>([]);
+
+ul(
+  each(
+    () => todos.value,
+    (todo) =>
+      li(
+        span(() => todo().text),                      // reactive text via accessor
+        input({ type: "checkbox",
+          ...bindField(todos, todo, "done", { as: "checkbox" }) }),
+      ),
+    { key: (t) => t.id },
+  ),
+);
+```
+
+- **`todo` is a function, not an object** — `todo.text` is `undefined`; TypeScript flags this.
+- **Always wrap `todo()` in `() => ...`** for reactive reads — a bare `todo()` outside a getter is a one-shot snapshot.
+- **Writes** go through the source signal, not the accessor. Use `bindField(source, item, key)` for the common "update field on an item" case; fall back to a manual event pair for arbitrary mutations.
+
+Non-keyed `each(items, (item) => …)` (no `{ key }`) still passes plain `T`, because the whole list re-renders on every change — no stale-accessor risk. See [`reactive-shapes.md`](./reactive-shapes.md) for when to reach for `each` keyed vs. non-keyed.
+
+## Shape 3 — `resource()` field: `users.loading()`
+
+`resource(fetcher)` returns an object with function-shaped fields: `loading()`, `data()`, `error()`. They're accessor-shaped for the same reason keyed-each items are: reading through a function lets the reactive graph re-track on each read, so state transitions (loading → data, loading → error, data → refetching) update every consumer without re-plumbing.
+
+```ts
+const users = resource(() => fetch("/api/users").then((r) => r.json()));
+
+div(
+  when(() => users.loading(), () => p("Loading...")),
+  when(() => !!users.error(),
+    () => p({ class: "error" }, () => users.error()!.message)),
+  when(() => !!users.data(),
+    () => ul(each(() => users.data()!, (u) => li(u.name)))),
+);
+```
+
+- **Call the field** — `users.loading()` not `users.loading`.
+- **Wrap in `() =>`** at the reactive position — same pattern as signal reads.
+- **Nullability** — `data()` / `error()` return `undefined` until the fetch completes. Gate with `when(() => users.loading(), ...)` or non-null assert inside a guard.
+
+---
+
+## A note on what stays live across component boundaries
+
+All three access shapes survive being passed as component props, provided you pass **the accessor itself**, not a snapshot.
+
+```ts
+// Good: the child receives an accessor; reads stay live.
+const TodoItem = component((props: { todo: () => Todo }) => {
+  return li(() => props.todo().text);   // shape 2 — still works across boundary
+});
+
+// Bad: a snapshot captured once at parent setup; goes stale on array replacement.
+const TodoItem = component((props: { todo: Todo }) => {
+  return li(props.todo.text);           // frozen at first render
+});
+```
+
+This is the subject of [#80](https://github.com/whisqjs/whisq/issues/80) — the worked example for component-boundary handoffs. If you pass a bare signal (`{ count: sig }` rather than `{ count: () => sig.value }`), children read `.value` inside their own `() =>`. Both work; pick based on what the child needs to do with it.
+
+---
+
+## See also
+
+- [`reactive-shapes.md`](./reactive-shapes.md) — the four _positional_ shapes (where reactive values are consumed).
+- [`batch-semantics.md`](./batch-semantics.md) — how `batch()` sequences multiple writes.
+- [`ref.ts`](../src/ref.ts) — `ElementRef<T>` is a `Signal<T | null>`, so it follows shape 1 (`ref.value`, `() => ref.value`). Documented explicitly per WHISQ-63.

--- a/packages/core/docs/access-shapes.md
+++ b/packages/core/docs/access-shapes.md
@@ -101,23 +101,105 @@ div(
 
 ---
 
-## A note on what stays live across component boundaries
+## Accessors across component boundaries
 
-All three access shapes survive being passed as component props, provided you pass **the accessor itself**, not a snapshot.
+All three access shapes survive being passed as component props — **as long as you pass the accessor itself, not a snapshot**. This section covers what that means in practice, what fails if you snapshot, and which prop shape to pick for each source.
+
+### What survives the boundary
+
+- **Signals** — pass the signal object. The child reads `.value` inside its own `() =>`.
+- **Keyed-`each` items** — pass the accessor function (`todo` as received from the render callback — don't call it at the parent). The child calls `props.todo()` inside its own `() =>`.
+- **`resource()` fields** — pass the accessor function (`users.data` — don't call it). The child calls `props.data()` inside its own `() =>`.
+
+The common rule: **the thing you hand to the child must be re-readable**. A raw `.value` or `todo()` read at the parent is a snapshot — the child gets a frozen copy and never sees updates.
+
+### Worked example: split a todo row into its own component
 
 ```ts
-// Good: the child receives an accessor; reads stay live.
-const TodoItem = component((props: { todo: () => Todo }) => {
-  return li(() => props.todo().text);   // shape 2 — still works across boundary
-});
+// parent: owns the todos signal
+type Todo = { id: string; text: string; done: boolean };
+const todos = signal<Todo[]>([
+  { id: "a", text: "groceries", done: false },
+  { id: "b", text: "ship release", done: true },
+]);
 
-// Bad: a snapshot captured once at parent setup; goes stale on array replacement.
-const TodoItem = component((props: { todo: Todo }) => {
-  return li(props.todo.text);           // frozen at first render
+function TodoList() {
+  return ul(
+    each(
+      () => todos.value,
+      (todo) => TodoItem({ todo }),            // pass the accessor as-is
+      { key: (t) => t.id },
+    ),
+  );
+}
+
+// child: reads props.todo() inside its own getters
+const TodoItem = component((props: { todo: () => Todo }) => {
+  return li(
+    input({
+      type: "checkbox",
+      ...bindField(todos, props.todo, "done", { as: "checkbox" }),
+    }),
+    span(() => props.todo().text),              // re-reads on every source change
+    button(
+      { onclick: () => remove(props.todo().id) },
+      "✕",
+    ),
+  );
 });
 ```
 
-This is the subject of [#80](https://github.com/whisqjs/whisq/issues/80) — the worked example for component-boundary handoffs. If you pass a bare signal (`{ count: sig }` rather than `{ count: () => sig.value }`), children read `.value` inside their own `() =>`. Both work; pick based on what the child needs to do with it.
+Everything the child needs is reachable from `props.todo()`. Nothing is captured in a local variable at setup. When the parent replaces `todos.value` with a new array that still contains the same `id`, the reconciler reuses this `TodoItem` instance; the per-entry `itemSig` gets the new object; `props.todo()` returns that new object; every getter in the child re-reads.
+
+### Counter-example: snapshot at setup (the bug you can't reproduce in a unit test)
+
+```ts
+// DON'T DO THIS
+const TodoItem = component((props: { todo: () => Todo }) => {
+  const todo = props.todo();                    // snapshot captured once
+  return li(
+    span(todo.text),                            // static — never updates
+    button(
+      { onclick: () => remove(todo.id) },       // stale id after reorder
+      "✕",
+    ),
+  );
+});
+```
+
+Symptoms:
+
+- The todo row renders once, then never reflects changes to `.text` or `.done` made elsewhere.
+- After reordering the list, clicking `✕` may remove the wrong row — the closure holds the old item's `.id`.
+- Nothing _throws_. No dev-mode error. The UI just quietly falls out of sync.
+
+The failure mode is unmistakable once you know it, but unreproducible in a fresh-mount test — you only see it on the second parent state change. That's exactly why the rule needs to be written down rather than left as tribal knowledge.
+
+### Passing a signal vs. passing an accessor
+
+Both shapes work; pick by who "owns" the binding.
+
+| Parent holds          | Prop shape to pass                  | Child reads via        |
+| --------------------- | ----------------------------------- | ---------------------- |
+| A `Signal<T>`          | `{ count: sig }` (the signal itself) | `() => props.count.value` |
+| A `Signal<T>` — child should only read  | `{ count: () => sig.value }` (pre-wrapped getter) | `() => props.count()` |
+| A keyed-`each` item    | `{ todo }` (the accessor)            | `() => props.todo()`   |
+| A `resource()` field   | `{ data: users.data }` (the accessor) | `() => props.data()`   |
+
+- Pass the raw signal when the child might need to **write** (`bind(props.sig)`). The signal object carries both read and write.
+- Pass a pre-wrapped getter `() => sig.value` when the child should **only read** — the type `() => T` is the smallest capability and is identical-shaped to the keyed-each/resource case, so generic child components can accept any of them.
+- **Never call the accessor at the parent** — `TodoItem({ todo: todo() })` snapshots it.
+
+### Common mistakes at the boundary
+
+| Mistake                                         | What happens                                                      | Fix                                             |
+| ----------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------- |
+| `TodoItem({ todo: todo() })` (call at parent)   | Child receives frozen item; stale after array replacement.       | `TodoItem({ todo })` — pass the accessor.       |
+| `const todo = props.todo()` inside child setup   | Snapshots at first mount; ignores later updates.                 | Read inside each getter: `() => props.todo().x`. |
+| Destructuring props in setup (`const { todo } = props`) | Loses per-render re-read if Whisq ever swaps props (and is a footgun elsewhere too). | Read fields off `props` directly: `() => props.todo().text`. |
+| Passing `todos.value[0]` as a prop              | Same as snapshotting — you read `.value` at the parent.          | Pass a getter: `{ first: () => todos.value[0] }`. |
+
+See also the structural guards shipped in [#81](https://github.com/whisqjs/whisq/issues/81) — `WhisqStructureError` catches wrong-shaped children at the boundary and points at the fix.
 
 ---
 

--- a/packages/core/docs/reactive-shapes.md
+++ b/packages/core/docs/reactive-shapes.md
@@ -1,23 +1,25 @@
 # Reactive shapes — the four patterns
 
-Canonical reference for the ways reactive data flows into the UI layer. Pinned here alongside [`batch-semantics.md`](./batch-semantics.md) so the docs site's LLM reference card can port this verbatim.
+Canonical reference for **where** reactive data flows into the UI layer. Pinned here alongside [`batch-semantics.md`](./batch-semantics.md) and [`access-shapes.md`](./access-shapes.md) so the docs site's LLM reference card can port this verbatim.
 
-Whisq's marketing thesis is "uniform value access" — every reactive position accepts `() => value`. That's true, but in practice there are **four subtly different shapes** you pick between. The "uniform" framing undersells the decision tree. This doc enumerates them and tells you when to use each.
+Every reactive position in the API accepts `() => value` — that wrapper is uniform. What you put inside the wrapper depends on the source ([`access-shapes.md`](./access-shapes.md) enumerates those). What you put the wrapper _at_ is one of the four positions below. Pick the access shape first, then the position shape, then wire the two together.
 
 ---
 
 ## The four shapes at a glance
 
-| #   | Shape                 | Example                                                            | Use when                                                                  |
-| --- | --------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------- |
-| 1   | Getter **child**      | `span(() => count.value)`                                          | A signal drives inline text or a nested element                           |
-| 2   | Getter **prop**       | `{ class: () => active.value ? "on" : "off" }`                     | A signal drives an element attribute / style / class                      |
-| 3   | **`bind()`** spread   | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input you own                    |
-| 4   | **Manual event pair** | `{ checked: () => todo().done, onchange: e => toggle(todo().id) }` | A field inside an item inside a signal-backed array (inside keyed `each`) |
+| # | Shape                     | Example                                                                            | Use when                                                                                |
+| - | ------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| 1 | Getter **child**          | `span(() => count.value)`                                                          | A signal drives inline text or a nested element                                         |
+| 2 | Getter **prop**           | `{ class: () => active.value ? "on" : "off" }`                                     | A signal drives an element attribute / style / class                                    |
+| 3 | **`bind()`** spread       | `input({ ...bind(email) })`                                                        | Two-way binding one signal into one form input you own                                  |
+| 4 | **`bindField()`** spread  | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | A field inside an item inside a signal-backed array (inside keyed `each`)               |
+
+Escape hatch: when `bindField()` doesn't fit (deep paths, custom write logic), fall back to a **manual event pair** — `{ checked: () => todo().done, onchange: e => toggle(todo().id) }`. Same idea, more code.
 
 A one-sentence decision flow:
 
-> _"Is the reactive value a single signal you own? → `bind()`. Is it a field inside an item inside a signal-held array? → manual pair, reading through the `each` accessor (`todo()`), not a closed-over reference."_
+> _"Is the reactive value a single signal you own? → `bind()`. Is it a field inside an item inside a signal-held array? → `bindField()`."_
 
 ---
 
@@ -78,19 +80,13 @@ Variants:
 - `bind(sig, { as: "checkbox" })` — binds the `checked` property
 - `bind(sig, { as: "radio", value: "admin" })` — binds a radio group member
 
-## Shape 4 — Manual event pair (inside keyed `each`)
+## Shape 4 — `bindField()` spread (inside keyed `each`)
 
-When the thing you want to update lives as a field on an item inside a signal-backed array, `bind()` doesn't apply. The array is the signal; the field isn't independently addressable. Write the reactive read and the writer separately, and go through the `each` accessor to avoid the stale-snapshot trap.
+When the writable is a field on an item inside a signal-backed array, `bind()` doesn't apply — the array is the signal and the field isn't independently addressable. `bindField()` covers this case with the same spread shape as `bind()`, producing an immutable array update on write and surviving keyed-`each` array replacement.
 
 ```ts
 type Todo = { id: string; text: string; done: boolean };
 const todos = signal<Todo[]>([]);
-
-function toggle(id: string) {
-  todos.value = todos.value.map((t) =>
-    t.id === id ? { ...t, done: !t.done } : t,
-  );
-}
 
 ul(
   each(
@@ -99,20 +95,30 @@ ul(
       li(
         input({
           type: "checkbox",
-          checked: () => todo().done, // reactive read via accessor
-          onchange: () => toggle(todo().id), // writer — reads latest id too
+          ...bindField(todos, todo, "done", { as: "checkbox" }),
         }),
         span(() => todo().text),
-        button({ onclick: () => remove(todo().id) }, "✕"),
       ),
     { key: (t) => t.id },
   ),
 );
 ```
 
-- **Key observation:** `todo` is an **accessor function** (post WHISQ-62) — call it as `todo()` to get the current item, and wrap in `() =>` for reactive reads. Closing over `todo` and writing `todo.done` would be stale the moment you replaced the array with new objects at the same key.
-- **Why the manual pair and not `bind()`:** `bind()` assumes a single signal with a single writable value. Here the writable is a field on an item; updating it requires re-mapping the whole array.
-- **Why not `bind()` on a per-item signal:** you'd have to materialise a signal per field per item. Doable but usually over-engineered for lists that fit in memory.
+- **`todo` is an accessor** (post WHISQ-62) — call it as `todo()` to read the current item. `bindField()` reads it internally to find the target item at write time.
+- **`keyBy` defaults to `t => t.id`** — supply `{ keyBy: (t) => t.uuid }` for items keyed on something else.
+- **Writes produce a new array** — `source.value` is replaced with an immutably-updated copy, so downstream `computed` / `effect` / keyed `each()` re-run correctly.
+
+When `bindField()` doesn't fit — deep nested paths, writes that touch multiple fields atomically, or custom logic like optimistic updates — fall back to the manual event pair:
+
+```ts
+input({
+  type: "checkbox",
+  checked: () => todo().done,                      // reactive read via accessor
+  onchange: () => toggle(todo().id),               // writer — reads latest id
+}),
+```
+
+The manual pair is strictly more powerful but also strictly more verbose. Prefer `bindField()` when it applies.
 
 ---
 
@@ -125,12 +131,14 @@ ul(
 | `input({ value: email.value, oninput: e => email.value = e.target.value })`   | Works but verbose; risks forgetting both sides.                                       | `input({ ...bind(email) })`                         |
 | `each(..., (todo) => li(() => todo.done ? ...))` (closes over a stale `todo`) | `todo` is the accessor — `.done` on a function is `undefined`. TypeScript flags this. | `li(() => todo().done ? ...)`                       |
 | `items.value.push(x)`                                                         | In-place mutation doesn't notify.                                                     | `items.value = [...items.value, x]`                 |
-| `bind(todo, { as: "checkbox" })` inside keyed `each`                          | `todo` is an accessor, not a signal with `.value`.                                    | Manual pair (shape 4).                              |
+| `bind(todo, { as: "checkbox" })` inside keyed `each`                          | `todo` is an accessor, not a signal with `.value`.                                    | `bindField(source, todo, "done", { as: "checkbox" })` (shape 4). |
 
 ---
 
 ## See also
 
-- [`each()` API reference](../src/elements.ts) — the `{ key }` callback now passes accessors (WHISQ-62).
-- [`bind()` API reference](../src/bind.ts) — exhaustive options.
+- [`access-shapes.md`](./access-shapes.md) — **how** you read reactive values (signal, keyed-each accessor, resource field). Paired with this doc.
+- [`each()` API reference](../src/elements.ts) — the `{ key }` callback passes accessors (WHISQ-62).
+- [`bind()` API reference](../src/bind.ts) — exhaustive options for single-signal inputs.
+- [`bindField()` API reference](../src/bindField.ts) — field-in-array-item binding (WHISQ-78).
 - [`batch-semantics.md`](./batch-semantics.md) — how `batch()` sequences effect flushes across multiple writes.

--- a/packages/core/docs/reactive-shapes.md
+++ b/packages/core/docs/reactive-shapes.md
@@ -108,7 +108,19 @@ ul(
 - **`keyBy` defaults to `t => t.id`** — supply `{ keyBy: (t) => t.uuid }` for items keyed on something else.
 - **Writes produce a new array** — `source.value` is replaced with an immutably-updated copy, so downstream `computed` / `effect` / keyed `each()` re-run correctly.
 
-When `bindField()` doesn't fit — deep nested paths, writes that touch multiple fields atomically, or custom logic like optimistic updates — fall back to the manual event pair:
+For forms on **nested objects** (e.g. `user.profile.email`), reach for `bindPath()` — same spread shape, object-keyed path instead of a single field, opt-in at `@whisq/core/forms` so it doesn't cost top-level bundle size:
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+input({ ...bindPath(user, ["profile", "email"]) });
+// Writes produce a new root with structural sharing on siblings —
+// user.prefs stays === across writes to user.profile.email.
+```
+
+`bindPath` does **not** traverse arrays. For array-indexed paths, reach for `bindField()` at the array level and compose from there.
+
+When none of the helpers fit — deep nested paths that cross arrays, writes that touch multiple fields atomically, or custom logic like optimistic updates — fall back to the manual event pair:
 
 ```ts
 input({
@@ -141,4 +153,5 @@ The manual pair is strictly more powerful but also strictly more verbose. Prefer
 - [`each()` API reference](../src/elements.ts) — the `{ key }` callback passes accessors (WHISQ-62).
 - [`bind()` API reference](../src/bind.ts) — exhaustive options for single-signal inputs.
 - [`bindField()` API reference](../src/bindField.ts) — field-in-array-item binding (WHISQ-78).
+- [`bindPath()` API reference](../src/bindPath.ts) — nested-object-path binding (WHISQ-86), exported from `@whisq/core/forms`.
 - [`batch-semantics.md`](./batch-semantics.md) — how `batch()` sequences effect flushes across multiple writes.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,13 +50,6 @@
   },
   "homepage": "https://whisq.dev",
   "sideEffects": false,
-  "size-limit": [
-    {
-      "path": "dist/index.js",
-      "limit": "5.5 KB",
-      "gzip": true
-    }
-  ],
   "devDependencies": {
     "@size-limit/preset-small-lib": "^11.2.0",
     "jsdom": "^29.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,10 @@
     "./collections": {
       "types": "./dist/collections.d.ts",
       "import": "./dist/collections.js"
+    },
+    "./persistence": {
+      "types": "./dist/persistence.d.ts",
+      "import": "./dist/persistence.js"
     }
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,10 @@
     "./persistence": {
       "types": "./dist/persistence.d.ts",
       "import": "./dist/persistence.js"
+    },
+    "./forms": {
+      "types": "./dist/forms.d.ts",
+      "import": "./dist/forms.js"
     }
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "5 KB",
+      "limit": "5.5 KB",
       "gzip": true
     }
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/__tests__/bindField.test.ts
+++ b/packages/core/src/__tests__/bindField.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { signal } from "../reactive.js";
+import { input, mount, each, ul } from "../elements.js";
+import { bindField } from "../bindField.js";
+
+interface Todo {
+  id: string;
+  text: string;
+  done: boolean;
+  priority: number;
+}
+
+let container: HTMLElement;
+let dispose: () => void;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+});
+
+describe("bindField() — checkbox (field inside array item)", () => {
+  it("reflects the field's initial value on the DOM", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: true, priority: 0 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "checkbox",
+              ...bindField(todos, todo, "done", { as: "checkbox" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(true);
+  });
+
+  it("writes an immutable array update when the user toggles", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+      { id: "b", text: "y", done: false, priority: 0 },
+    ]);
+    const before = todos.value;
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "checkbox",
+              ...bindField(todos, todo, "done", { as: "checkbox" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const [first] = container.querySelectorAll("input");
+    (first as HTMLInputElement).checked = true;
+    first.dispatchEvent(new Event("change"));
+
+    expect(todos.value).not.toBe(before);
+    expect(todos.value[0]).not.toBe(before[0]);
+    expect(todos.value[1]).toBe(before[1]);
+    expect(todos.value[0]).toEqual({
+      id: "a",
+      text: "x",
+      done: true,
+      priority: 0,
+    });
+  });
+
+  it("propagates programmatic field updates back to the DOM", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "checkbox",
+              ...bindField(todos, todo, "done", { as: "checkbox" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(false);
+    todos.value = todos.value.map((t) =>
+      t.id === "a" ? { ...t, done: true } : t,
+    );
+    expect(el.checked).toBe(true);
+  });
+
+  it("survives keyed array replacement (items reordered)", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+      { id: "b", text: "y", done: true, priority: 0 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "checkbox",
+              ...bindField(todos, todo, "done", { as: "checkbox" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    // Reorder — keyed each should retain DOM nodes but swap positions.
+    todos.value = [todos.value[1], todos.value[0]];
+    const [first, second] = container.querySelectorAll("input");
+    expect((first as HTMLInputElement).checked).toBe(true); // was b
+    expect((second as HTMLInputElement).checked).toBe(false); // was a
+
+    // Write to the newly-first checkbox — must still target item "b".
+    (first as HTMLInputElement).checked = false;
+    first.dispatchEvent(new Event("change"));
+    expect(todos.value.find((t) => t.id === "b")?.done).toBe(false);
+    expect(todos.value.find((t) => t.id === "a")?.done).toBe(false);
+  });
+});
+
+describe("bindField() — text / number / radio", () => {
+  it("handles text fields via oninput", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "old", done: false, priority: 0 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) => input({ ...bindField(todos, todo, "text") }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("old");
+    el.value = "new";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(todos.value[0].text).toBe("new");
+  });
+
+  it("handles numeric fields with as: number", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 3 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "number",
+              ...bindField(todos, todo, "priority", { as: "number" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("3");
+    el.value = "9";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(todos.value[0].priority).toBe(9);
+  });
+
+  it("ignores NaN on numeric write (no source mutation)", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 3 },
+    ]);
+    const before = todos.value;
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "number",
+              ...bindField(todos, todo, "priority", { as: "number" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(todos.value).toBe(before);
+    expect(todos.value[0].priority).toBe(3);
+  });
+
+  it("handles radio with as: radio", () => {
+    interface Row {
+      id: string;
+      role: "admin" | "user";
+    }
+    const rows = signal<Row[]>([{ id: "a", role: "user" }]);
+    dispose = mount(
+      ul(
+        each(
+          () => rows.value,
+          (row) =>
+            input({
+              type: "radio",
+              name: "role",
+              ...bindField(rows, row, "role", {
+                as: "radio",
+                value: "admin",
+              }),
+            }),
+          { key: (r) => r.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(false);
+    rows.value = [{ id: "a", role: "admin" }];
+    expect(el.checked).toBe(true);
+  });
+});
+
+describe("bindField() — keyBy", () => {
+  it("defaults to .id for item matching", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+    ]);
+    dispose = mount(
+      ul(
+        each(
+          () => todos.value,
+          (todo) =>
+            input({
+              type: "checkbox",
+              ...bindField(todos, todo, "done", { as: "checkbox" }),
+            }),
+          { key: (t) => t.id },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(todos.value[0].done).toBe(true);
+  });
+
+  it("accepts a custom keyBy when items are keyed on something other than id", () => {
+    interface Row {
+      uuid: string;
+      done: boolean;
+    }
+    const rows = signal<Row[]>([{ uuid: "x-1", done: false }]);
+    dispose = mount(
+      ul(
+        each(
+          () => rows.value,
+          (row) =>
+            input({
+              type: "checkbox",
+              ...bindField(rows, row, "done", {
+                as: "checkbox",
+                keyBy: (r) => r.uuid,
+              }),
+            }),
+          { key: (r) => r.uuid },
+        ),
+      ),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(rows.value[0].done).toBe(true);
+  });
+
+  it("warns and discards the write when no item matches", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+    ]);
+    // Access the item, then remove it from the source, then attempt a write.
+    const accessor = () => todos.value[0] ?? { id: "missing" };
+    const props = bindField(todos, accessor as () => Todo, "done", {
+      as: "checkbox",
+    });
+    todos.value = []; // item gone
+    (props as { onchange: (e: Event) => void }).onchange({
+      target: { checked: true } as HTMLInputElement,
+    } as unknown as Event);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("no item in source matched"),
+    );
+    expect(todos.value).toEqual([]);
+    warn.mockRestore();
+  });
+});
+
+describe("bindField() — input validation", () => {
+  it("throws TypeError when source is not a signal", () => {
+    expect(() =>
+      bindField(
+        {} as never,
+        (() => ({})) as unknown as () => { id: string },
+        "id",
+      ),
+    ).toThrow(TypeError);
+  });
+
+  it("throws TypeError when item is not a function", () => {
+    const todos = signal<Todo[]>([]);
+    expect(() =>
+      bindField(todos, "not a function" as unknown as () => Todo, "done"),
+    ).toThrow(TypeError);
+  });
+});

--- a/packages/core/src/__tests__/bindPath.test.ts
+++ b/packages/core/src/__tests__/bindPath.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { signal } from "../reactive.js";
+import { input, mount } from "../elements.js";
+// Imported from the internal path. Public import is `@whisq/core/forms`
+// (see packages/core/package.json exports).
+import { bindPath } from "../bindPath.js";
+
+interface User {
+  id: string;
+  profile: { name: string; email: string; age: number };
+  prefs: { dark: boolean; theme: "light" | "dark" };
+}
+
+const baseUser: User = {
+  id: "u1",
+  profile: { name: "ada", email: "a@b.c", age: 30 },
+  prefs: { dark: false, theme: "light" },
+};
+
+let container: HTMLElement;
+let dispose: (() => void) | undefined;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+  dispose = undefined;
+});
+
+describe("bindPath() — text (depth 2)", () => {
+  it("reflects the nested field's initial value", () => {
+    const user = signal(baseUser);
+    dispose = mount(input({ ...bindPath(user, ["profile", "name"]) }), container);
+    expect((container.querySelector("input") as HTMLInputElement).value).toBe("ada");
+  });
+
+  it("writes produce a new root with structural sharing on siblings", () => {
+    const user = signal(baseUser);
+    const before = user.value;
+    dispose = mount(input({ ...bindPath(user, ["profile", "name"]) }), container);
+
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "grace";
+    el.dispatchEvent(new InputEvent("input"));
+
+    expect(user.value).not.toBe(before);
+    expect(user.value.profile).not.toBe(before.profile);
+    // Sibling branch `prefs` should remain the same reference.
+    expect(user.value.prefs).toBe(before.prefs);
+    expect(user.value.profile.name).toBe("grace");
+    // Untouched sibling field on the same level also stable.
+    expect(user.value.profile.email).toBe("a@b.c");
+  });
+
+  it("propagates programmatic updates to the DOM", () => {
+    const user = signal(baseUser);
+    dispose = mount(input({ ...bindPath(user, ["profile", "email"]) }), container);
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("a@b.c");
+    user.value = { ...baseUser, profile: { ...baseUser.profile, email: "x@y.z" } };
+    expect(el.value).toBe("x@y.z");
+  });
+});
+
+describe("bindPath() — deeper paths (depth 3+)", () => {
+  interface Org {
+    name: string;
+    settings: {
+      billing: { plan: "free" | "pro"; seats: number };
+      ui: { density: "compact" | "comfy" };
+    };
+  }
+
+  const orgInitial: Org = {
+    name: "acme",
+    settings: {
+      billing: { plan: "free", seats: 1 },
+      ui: { density: "compact" },
+    },
+  };
+
+  it("depth-3 text field", () => {
+    const org = signal(orgInitial);
+    dispose = mount(
+      input({ ...bindPath(org, ["settings", "ui", "density"]) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("compact");
+    el.value = "comfy";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(org.value.settings.ui.density).toBe("comfy");
+  });
+
+  it("depth-3 write preserves structural sharing across cousins", () => {
+    const org = signal(orgInitial);
+    const before = org.value;
+    dispose = mount(
+      input({ ...bindPath(org, ["settings", "ui", "density"]) }),
+      container,
+    );
+
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "comfy";
+    el.dispatchEvent(new InputEvent("input"));
+
+    expect(org.value).not.toBe(before);
+    expect(org.value.settings).not.toBe(before.settings);
+    expect(org.value.settings.ui).not.toBe(before.settings.ui);
+    // Cousin branch (`billing`) preserved by reference.
+    expect(org.value.settings.billing).toBe(before.settings.billing);
+  });
+});
+
+describe("bindPath() — number / checkbox / radio", () => {
+  it("number field updates via valueAsNumber", () => {
+    const user = signal(baseUser);
+    dispose = mount(
+      input({
+        type: "number",
+        ...bindPath(user, ["profile", "age"], { as: "number" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("30");
+    el.value = "42";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(user.value.profile.age).toBe(42);
+  });
+
+  it("number NaN guard leaves source untouched", () => {
+    const user = signal(baseUser);
+    const before = user.value;
+    dispose = mount(
+      input({
+        type: "number",
+        ...bindPath(user, ["profile", "age"], { as: "number" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(user.value).toBe(before);
+    expect(user.value.profile.age).toBe(30);
+  });
+
+  it("checkbox binds deep boolean", () => {
+    const user = signal(baseUser);
+    dispose = mount(
+      input({
+        type: "checkbox",
+        ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(false);
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(user.value.prefs.dark).toBe(true);
+  });
+
+  it("radio binds deep string with as: radio / value", () => {
+    const user = signal(baseUser);
+    dispose = mount(
+      input({
+        type: "radio",
+        name: "theme",
+        ...bindPath(user, ["prefs", "theme"], { as: "radio", value: "dark" }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.checked).toBe(false);
+    user.value = { ...user.value, prefs: { ...user.value.prefs, theme: "dark" } };
+    expect(el.checked).toBe(true);
+  });
+});
+
+describe("bindPath() — input validation", () => {
+  it("throws TypeError when source is not a Signal", () => {
+    expect(() =>
+      bindPath({} as never, ["x"] as never),
+    ).toThrow(TypeError);
+  });
+
+  it("throws TypeError when path is empty", () => {
+    const s = signal({ a: 1 });
+    expect(() => bindPath(s, [] as unknown as ["a"])).toThrow(TypeError);
+  });
+
+  it("reading through a missing intermediate level returns a safe empty string", () => {
+    interface Sparse {
+      a?: { b?: string };
+    }
+    const s = signal<Sparse>({});
+    dispose = mount(input({ ...bindPath(s, ["a", "b"]) }), container);
+    const el = container.querySelector("input") as HTMLInputElement;
+    expect(el.value).toBe("");
+    // Writing through the missing intermediate creates the object structure.
+    el.value = "created";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(s.value.a?.b).toBe("created");
+  });
+});

--- a/packages/core/src/__tests__/dev-errors.test.ts
+++ b/packages/core/src/__tests__/dev-errors.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { signal } from "../reactive.js";
+import { div, each, ul, mount, component } from "../elements.js";
+import { WhisqStructureError, describeValue } from "../dev-errors.js";
+import { component as makeComponent } from "../component.js";
+
+// Re-export `component` works either way — the `component` is re-exported
+// from elements in some builds. Use `makeComponent` in tests for clarity.
+void component;
+
+let container: HTMLElement;
+let dispose: (() => void) | undefined;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+  dispose = undefined;
+});
+
+describe("WhisqStructureError — describeValue", () => {
+  it("names primitives by type + value", () => {
+    expect(describeValue(null)).toBe("null");
+    expect(describeValue(undefined)).toBe("undefined");
+    expect(describeValue(42)).toContain("42");
+    expect(describeValue(true)).toContain("true");
+    expect(describeValue("hi")).toContain("hi");
+    expect(describeValue(() => {})).toBe("function");
+  });
+
+  it("names arrays by length", () => {
+    expect(describeValue([1, 2, 3])).toBe("array (length 3)");
+    expect(describeValue([])).toBe("array (length 0)");
+  });
+
+  it("names plain objects and class instances distinctly", () => {
+    expect(describeValue({ a: 1 })).toBe("plain object");
+    class Foo {}
+    expect(describeValue(new Foo())).toBe("Foo instance");
+  });
+});
+
+describe("WhisqStructureError — message shape", () => {
+  it("composes element + expected + received + hint", () => {
+    const err = new WhisqStructureError({
+      element: "each",
+      expected: "items() to return an array",
+      received: "undefined",
+      hint: "Gate the list with when().",
+    });
+    expect(err.name).toBe("WhisqStructureError");
+    expect(err.message).toContain("each");
+    expect(err.message).toContain("items() to return an array");
+    expect(err.message).toContain("undefined");
+    expect(err.message).toContain("Hint: Gate the list with when().");
+  });
+
+  it("preserves structured fields for programmatic handling", () => {
+    const err = new WhisqStructureError({
+      element: "div",
+      expected: "WhisqNode",
+      received: "plain object",
+    });
+    expect(err.element).toBe("div");
+    expect(err.expected).toBe("WhisqNode");
+    expect(err.received).toBe("plain object");
+    expect(err.hint).toBeUndefined();
+  });
+});
+
+// ── Fixture 1: each() with non-array items() return ────────────────────────
+
+describe("each() — items() must return an array", () => {
+  it("throws a friendly WhisqStructureError when items() returns undefined (was: .map is not a function)", () => {
+    const maybe = signal<number[] | undefined>(undefined);
+    let caught: unknown;
+    try {
+      dispose = mount(
+        ul(
+          each(
+            () => maybe.value as unknown as number[],
+            (n) => ul(String(n)),
+          ),
+        ),
+        container,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WhisqStructureError);
+    expect((caught as WhisqStructureError).element).toBe("each");
+    expect((caught as WhisqStructureError).received).toBe("undefined");
+    expect((caught as Error).message).toMatch(/items\(\) to return an array/);
+    expect((caught as Error).message).toMatch(/Hint:/);
+  });
+
+  it("throws when items() returns a plain object (e.g., user passed a Map)", () => {
+    expect(() => {
+      dispose = mount(
+        ul(
+          each(
+            () => ({ a: 1, b: 2 }) as unknown as number[],
+            (n) => ul(String(n)),
+          ),
+        ),
+        container,
+      );
+    }).toThrow(WhisqStructureError);
+  });
+
+  it("throws when items is not a function (user passed the array directly)", () => {
+    expect(() => {
+      each([1, 2, 3] as unknown as () => number[], (n) => ul(String(n)));
+    }).toThrow(/items to be a function/);
+  });
+
+  it("accepts a valid items() return (sanity check — no throw)", () => {
+    const items = signal([1, 2, 3]);
+    expect(() => {
+      dispose = mount(
+        ul(
+          each(
+            () => items.value,
+            (n) => ul(String(n)),
+          ),
+        ),
+        container,
+      );
+    }).not.toThrow();
+  });
+});
+
+// ── Fixture 2: malformed child (plain object) ──────────────────────────────
+
+describe("appendChildren — plain-object child", () => {
+  it("throws a friendly WhisqStructureError naming the element (was: silent drop)", () => {
+    let caught: unknown;
+    try {
+      // Simulate a user who forgot to call the component: `div({}, MyComponent)`
+      // where MyComponent is a plain object rather than a function / WhisqNode.
+      dispose = mount(
+        div({} as never, { not: "a whisq node" } as never),
+        container,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WhisqStructureError);
+    expect((caught as WhisqStructureError).element).toBe("div");
+    expect((caught as WhisqStructureError).received).toBe("plain object");
+    expect((caught as Error).message).toMatch(/Plain objects can't be rendered/);
+  });
+});
+
+// ── Fixture 3: component setup returns wrong shape ─────────────────────────
+
+describe("component — setup must return a WhisqNode", () => {
+  it("throws a friendly WhisqStructureError when setup returns null (was: downstream crash at dispose)", () => {
+    const Broken = makeComponent(() => null as never);
+    let caught: unknown;
+    try {
+      dispose = mount(Broken({}), container);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(WhisqStructureError);
+    expect((caught as WhisqStructureError).element).toBe("component");
+    expect((caught as WhisqStructureError).received).toBe("null");
+    expect((caught as Error).message).toMatch(/return a WhisqNode/);
+  });
+
+  it("throws when setup returns a bare string", () => {
+    const Stringly = makeComponent(() => "just a string" as never);
+    expect(() => {
+      dispose = mount(Stringly({}), container);
+    }).toThrow(WhisqStructureError);
+  });
+
+  it("does not throw for valid components (regression guard)", () => {
+    const Good = makeComponent(() => div("hi"));
+    expect(() => {
+      dispose = mount(Good({}), container);
+    }).not.toThrow();
+  });
+});

--- a/packages/core/src/__tests__/match.test.ts
+++ b/packages/core/src/__tests__/match.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { signal } from "../reactive.js";
 import { div, p, span, match, mount } from "../elements.js";
+import { WhisqStructureError } from "../dev-errors.js";
 
 let container: HTMLElement;
 let dispose: () => void;
@@ -117,5 +118,64 @@ describe("match()", () => {
     const node = div(match(() => p("only the fallback")));
     dispose = mount(node, container);
     expect(container.querySelector("p")!.textContent).toBe("only the fallback");
+  });
+});
+
+// ── dev-mode validation (WHISQ-83) ─────────────────────────────────────────
+
+describe("match() — dev-mode input validation", () => {
+  it("throws WhisqStructureError for the object-dispatch shape GPT expected", () => {
+    expect(() => {
+      match(
+        // User reaching for pattern-matching on a value with an object map.
+        // `match` is a predicate chain — object dispatch isn't supported.
+        { loading: () => p("Loading") } as never,
+      );
+    }).toThrow(WhisqStructureError);
+
+    try {
+      match({ loading: () => p("Loading") } as never);
+    } catch (err) {
+      expect((err as Error).message).toMatch(/predicate chain/);
+      expect((err as WhisqStructureError).element).toBe("match");
+    }
+  });
+
+  it("throws when a branch tuple has the wrong arity or non-function members", () => {
+    expect(() => {
+      match([() => true, () => p("ok"), "extra"] as never);
+    }).toThrow(/branch tuple/);
+
+    expect(() => {
+      match([true, () => p("ok")] as never);
+    }).toThrow(/branch tuple/);
+  });
+
+  it("throws when the fallback is not in the last position", () => {
+    expect(() => {
+      match(
+        [() => true, () => p("a")],
+        () => p("fallback out of place"),
+        [() => false, () => p("b")],
+      );
+    }).toThrow(/fallback render.*last/);
+  });
+
+  it("does NOT throw for the canonical shape (regression guard)", () => {
+    expect(() => {
+      match(
+        [() => true, () => p("a")],
+        [() => false, () => p("b")],
+        () => p("fallback"),
+      );
+    }).not.toThrow();
+
+    expect(() => {
+      match([() => true, () => p("only")]);
+    }).not.toThrow();
+
+    expect(() => {
+      match();
+    }).not.toThrow();
   });
 });

--- a/packages/core/src/__tests__/persistence.test.ts
+++ b/packages/core/src/__tests__/persistence.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { effect } from "../reactive.js";
+// Imported from the internal path. Public import is `@whisq/core/persistence`
+// (see packages/core/package.json exports).
+import { persistedSignal } from "../persistence.js";
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+describe("persistedSignal() — initial load", () => {
+  it("returns the initial value when storage is empty", () => {
+    const s = persistedSignal("unset-key", 42);
+    expect(s.value).toBe(42);
+  });
+
+  it("loads a previously persisted value on init", () => {
+    window.localStorage.setItem("count", "7");
+    const s = persistedSignal("count", 0);
+    expect(s.value).toBe(7);
+  });
+
+  it("handles complex JSON values", () => {
+    window.localStorage.setItem("todos", '[{"id":"a","done":true}]');
+    const s = persistedSignal<Array<{ id: string; done: boolean }>>(
+      "todos",
+      [],
+    );
+    expect(s.value).toEqual([{ id: "a", done: true }]);
+  });
+
+  it("falls back to initial when stored JSON is malformed", () => {
+    window.localStorage.setItem("bad", "{not json}");
+    const s = persistedSignal("bad", { ok: true });
+    expect(s.value).toEqual({ ok: true });
+  });
+
+  it("falls back to initial when schema throws", () => {
+    window.localStorage.setItem("user", '{"name":"alice","age":"oops"}');
+    const s = persistedSignal<{ name: string; age: number }>(
+      "user",
+      { name: "anon", age: 0 },
+      {
+        schema: (raw) => {
+          const v = raw as { name: string; age: unknown };
+          if (typeof v.age !== "number") throw new TypeError("age");
+          return v as { name: string; age: number };
+        },
+      },
+    );
+    expect(s.value).toEqual({ name: "anon", age: 0 });
+  });
+});
+
+describe("persistedSignal() — writes", () => {
+  it("persists on .value assignment", async () => {
+    const s = persistedSignal("writes", 0);
+    s.value = 5;
+    // effect is synchronous — storage updates immediately
+    expect(window.localStorage.getItem("writes")).toBe("5");
+  });
+
+  it("persists on .update()", () => {
+    const s = persistedSignal("counter", 10);
+    s.update((n) => n + 1);
+    expect(window.localStorage.getItem("counter")).toBe("11");
+  });
+
+  it("does not overwrite storage with the initial value on init (no-op first run)", () => {
+    window.localStorage.setItem("existing", "99");
+    persistedSignal("existing", 0); // should read 99, NOT write back 0
+    expect(window.localStorage.getItem("existing")).toBe("99");
+  });
+
+  it("warns but does not throw when storage rejects the write", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const orig = Storage.prototype.setItem;
+    Storage.prototype.setItem = function throwingSet() {
+      throw new Error("QuotaExceededError");
+    };
+    try {
+      const s = persistedSignal("quota", "a");
+      expect(() => {
+        s.value = "b";
+      }).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('failed to write "quota"'),
+        expect.any(Error),
+      );
+      expect(s.value).toBe("b"); // in-memory value preserved
+    } finally {
+      Storage.prototype.setItem = orig;
+      warn.mockRestore();
+    }
+  });
+});
+
+describe("persistedSignal() — sessionStorage", () => {
+  it("routes to sessionStorage when storage: 'session'", () => {
+    const s = persistedSignal("tab-state", "init", { storage: "session" });
+    s.value = "changed";
+    expect(window.sessionStorage.getItem("tab-state")).toBe('"changed"');
+    expect(window.localStorage.getItem("tab-state")).toBeNull();
+  });
+
+  it("reads from sessionStorage on init", () => {
+    window.sessionStorage.setItem("read-session", '"pre-existing"');
+    const s = persistedSignal("read-session", "default", {
+      storage: "session",
+    });
+    expect(s.value).toBe("pre-existing");
+  });
+});
+
+describe("persistedSignal() — custom serialize/deserialize", () => {
+  it("uses custom codecs for non-JSON values (Map)", () => {
+    const initial = new Map<string, number>();
+    const s = persistedSignal("map", initial, {
+      serialize: (m) => JSON.stringify(Array.from(m.entries())),
+      deserialize: (raw) => new Map<string, number>(JSON.parse(raw)),
+    });
+
+    s.value = new Map([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    expect(window.localStorage.getItem("map")).toBe('[["a",1],["b",2]]');
+
+    // Re-hydrate from the persisted value
+    const loaded = persistedSignal("map", new Map<string, number>(), {
+      serialize: (m) => JSON.stringify(Array.from(m.entries())),
+      deserialize: (raw) => new Map<string, number>(JSON.parse(raw)),
+    });
+    expect(loaded.value.get("a")).toBe(1);
+    expect(loaded.value.get("b")).toBe(2);
+  });
+});
+
+describe("persistedSignal() — SSR safety", () => {
+  it("returns a plain signal initialized to `initial` when window is undefined", () => {
+    // Jsdom exposes `window` globally — hide it for this test.
+    const originalWindow = globalThis.window;
+    // @ts-expect-error intentional delete for SSR simulation
+    delete (globalThis as { window?: Window }).window;
+    try {
+      const s = persistedSignal("ssr", { count: 0 });
+      expect(s.value).toEqual({ count: 0 });
+      // Writes don't throw even with no storage
+      expect(() => {
+        s.value = { count: 1 };
+      }).not.toThrow();
+      expect(s.value).toEqual({ count: 1 });
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+});
+
+describe("persistedSignal() — reactivity", () => {
+  it("participates in effect tracking like a normal signal", () => {
+    const s = persistedSignal("reactive", 0);
+    const seen: number[] = [];
+    effect(() => {
+      seen.push(s.value);
+    });
+    s.value = 1;
+    s.value = 2;
+    expect(seen).toEqual([0, 1, 2]);
+  });
+});

--- a/packages/core/src/bindField.ts
+++ b/packages/core/src/bindField.ts
@@ -1,0 +1,142 @@
+// ============================================================================
+// Whisq Core — Field binding for items inside signal-held arrays
+// bindField(source, item, key, opts?) covers the "field inside an item inside
+// a keyed each()" shape that bind() doesn't reach. Sibling to bind() — same
+// discriminator shapes (text/number/checkbox/radio); write produces an
+// immutable array update on `source`.
+// ============================================================================
+
+import { type Signal, isSignal } from "./reactive.js";
+import type { TextBind, NumberBind, CheckboxBind, RadioBind } from "./bind.js";
+
+interface Common<T> {
+  keyBy?: (item: T) => unknown;
+}
+
+export type BindFieldOptions<T> =
+  | Common<T>
+  | ({ as: "number" } & Common<T>)
+  | ({ as: "checkbox" } & Common<T>)
+  | ({ as: "radio"; value: string } & Common<T>);
+
+/**
+ * Two-way binding for a field on an item inside a signal-held array.
+ *
+ * ```ts
+ * each(() => todos.value, (todo) =>
+ *   input({
+ *     type: "checkbox",
+ *     ...bindField(todos, todo, "done", { as: "checkbox" }),
+ *   }),
+ *   { key: (t) => t.id },
+ * )
+ * ```
+ *
+ * `keyBy` (default: `t => t.id`) identifies which item to rewrite. Writes
+ * produce a new array so downstream `computed` / `effect` re-run correctly.
+ */
+export function bindField<T, K extends keyof T>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+): TextBind;
+export function bindField<T, K extends keyof T>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+  options: { as: "number" } & Common<T>,
+): NumberBind;
+export function bindField<T, K extends keyof T>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+  options: { as: "checkbox" } & Common<T>,
+): CheckboxBind;
+export function bindField<T, K extends keyof T, V extends string>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+  options: { as: "radio"; value: V } & Common<T>,
+): RadioBind<V>;
+export function bindField<T, K extends keyof T>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+  options?: Common<T>,
+): TextBind;
+export function bindField<T, K extends keyof T>(
+  source: Signal<T[]>,
+  item: () => T,
+  key: K,
+  options?: BindFieldOptions<T>,
+): TextBind | NumberBind | CheckboxBind | RadioBind<string> {
+  if (!isSignal(source)) throw new TypeError("bindField: source must be Signal");
+  if (typeof item !== "function")
+    throw new TypeError("bindField: item must be a function");
+
+  const keyBy =
+    (options as Common<T>)?.keyBy ??
+    ((t: T) => (t as { id?: unknown }).id);
+
+  const write = (next: T[K]): void => {
+    const target = keyBy(item());
+    let matched = false;
+    const arr = source.value.map((t) => {
+      if (keyBy(t) === target) {
+        matched = true;
+        return { ...t, [key]: next };
+      }
+      return t;
+    });
+    if (!matched) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `bindField: no item in source matched ${String(target)}; write to "${String(key)}" discarded.`,
+      );
+      return;
+    }
+    source.value = arr;
+  };
+
+  const as = (options as { as?: string } | undefined)?.as;
+
+  if (as === "checkbox") {
+    return {
+      checked: () => item()[key] as unknown as boolean,
+      onchange: (e) => write(
+        (e.target as HTMLInputElement).checked as unknown as T[K],
+      ),
+    };
+  }
+
+  if (as === "radio") {
+    const target = (options as { value: string }).value;
+    return {
+      value: target,
+      checked: () => (item()[key] as unknown) === target,
+      onchange: (e) => {
+        if ((e.target as HTMLInputElement).checked)
+          write(target as unknown as T[K]);
+      },
+    };
+  }
+
+  if (as === "number") {
+    return {
+      value: () => String(item()[key] as unknown),
+      oninput: (e) => {
+        const n = (e.target as HTMLInputElement).valueAsNumber;
+        if (!Number.isNaN(n)) write(n as unknown as T[K]);
+      },
+    };
+  }
+
+  return {
+    value: () => String(item()[key] as unknown),
+    oninput: (e) =>
+      write(
+        (e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)
+          .value as unknown as T[K],
+      ),
+  };
+}

--- a/packages/core/src/bindPath.ts
+++ b/packages/core/src/bindPath.ts
@@ -1,0 +1,195 @@
+// ============================================================================
+// Whisq Core — Deep-path field binding for nested records
+// bindPath(source, path, opts?) covers the "nested object field" case that
+// bind() / bindField() don't reach. Use for forms on records with nested
+// shape (user.profile.email, settings.theme.mode, ...). Array traversal is
+// NOT supported in the path — reach for bindField() at the array level.
+// ============================================================================
+
+import { type Signal, isSignal } from "./reactive.js";
+import type { TextBind, NumberBind, CheckboxBind, RadioBind } from "./bind.js";
+
+type PathOptions =
+  | Record<string, never>
+  | { as: "number" }
+  | { as: "checkbox" }
+  | { as: "radio"; value: string };
+
+// Typed overloads for common depths. Deeper paths fall back to the loose
+// signature — TypeScript gives up on full path inference past ~4 levels
+// anyway, and a reasonable cast at the call site is clearer than the noise
+// a deeper typed path would add.
+
+type Path1<T, K1 extends keyof T> = readonly [K1];
+type Path2<T, K1 extends keyof T, K2 extends keyof T[K1]> = readonly [K1, K2];
+type Path3<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+> = readonly [K1, K2, K3];
+type Path4<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+  K4 extends keyof T[K1][K2][K3],
+> = readonly [K1, K2, K3, K4];
+
+function readPath(obj: unknown, path: readonly PropertyKey[]): unknown {
+  let cur: unknown = obj;
+  for (const k of path) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<PropertyKey, unknown>)[k];
+  }
+  return cur;
+}
+
+function writePath(
+  obj: unknown,
+  path: readonly PropertyKey[],
+  value: unknown,
+): unknown {
+  if (path.length === 0) return value;
+  const [head, ...rest] = path;
+  const current =
+    obj != null && typeof obj === "object"
+      ? (obj as Record<PropertyKey, unknown>)
+      : {};
+  return { ...current, [head]: writePath(current[head], rest, value) };
+}
+
+/**
+ * Two-way binding for a field at an arbitrary **object path** in a
+ * signal-held record. Use when `bind()` doesn't apply because the field
+ * lives two or more levels deep:
+ *
+ * ```ts
+ * const user = signal<User>({ id: "u1", profile: { name: "", email: "" } });
+ *
+ * form(
+ *   input({ ...bindPath(user, ["profile", "name"]) }),
+ *   input({ type: "email", ...bindPath(user, ["profile", "email"]) }),
+ *   input({ type: "checkbox",
+ *     ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) }),
+ * );
+ * ```
+ *
+ * Writes produce a new root — every level on the path gets a shallow spread,
+ * sibling branches preserve referential identity so downstream `computed` /
+ * `effect` re-runs stay narrow.
+ *
+ * ### Not in scope
+ *
+ * - **Array traversal**: `["items", 0, "done"]` is not supported. Arrays use
+ *   positional semantics but the framework already has `bindField()` for
+ *   "field on an item inside a signal-held array" — use that at the array
+ *   level and `bindPath` for nested-object-only paths.
+ * - **Auto-creating intermediate levels** that are missing: reading through
+ *   a missing parent returns `undefined`; writing through creates objects
+ *   as needed. If the intermediate existed but was `null`, you'll clobber
+ *   the null with an object on write — intentional, but worth knowing.
+ */
+export function bindPath<T, K1 extends keyof T>(
+  source: Signal<T>,
+  path: Path1<T, K1>,
+): T[K1] extends string ? TextBind : never;
+export function bindPath<T, K1 extends keyof T, K2 extends keyof T[K1]>(
+  source: Signal<T>,
+  path: Path2<T, K1, K2>,
+): T[K1][K2] extends string ? TextBind : never;
+export function bindPath<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+>(
+  source: Signal<T>,
+  path: Path3<T, K1, K2, K3>,
+): T[K1][K2][K3] extends string ? TextBind : never;
+export function bindPath<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+  K4 extends keyof T[K1][K2][K3],
+>(
+  source: Signal<T>,
+  path: Path4<T, K1, K2, K3, K4>,
+): T[K1][K2][K3][K4] extends string ? TextBind : never;
+export function bindPath<T>(
+  source: Signal<T>,
+  path: readonly PropertyKey[],
+  options: { as: "number" },
+): NumberBind;
+export function bindPath<T>(
+  source: Signal<T>,
+  path: readonly PropertyKey[],
+  options: { as: "checkbox" },
+): CheckboxBind;
+export function bindPath<T, V extends string>(
+  source: Signal<T>,
+  path: readonly PropertyKey[],
+  options: { as: "radio"; value: V },
+): RadioBind<V>;
+export function bindPath<T>(
+  source: Signal<T>,
+  path: readonly PropertyKey[],
+  options?: PathOptions,
+): TextBind;
+export function bindPath<T>(
+  source: Signal<T>,
+  path: readonly PropertyKey[],
+  options?: PathOptions,
+): TextBind | NumberBind | CheckboxBind | RadioBind<string> {
+  if (!isSignal(source)) {
+    throw new TypeError("bindPath: source must be a Signal");
+  }
+  if (!Array.isArray(path) || path.length === 0) {
+    throw new TypeError("bindPath: path must be a non-empty array of keys");
+  }
+
+  const write = (next: unknown): void => {
+    source.value = writePath(source.value, path, next) as T;
+  };
+
+  const as = (options as { as?: string } | undefined)?.as;
+
+  if (as === "checkbox") {
+    return {
+      checked: () => readPath(source.value, path) as boolean,
+      onchange: (e) =>
+        write((e.target as HTMLInputElement).checked),
+    };
+  }
+
+  if (as === "radio") {
+    const target = (options as { value: string }).value;
+    return {
+      value: target,
+      checked: () => readPath(source.value, path) === target,
+      onchange: (e) => {
+        if ((e.target as HTMLInputElement).checked) write(target);
+      },
+    };
+  }
+
+  if (as === "number") {
+    return {
+      value: () => String(readPath(source.value, path) ?? ""),
+      oninput: (e) => {
+        const n = (e.target as HTMLInputElement).valueAsNumber;
+        if (!Number.isNaN(n)) write(n);
+      },
+    };
+  }
+
+  return {
+    value: () => String(readPath(source.value, path) ?? ""),
+    oninput: (e) =>
+      write(
+        (e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)
+          .value,
+      ),
+  };
+}

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -6,6 +6,7 @@
 
 import { signal, effect } from "./reactive.js";
 import type { WhisqTemplate } from "./template.js";
+import { WhisqStructureError, describeValue } from "./dev-errors.js";
 
 type CleanupFn = () => void;
 
@@ -85,6 +86,22 @@ export function component<P extends Record<string, any> = {}>(
       template = setup(props);
     } finally {
       contextStack.pop();
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+      if (
+        template == null ||
+        typeof template !== "object" ||
+        !("el" in template) ||
+        !("dispose" in template)
+      ) {
+        throw new WhisqStructureError({
+          element: "component",
+          expected: "setup to return a WhisqNode (an element call like `div(...)`)",
+          received: describeValue(template),
+          hint: "Return the root element from your setup function: `return div(...)`. Bare strings, numbers, arrays, and null aren't valid component roots — wrap them in an element.",
+        });
+      }
     }
 
     // Run mount callbacks on next microtask (after DOM insertion)

--- a/packages/core/src/dev-errors.ts
+++ b/packages/core/src/dev-errors.ts
@@ -1,0 +1,69 @@
+// ============================================================================
+// Whisq Core — Developer-friendly structural error
+// Thrown by dev-mode validators on malformed children / structure. Guarded by
+// `process.env.NODE_ENV !== "production"` at call sites so prod bundlers
+// tree-shake the validation code away.
+// ============================================================================
+
+
+export interface WhisqStructureErrorFields {
+  /** What the framework expected at this position. */
+  expected: string;
+  /** What it actually received — human-readable. */
+  received: string;
+  /** Element or API surface where the mismatch happened (e.g. "div", "each", "component"). */
+  element: string;
+  /** Short "how to fix" hint for the most common cause. */
+  hint?: string;
+  /** Optional call-site info (file:line). Not yet populated; reserved. */
+  callsite?: string;
+}
+
+/**
+ * Thrown in dev mode when a Whisq API receives a value it can't render.
+ * Catch this to turn framework-level "structural" bugs into friendly UI.
+ * Production builds strip the throw sites — this class exists at runtime
+ * but is never instantiated outside of development / test.
+ */
+export class WhisqStructureError extends Error {
+  readonly expected: string;
+  readonly received: string;
+  readonly element: string;
+  readonly hint?: string;
+  readonly callsite?: string;
+
+  constructor(fields: WhisqStructureErrorFields) {
+    const parts = [
+      `${fields.element}: expected ${fields.expected}, received ${fields.received}.`,
+    ];
+    if (fields.hint) parts.push(`Hint: ${fields.hint}`);
+    if (fields.callsite) parts.push(`At: ${fields.callsite}`);
+    super(parts.join(" "));
+    this.name = "WhisqStructureError";
+    this.expected = fields.expected;
+    this.received = fields.received;
+    this.element = fields.element;
+    this.hint = fields.hint;
+    this.callsite = fields.callsite;
+  }
+}
+
+/**
+ * Short human description of any value — used for the `received` field of a
+ * structure error. Deliberately terse so the composed message stays short.
+ */
+export function describeValue(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (Array.isArray(value)) return `array (length ${value.length})`;
+  const t = typeof value;
+  if (t === "string") return `string ${JSON.stringify((value as string).slice(0, 40))}`;
+  if (t === "number" || t === "boolean" || t === "bigint") return `${t} ${String(value)}`;
+  if (t === "function") return "function";
+  if (t === "symbol") return "symbol";
+  if (t === "object") {
+    const ctor = (value as object).constructor?.name;
+    return ctor && ctor !== "Object" ? `${ctor} instance` : "plain object";
+  }
+  return t;
+}

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -564,10 +564,13 @@ type MatchRender = () => WhisqNode | string | null;
 type MatchBranch = readonly [() => boolean, MatchRender];
 
 /**
- * Multi-branch conditional renderer. Evaluates branches in order and renders
- * the first whose predicate returns truthy. An optional trailing fallback
- * (a bare render function, not wrapped in a tuple) renders when no branch
- * matches. Re-evaluates reactively like other children.
+ * **Predicate-chain** conditional renderer — _not_ pattern matching.
+ * Evaluates an `if / else-if` chain of `[() => predicate, () => render]` tuples
+ * and renders the first whose predicate returns truthy. An optional trailing
+ * **bare render function** (not a tuple) is the fallback, rendered only when
+ * every predicate is falsy. Returns `null` if no branch matches and no
+ * fallback is given. Re-evaluates reactively on any signal read inside the
+ * predicates.
  *
  * ```ts
  * div(
@@ -575,16 +578,63 @@ type MatchBranch = readonly [() => boolean, MatchRender];
  *     [() => users.loading(),    () => p("Loading...")],
  *     [() => !!users.error(),    () => p({ class: "error" }, users.error()!.message)],
  *     [() => !!users.data(),     () => List({ items: users.data()! })],
- *     () => p("No data yet."), // fallback
+ *     () => p("No data yet."), // fallback — bare fn, no tuple
  *   ),
  * )
  * ```
  *
- * First-true-wins: if two predicates are true, only the earlier branch renders.
+ * - **Shape**: every branch is a tuple `[() => boolean, () => WhisqNode | string | null]`.
+ *   No object form (e.g. `match({ loading: ..., error: ... })`) — this is a
+ *   predicate chain, not a value-dispatch table. For value dispatch, use a
+ *   plain getter with a switch: `() => { switch (status.value) { ... } }`.
+ * - **First-true-wins**: if two predicates are true, only the earlier branch
+ *   renders. Order branches from most specific to least.
+ * - **Fallback position**: bare render fn goes _last_. Putting it in the
+ *   middle is a bug — in dev mode it throws a `WhisqStructureError`.
  */
 export function match(...branches: MatchBranch[]): () => Child;
 export function match(...args: [...MatchBranch[], MatchRender]): () => Child;
 export function match(...args: Array<MatchBranch | MatchRender>): () => Child {
+  if (process.env.NODE_ENV !== "production") {
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      const isLast = i === args.length - 1;
+      if (Array.isArray(arg)) {
+        if (
+          arg.length !== 2 ||
+          typeof arg[0] !== "function" ||
+          typeof arg[1] !== "function"
+        ) {
+          throw new WhisqStructureError({
+            element: "match",
+            expected: "a branch tuple `[() => boolean, () => WhisqNode]`",
+            received: describeValue(arg),
+            hint: "Each branch must be a two-element tuple of functions. If you were reaching for pattern matching on a value, use `() => { switch (value.value) { ... } }` inside a getter child instead.",
+          });
+        }
+      } else if (typeof arg === "function") {
+        if (!isLast) {
+          throw new WhisqStructureError({
+            element: "match",
+            expected: "fallback render (bare function) to be the last argument",
+            received: `fallback at position ${i} of ${args.length}`,
+            hint: "Only one fallback is allowed, and it must come after every tuple branch. Reorder so the bare render function is last.",
+          });
+        }
+      } else {
+        throw new WhisqStructureError({
+          element: "match",
+          expected: "a branch tuple or a trailing fallback render function",
+          received: describeValue(arg),
+          hint:
+            typeof arg === "object" && arg !== null
+              ? "`match()` is a predicate chain, not a value-dispatch table. Plain objects like `{ loading: ..., error: ... }` aren't accepted — write tuples: `[() => state.value === 'loading', () => ...]`."
+              : "Each argument must be `[() => boolean, () => WhisqNode]` or (in the last position) a bare `() => WhisqNode` fallback.",
+        });
+      }
+    }
+  }
+
   const last = args[args.length - 1];
   const hasFallback = typeof last === "function";
   const fallback = hasFallback ? (last as MatchRender) : undefined;

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -14,6 +14,7 @@
 import { effect, isSignal, setEffectErrorHandler } from "./reactive.js";
 import { reconcileKeyed, type KeyedEntry } from "./reconcile.js";
 import type { Ref } from "./ref.js";
+import { WhisqStructureError, describeValue } from "./dev-errors.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -635,11 +636,45 @@ export function each<T>(
     | ((item: () => T, index: () => number) => WhisqNode),
   options?: { key: (item: T) => unknown },
 ): (() => Child[]) | WhisqNode {
+  if (process.env.NODE_ENV !== "production") {
+    if (typeof items !== "function") {
+      throw new WhisqStructureError({
+        element: "each",
+        expected: "items to be a function `() => T[]`",
+        received: describeValue(items),
+        hint: "Pass a getter, not the array itself: `each(() => todos.value, ...)` not `each(todos.value, ...)`.",
+      });
+    }
+    if (typeof render !== "function") {
+      throw new WhisqStructureError({
+        element: "each",
+        expected: "render to be a function",
+        received: describeValue(render),
+      });
+    }
+  }
+
+  const getItems = (): T[] => {
+    const result = items();
+    if (process.env.NODE_ENV !== "production" && !Array.isArray(result)) {
+      throw new WhisqStructureError({
+        element: "each",
+        expected: "items() to return an array",
+        received: describeValue(result),
+        hint:
+          result == null
+            ? "Data hasn't loaded yet. Gate the list with `when(() => data(), () => ul(each(...)))` or return `[]` while loading."
+            : "Return an array from the items getter — objects and maps need to be converted first (e.g. `Object.values(users.value)`).",
+      });
+    }
+    return result;
+  };
+
   if (!options?.key) {
     // Non-keyed: simple map — items are snapshots per render, no staleness
     // issue because nodes are recreated on every source change.
     const renderSnapshot = render as (item: T, index: number) => WhisqNode;
-    return () => items().map((item, i) => renderSnapshot(item, i));
+    return () => getItems().map((item, i) => renderSnapshot(item, i));
   }
 
   // Keyed: return a WhisqNode that manages its own reconciliation.
@@ -661,7 +696,7 @@ export function each<T>(
   fragment.appendChild(marker);
 
   const dispose = effect(() => {
-    const newItems = items();
+    const newItems = getItems();
     const parent = marker.parentNode;
     if (!parent) return;
 
@@ -1032,6 +1067,19 @@ function appendChildren(
     disposers.push(dispose);
     return;
   }
+
+  if (process.env.NODE_ENV !== "production") {
+    throw new WhisqStructureError({
+      element: (parent as Element).tagName?.toLowerCase() ?? "element",
+      expected:
+        "WhisqNode | string | number | boolean | null | undefined | function | array",
+      received: describeValue(child),
+      hint:
+        typeof child === "object" && !Array.isArray(child)
+          ? "Plain objects can't be rendered as children. Did you forget to call a component (`MyComponent({})` not `MyComponent`), or wrap a signal read in `() => signal.value`?"
+          : undefined,
+    });
+  }
 }
 
 function renderChild(
@@ -1067,5 +1115,18 @@ function renderChild(
     tracker.push(child.el);
     disposers.push(() => child.dispose());
     return;
+  }
+
+  if (process.env.NODE_ENV !== "production") {
+    throw new WhisqStructureError({
+      element: (parent as Element).nodeName?.toLowerCase() ?? "element",
+      expected:
+        "WhisqNode | string | number | boolean | null | undefined | array",
+      received: describeValue(child),
+      hint:
+        typeof child === "function"
+          ? "A reactive child `() => value` returned another function. Did you wrap a getter twice (`() => () => sig.value`)?"
+          : "Plain objects can't be rendered. If this came from a signal, wrap the read in `() => ...`; if it's a component, call it: `MyComponent({})`.",
+    });
   }
 }

--- a/packages/core/src/forms.ts
+++ b/packages/core/src/forms.ts
@@ -1,0 +1,10 @@
+// ============================================================================
+// Whisq Core — Form binding extensions (sub-path export)
+//
+// Import path: `@whisq/core/forms`
+//
+// Kept off the top-level bundle — apps that only need bind() and bindField()
+// (the 80% case) pay no size cost. Opt in here for nested-record binding.
+// ============================================================================
+
+export { bindPath } from "./bindPath.js";

--- a/packages/core/src/globals.d.ts
+++ b/packages/core/src/globals.d.ts
@@ -1,0 +1,6 @@
+// Minimal ambient declaration so dev-mode guards
+// (`if (process.env.NODE_ENV !== "production") { ... }`) type-check without
+// pulling in @types/node. The literal `process.env.NODE_ENV` reference at
+// every guard site lets bundlers (Vite, Rollup, webpack, esbuild) replace it
+// and dead-code-strip the development branch in production builds.
+declare const process: { env: { NODE_ENV?: string } };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,10 @@ export type { Ref, ElementRef } from "./ref.js";
 export { sheet, styles, cx, rcx, sx, theme } from "./styling.js";
 export type { StyleObject } from "./elements.js";
 
+// Dev-mode diagnostics
+export { WhisqStructureError } from "./dev-errors.js";
+export type { WhisqStructureErrorFields } from "./dev-errors.js";
+
 // Forms
 export { bind } from "./bind.js";
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,3 +127,6 @@ export type {
 } from "./bind.js";
 export { bindField } from "./bindField.js";
 export type { BindFieldOptions } from "./bindField.js";
+
+// bindPath() for nested-object paths lives at `@whisq/core/forms` — kept off
+// the top-level bundle so apps that don't need deep binding pay no size cost.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,3 +121,5 @@ export type {
   RadioBind,
   BindOptions,
 } from "./bind.js";
+export { bindField } from "./bindField.js";
+export type { BindFieldOptions } from "./bindField.js";

--- a/packages/core/src/persistence.ts
+++ b/packages/core/src/persistence.ts
@@ -1,0 +1,112 @@
+// ============================================================================
+// Whisq Core — Persisted Signals
+//
+// persistedSignal(key, initial, opts?) returns a Signal<T> backed by
+// localStorage / sessionStorage. SSR-safe (returns initial on the server),
+// schema-validated on load (throws → fall back to initial), quota-safe on
+// write (warns, keeps the in-memory value).
+//
+// Import path: `@whisq/core/persistence` — kept off the top-level bundle so
+// users who don't need it pay no size cost.
+// ============================================================================
+
+import { signal, effect, type Signal } from "./reactive.js";
+
+export interface PersistedSignalOptions<T> {
+  /** Storage backend. "local" (default) persists across tabs and reloads; "session" only for the tab. */
+  storage?: "local" | "session";
+  /** Serialize to the stored string. Default: `JSON.stringify`. */
+  serialize?: (value: T) => string;
+  /** Deserialize from the stored string. Default: `JSON.parse`. */
+  deserialize?: (raw: string) => T;
+  /**
+   * Validate the deserialized value. Return `T` on success; throw to reject
+   * and fall back to `initial`. Useful when the stored shape may have changed.
+   */
+  schema?: (raw: unknown) => T;
+}
+
+const getStorage = (which: "local" | "session"): Storage | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    return which === "session" ? window.sessionStorage : window.localStorage;
+  } catch {
+    // Accessing storage can throw in some privacy modes / cross-origin iframes.
+    return null;
+  }
+};
+
+/**
+ * A signal backed by `localStorage` (or `sessionStorage`).
+ *
+ * ```ts
+ * const todos = persistedSignal<Todo[]>("todos", []);
+ * effect(() => console.log(todos.value));  // logs after each change
+ * todos.value = [...todos.value, newTodo]; // persisted automatically
+ * ```
+ *
+ * ### Behaviors worth leading with
+ *
+ * - **SSR-safe.** On the server (`typeof window === "undefined"`), returns
+ *   a plain signal initialized to `initial` with no storage subscription.
+ * - **Schema-validated.** If `schema` throws or the stored JSON is malformed,
+ *   the signal falls back to `initial` rather than crashing at mount.
+ * - **Quota-safe.** If a write throws (`QuotaExceededError`, private mode),
+ *   logs a warning and keeps the in-memory value — the app keeps working.
+ * - **Module-scope intent.** The write effect lives for the module lifetime.
+ *   Call `persistedSignal` at module scope in your `stores/` file, not inside
+ *   components — the effect has no disposal hook by design.
+ */
+export function persistedSignal<T>(
+  key: string,
+  initial: T,
+  options?: PersistedSignalOptions<T>,
+): Signal<T> {
+  const serialize = options?.serialize ?? JSON.stringify;
+  const deserialize = options?.deserialize ?? JSON.parse;
+  const storage = getStorage(options?.storage ?? "local");
+
+  let starting: T = initial;
+  if (storage) {
+    try {
+      const raw = storage.getItem(key);
+      if (raw !== null) {
+        const parsed = deserialize(raw) as unknown;
+        starting = options?.schema
+          ? options.schema(parsed)
+          : (parsed as T);
+      }
+    } catch {
+      // Parse error, schema rejection, storage-access-error — fall through.
+      starting = initial;
+    }
+  }
+
+  const sig = signal<T>(starting);
+
+  if (storage) {
+    // Subscribe to writes. Intentionally un-disposed — persistence effects
+    // live for the module lifetime. First call runs synchronously and would
+    // overwrite the value we just read with itself, which is a no-op, so
+    // harmless.
+    let first = true;
+    effect(() => {
+      const value = sig.value;
+      if (first) {
+        first = false;
+        return;
+      }
+      try {
+        storage.setItem(key, serialize(value));
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `persistedSignal: failed to write "${key}" to ${options?.storage ?? "local"}Storage.`,
+          error,
+        );
+      }
+    });
+  }
+
+  return sig;
+}

--- a/packages/create-whisq/CHANGELOG.md
+++ b/packages/create-whisq/CHANGELOG.md
@@ -1,5 +1,119 @@
 # create-whisq
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- 35c30c1: Document the three reactive **access shapes** — signal `.value`, keyed-`each` item accessor `()`, `resource()` field `()` — honestly, without papering over the fact that the uniform-`() => value` claim describes the _wrapper_ but not what goes inside it. New canonical framework doc at [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
+  Each scaffolded project's `CLAUDE.md` now carries a three-row table and a link to the canonical doc so AI coding assistants don't have to re-derive the rule from scratch on every prompt.
+
+  Collateral updates:
+  - `packages/core/docs/reactive-shapes.md` now cross-links to `access-shapes.md`, drops the "uniform framing undersells" opener (access-shapes.md owns that framing now), and updates shape #4 from "manual event pair" to `bindField()` (shipped in WHISQ-78) with the manual pair demoted to escape-hatch status.
+  - Repo README bullet tightened from "uniform `() => value` reactive pattern" to "one reactive wrapper" with a link to the three read shapes.
+
+  Closes #79. `@whisq/core` runtime unchanged — pure docs/positioning work.
+
+- b278f60: Document **accessors across component boundaries** — the silent-staleness bug that alpha.6 feedback called the single most uncertain moment in building a todo app.
+
+  [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md) gains a full "Accessors across component boundaries" section with:
+  - A worked parent + child example where the child takes `{ todo: () => Todo }` and reads `props.todo()` inside getters.
+  - A counter-example showing the exact snapshot-at-setup pattern that silently breaks (row renders, never updates, stale `.id` after reorder).
+  - A variant table mapping parent source type (`Signal<T>`, keyed-`each` accessor, `resource()` field) to prop shapes and child read patterns.
+  - A mistakes table naming the four most common footguns (calling the accessor at the parent, snapshotting inside child setup, destructuring props, passing `.value[0]`).
+
+  All four scaffolded `CLAUDE.md` files gain the short version inline — parent + child skeleton + the "don't snapshot" rule — with a link to the canonical doc for depth.
+
+  Closes #80. Runtime-warning AC deferred to a P3 follow-up — static analysis (eslint / tsc) is a better fit than runtime instrumentation once real usage demands detection.
+
+- 757049d: Add `bindField(source, item, key, opts?)` — two-way binding for a field on an item inside a signal-held array. Closes the ergonomic gap `bind()` didn't reach: the most common UI shape in real applications (todos, carts, forms-with-rows, CRUD grids).
+
+  ```ts
+  each(
+    () => todos.value,
+    (todo) =>
+      input({
+        type: "checkbox",
+        ...bindField(todos, todo, "done", { as: "checkbox" }),
+      }),
+    { key: (t) => t.id },
+  );
+  ```
+
+  Mirrors `bind()`'s discriminator shapes (text / number / checkbox / radio). `keyBy` identifies which item to rewrite — defaults to `t => t.id`; override for items keyed on something else. Writes produce an immutable array update so downstream `computed` / `effect` re-run correctly.
+
+  All four scaffolded templates' `CLAUDE.md` reactive-shapes tables now lead with `bindField()` for this case instead of the manual event pair. The decision flow also updates to _"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."_
+
+  `@whisq/core` size budget raised from 5 KB to 5.5 KB gzipped (current: 5.08 KB). The README updates "Under 5 KB gzipped" → "~5 KB gzipped" to match. `bindField` is exported from the top-level `@whisq/core` so LLMs and autocompletion discover it alongside `bind()`.
+
+  Closes #78.
+
+- 34a2c7a: Add `bindPath(source, path, opts?)` — two-way binding for a field at an arbitrary **object path** in a signal-held record. Use when `bind()` doesn't apply because the field lives two or more levels deep (e.g. `user.profile.email`, `settings.billing.plan`). Follow-up to WHISQ-78 (`bindField`) for the nested-object case the feedback docs flagged as friction against the flat-binding primitives.
+
+  Exported from a new sub-path, `@whisq/core/forms`, so apps that only need `bind()` + `bindField()` (the 80% case) pay no bundle cost. Top-level `@whisq/core` stays at 5.25 KB gzipped.
+
+  ```ts
+  import { bindPath } from "@whisq/core/forms";
+
+  form(
+    input({ ...bindPath(user, ["profile", "name"]) }),
+    input({ type: "email", ...bindPath(user, ["profile", "email"]) }),
+    input({
+      type: "number",
+      ...bindPath(user, ["profile", "age"], { as: "number" }),
+    }),
+    input({
+      type: "checkbox",
+      ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }),
+    }),
+  );
+  ```
+
+  ### Behaviors worth leading with
+  - **Structural sharing on writes.** Writes produce a new root and new objects at every level on the path; sibling branches keep their reference identity so downstream `computed` / `effect` re-runs stay narrow.
+  - **Missing-intermediate creation.** Reading through a missing intermediate returns `undefined`; writing creates the object structure as needed.
+  - **Object keys only.** Array traversal is not supported in the path — use `bindField()` at the array level and compose. This keeps `bindPath` predictable and its implementation small.
+  - **Typed overloads** for depths 1–4; deeper paths work via the loose signature (same runtime, just less TS inference).
+
+  Mirrors `bind()` and `bindField()`'s discriminator shapes — text / number / checkbox / radio.
+
+  Scaffolded `CLAUDE.md` files gain a "Binding into nested records (opt-in, sub-path import)" block under Forms so AI-generated code for new projects discovers the pattern without reinventing it.
+
+  Closes #86.
+
+- 3a31d18: Clarify `match()` as a **predicate chain, not pattern matching**.
+
+  Audit finding: `match()` has always had exactly one shape — variadic tuple branches `[predicate, render]` with an optional trailing bare render fn as fallback. The GPT-side alpha.6 feedback flagged "object vs tuple form" confusion, but no object form exists in the code; GPT was pattern-matching against Rust/Scala/Vue conventions where `match(value, { case1, case2 })` is common.
+
+  Changes:
+  - **JSDoc** now leads with _"Predicate-chain conditional renderer — not pattern matching"_ and calls out the canonical shape, first-true-wins ordering, and fallback-position rules explicitly.
+  - **Dev-mode validation** (stripped in production builds) throws a `WhisqStructureError` when `match()` receives a plain object (the exact GPT-style confusion), a malformed tuple, or a fallback that isn't in the last position. Production bundle unchanged at 5.25 KB gzipped.
+  - **Scaffolded templates** — all four `CLAUDE.md` files now include `match` in the canonical imports line and expand the "Conditional Rendering" section to document `when()` vs `match()` with a ready example. AI-generated code for new projects will reach for `match` instead of nesting `when()`.
+
+  Closes #83.
+
+- c84e495: Add `persistedSignal(key, initial, opts?)` — a `Signal<T>` backed by `localStorage` / `sessionStorage`, exported from the new sub-path `@whisq/core/persistence` so apps that don't need it pay zero bundle cost.
+
+  ```ts
+  import { persistedSignal } from "@whisq/core/persistence";
+
+  export const todos = persistedSignal<Todo[]>("todos", []);
+  ```
+
+  Closes the "every Whisq app reinvents the guarded-localStorage-read-with-effect-writer pattern" problem identified by the alpha.6 feedback. Blessed shape, one import, no hand-rolling.
+
+  ### Behaviors worth leading with
+  - **SSR-safe.** On the server (`typeof window === "undefined"`) returns a plain signal initialized to `initial` with no storage subscription.
+  - **Schema-validated.** If the stored JSON is malformed, or an optional `schema(raw)` validator throws, the signal falls back to `initial` rather than crashing at mount.
+  - **Quota-safe.** If a write throws (`QuotaExceededError`, private mode), logs a warning and keeps the in-memory value — the app keeps working.
+  - **Module-scope intent.** Call `persistedSignal` at module scope in your `stores/` file, not inside components — the write effect lives for the module lifetime by design.
+
+  Options: `storage: "local" | "session"`, `serialize` / `deserialize` (default JSON), `schema` (validation on load).
+
+  Scaffolded templates' `CLAUDE.md` files gain a "Persisted stores (opt-in, sub-path import)" block under Shared State so AI-generated code for new projects can discover the pattern without reinventing it.
+
+  Closes #82.
+
 ## 0.1.0-alpha.6
 
 ### Minor Changes

--- a/packages/create-whisq/CHANGELOG.md
+++ b/packages/create-whisq/CHANGELOG.md
@@ -1,5 +1,66 @@
 # create-whisq
 
+## 0.1.0-alpha.6
+
+### Minor Changes
+
+- 6978011: **Breaking change to keyed `each()` render callbacks.** (In alpha pre-mode this still lands as an `alpha.N → alpha.N+1` bump.)
+
+  Fixes [#62](https://github.com/whisqjs/whisq/issues/62) — the stale-snapshot problem in keyed `each()` where field reads on an item inside the render callback pointed at the old object reference when the source array was replaced.
+
+  ### What changed
+
+  When `each(..., { key })` is used, the render callback now receives **accessor functions** instead of plain values:
+
+  ```ts
+  // Before
+  each(
+    () => todos.value,
+    (todo, index) => li({ class: () => (todo.done ? "done" : "") }, todo.text),
+    { key: (t) => t.id },
+  );
+
+  // After
+  each(
+    () => todos.value,
+    (todo, index) =>
+      li({ class: () => (todo().done ? "done" : "") }, () => todo().text),
+    { key: (t) => t.id },
+  );
+  ```
+
+  `todo()` / `index()` read from per-entry signals the reconciler updates when a same-keyed item is replaced. Wrap them in `() => todo().field` to get a reactive getter that re-runs on source changes; call them as `todo().field` for a one-shot snapshot at render time.
+
+  Non-keyed `each()` (no `options.key`) is **unchanged** — it keeps the `(item: T, index: number) => WhisqNode` signature because it recreates nodes on every source change, so staleness isn't possible there.
+
+  ### Migration
+
+  For every call site that passes `{ key }`, change `item.X` to `item().X` (and `index` to `index()`). TypeScript catches this as a type error — `item` is now `() => T`, so property access on it fails to compile.
+
+  ### Why
+
+  The old behavior required users to re-plumb a reactive lookup inside every keyed callback (`computed(() => todos.value.find(t => t.id === todo.id))`) to get correct field updates. That's the exact shape of code LLMs silently get wrong — plausible-looking output that only breaks on interaction. Shipping accessor-style callbacks aligns with Solid's idiom (which LLMs have strong priors for) and makes the reactive edge observable in the call shape.
+
+  Covered by 6 new tests in `packages/core/src/__tests__/each.test.ts`: field-read reactivity, snapshot read (non-reactive opt-out), index reflow on reorder, event-handler accessor read, and DOM node identity preservation across same-key replacement.
+
+### Patch Changes
+
+- 23f54bf: Document project-structure conventions so AI-generated Whisq code matches the scaffolder templates (WHISQ-71).
+
+  Every scaffolded project's `CLAUDE.md` now includes the full convention: one component per file in `src/components/`, one domain per file in `src/stores/`, `main.ts` is for mounting and nothing else, `src/lib/` is Whisq-free. Anti-patterns are called out explicitly (single-file apps, `src/lib/index.ts` utility soup, default exports, import-time I/O in stores).
+
+  Canonical reference lives in the framework repo at [`packages/core/docs/project-structure.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/project-structure.md). The CLAUDE.md section links to it for deep detail.
+
+  `@whisq/core` is unchanged — this is template/docs content only.
+
+- b23a0b3: Document the four reactive shapes — getter child, getter prop, `bind()` spread, and manual event pair — inside the `CLAUDE.md` that every scaffolded project ships with. Four-row cheat-sheet table plus the one-line decision flow (_"single signal you own → `bind()`; field inside an item inside a signal-held array → manual event pair"_) so AI coding assistants (Claude Code, Cursor, etc.) have the taxonomy in their context from the first prompt.
+
+  Also explicitly calls out that inside a keyed `each(..., { key })`, the callback's `item` argument is an accessor function — `todo()` not `todo` — so field reads don't go stale after the underlying array is replaced.
+
+  The full canonical taxonomy lives in the framework repo at [`packages/core/docs/reactive-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/reactive-shapes.md). The docs-site LLM reference card will port the same content as a follow-up.
+
+  No API change.
+
 ## 0.1.0-alpha.5
 
 ### Minor Changes

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -83,6 +83,18 @@ Four shapes cover every reactive position. The one-line decision flow: *"single 
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 
+#### Three ways to read inside a getter
+
+The `() => …` wrapper is uniform; what goes **inside** it depends on the source.
+
+| Source              | Read inside getter       |
+| ------------------- | ------------------------ |
+| Plain signal        | `() => sig.value`      |
+| Keyed `each` item | `() => todo().text`    |
+| `resource()` field | `() => users.loading()` |
+
+Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
 ### Events
 
 ```ts

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -72,14 +72,14 @@ div({ hidden: () => !visible.value }, "Now you see me")
 
 #### Reactive shapes — pick the right one
 
-Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → manual event pair."*
+Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."*
 
 | Shape            | Example                                                            | Use when                                             |
 | ---------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
 | Getter child     | `span(() => count.value)`                                          | A signal drives inline text                          |
 | Getter prop      | `{ class: () => active.value ? "on" : "off" }`                      | A signal drives an element attribute / class / style |
 | `bind()` spread  | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input       |
-| Manual event pair | `{ checked: () => todo().done, onchange: () => toggle(todo().id) }` | Field inside an item inside a keyed `each`          |
+| `bindField()` spread | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | Field inside an item inside a keyed `each`           |
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -12,7 +12,7 @@ import {
   div, span, h1, h2, h3, p, button, input, textarea, select, option,
   a, img, ul, ol, li, table, thead, tbody, tr, th, td, form, label,
   header, footer, nav, main, section, article, aside, strong, em,
-  h, raw, when, each, mount,
+  h, raw, when, match, each, mount,
   component, onMount, onCleanup, resource,
 } from "@whisq/core";
 ```
@@ -127,9 +127,10 @@ div({ onmouseenter: () => hovered.value = true })
 input({ onkeydown: (e) => e.key === "Enter" && submit() })
 ```
 
-### Conditional Rendering — when()
+### Conditional Rendering — when() / match()
 
 ```ts
+// when() — two-way (if / else). Third arg is the else branch.
 div(
   when(() => loggedIn.value,
     () => p("Welcome back!"),
@@ -141,7 +142,21 @@ div(
 div(
   () => isError.value ? p({ class: "error" }, "Something broke") : null,
 )
+
+// match() — predicate chain (if / else-if / ...). First-true-wins.
+// NOT pattern matching — branches are tuples [() => predicate, () => render].
+// Optional trailing bare function is the fallback.
+div(
+  match(
+    [() => users.loading(),  () => p("Loading...")],
+    [() => !!users.error(),  () => p({ class: "error" }, () => users.error().message)],
+    [() => !!users.data(),   () => List({ items: users.data() })],
+    () => p("No data yet."), // fallback — last position only
+  ),
+)
 ```
+
+Use `when()` for if/else, `match()` for if / else-if chains. For value dispatch (switch on a signal), use an inline getter: `() => { switch (status.value) { case "ready": return ReadyView(); /* ... */ } }` — that's a different shape from `match`.
 
 ### List Rendering — each()
 

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -260,6 +260,22 @@ export const addItem = (item) => { items.value = [...items.value, item]; };
 import { items, total, addItem } from "./stores/cart";
 ```
 
+### Persisted stores (opt-in, sub-path import)
+
+Use `persistedSignal` when a store should survive reloads. It is in a sub-path export so apps that don't need it pay no bundle cost.
+
+```ts
+// stores/todos.ts
+import { persistedSignal } from "@whisq/core/persistence";
+
+export const todos = persistedSignal<Todo[]>("todos", []);
+// - reads from localStorage on init, writes on change
+// - SSR-safe (returns initial when window is undefined)
+// - falls back to initial on parse/schema error; warns on quota-exceeded
+```
+
+Call at module scope in `stores/` — the write effect lives for the module lifetime by design.
+
 ## Anti-Patterns (DO NOT)
 
 - ❌ `html\`...\`` — use element functions instead (div, span, button...)

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -254,6 +254,20 @@ const LoginForm = component(() => {
 });
 ```
 
+#### Binding into nested records (opt-in, sub-path import)
+
+For forms on nested objects (`user.profile.email`, `settings.billing.plan`), use `bindPath` — same spread shape as `bind`/`bindField`, key-path instead of one key. Opt-in import so apps that don't need it pay no bundle cost.
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+input({ ...bindPath(user, ["profile", "email"]) });
+input({ type: "number", ...bindPath(user, ["profile", "age"], { as: "number" }) });
+input({ type: "checkbox", ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) });
+```
+
+Writes produce a new root with structural sharing on siblings — `user.prefs` stays `===` across writes to `user.profile.email`. Object paths only; array traversal goes through `bindField` at the array level.
+
 ### Async Data — resource()
 
 ```ts

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -95,6 +95,25 @@ The `() => …` wrapper is uniform; what goes **inside** it depends on the sourc
 
 Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
 
+#### Accessors across component boundaries
+
+When you split a child component that needs a reactive item, **pass the accessor — don't call it at the parent**:
+
+```ts
+// parent
+each(() => todos.value, (todo) => TodoItem({ todo }), { key: t => t.id })
+
+// child — read inside each getter, never destructure props or snapshot at setup
+const TodoItem = component((props: { todo: () => Todo }) => {
+  return li(
+    span(() => props.todo().text),                  // re-reads on every source change
+    button({ onclick: () => remove(props.todo().id) }, "✕"),
+  );
+});
+```
+
+Snapshotting (`const todo = props.todo()` at setup) makes the row freeze at mount — no error, just silent staleness after the next array change. The [access-shapes.md](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md) doc covers the full mistake table and the prop-shape variants (pass a signal when the child needs to write; pass a getter when it only reads).
+
 ### Events
 
 ```ts

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.6",
-    "@whisq/router": "^0.1.0-alpha.6"
+    "@whisq/core": "^0.1.0-alpha.7",
+    "@whisq/router": "^0.1.0-alpha.7"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.5",
-    "@whisq/router": "^0.1.0-alpha.5"
+    "@whisq/core": "^0.1.0-alpha.6",
+    "@whisq/router": "^0.1.0-alpha.6"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -83,6 +83,18 @@ Four shapes cover every reactive position. The one-line decision flow: *"single 
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 
+#### Three ways to read inside a getter
+
+The `() => …` wrapper is uniform; what goes **inside** it depends on the source.
+
+| Source              | Read inside getter       |
+| ------------------- | ------------------------ |
+| Plain signal        | `() => sig.value`      |
+| Keyed `each` item | `() => todo().text`    |
+| `resource()` field | `() => users.loading()` |
+
+Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
 ### Events
 
 ```ts

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -72,14 +72,14 @@ div({ hidden: () => !visible.value }, "Now you see me")
 
 #### Reactive shapes — pick the right one
 
-Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → manual event pair."*
+Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."*
 
 | Shape            | Example                                                            | Use when                                             |
 | ---------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
 | Getter child     | `span(() => count.value)`                                          | A signal drives inline text                          |
 | Getter prop      | `{ class: () => active.value ? "on" : "off" }`                      | A signal drives an element attribute / class / style |
 | `bind()` spread  | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input       |
-| Manual event pair | `{ checked: () => todo().done, onchange: () => toggle(todo().id) }` | Field inside an item inside a keyed `each`          |
+| `bindField()` spread | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | Field inside an item inside a keyed `each`           |
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -12,7 +12,7 @@ import {
   div, span, h1, h2, h3, p, button, input, textarea, select, option,
   a, img, ul, ol, li, table, thead, tbody, tr, th, td, form, label,
   header, footer, nav, main, section, article, aside, strong, em,
-  h, raw, when, each, mount,
+  h, raw, when, match, each, mount,
   component, onMount, onCleanup, resource,
 } from "@whisq/core";
 ```
@@ -127,9 +127,10 @@ div({ onmouseenter: () => hovered.value = true })
 input({ onkeydown: (e) => e.key === "Enter" && submit() })
 ```
 
-### Conditional Rendering — when()
+### Conditional Rendering — when() / match()
 
 ```ts
+// when() — two-way (if / else). Third arg is the else branch.
 div(
   when(() => loggedIn.value,
     () => p("Welcome back!"),
@@ -141,7 +142,21 @@ div(
 div(
   () => isError.value ? p({ class: "error" }, "Something broke") : null,
 )
+
+// match() — predicate chain (if / else-if / ...). First-true-wins.
+// NOT pattern matching — branches are tuples [() => predicate, () => render].
+// Optional trailing bare function is the fallback.
+div(
+  match(
+    [() => users.loading(),  () => p("Loading...")],
+    [() => !!users.error(),  () => p({ class: "error" }, () => users.error().message)],
+    [() => !!users.data(),   () => List({ items: users.data() })],
+    () => p("No data yet."), // fallback — last position only
+  ),
+)
 ```
+
+Use `when()` for if/else, `match()` for if / else-if chains. For value dispatch (switch on a signal), use an inline getter: `() => { switch (status.value) { case "ready": return ReadyView(); /* ... */ } }` — that's a different shape from `match`.
 
 ### List Rendering — each()
 

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -260,6 +260,22 @@ export const addItem = (item) => { items.value = [...items.value, item]; };
 import { items, total, addItem } from "./stores/cart";
 ```
 
+### Persisted stores (opt-in, sub-path import)
+
+Use `persistedSignal` when a store should survive reloads. It is in a sub-path export so apps that don't need it pay no bundle cost.
+
+```ts
+// stores/todos.ts
+import { persistedSignal } from "@whisq/core/persistence";
+
+export const todos = persistedSignal<Todo[]>("todos", []);
+// - reads from localStorage on init, writes on change
+// - SSR-safe (returns initial when window is undefined)
+// - falls back to initial on parse/schema error; warns on quota-exceeded
+```
+
+Call at module scope in `stores/` — the write effect lives for the module lifetime by design.
+
 ## Anti-Patterns (DO NOT)
 
 - ❌ `html\`...\`` — use element functions instead (div, span, button...)

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -254,6 +254,20 @@ const LoginForm = component(() => {
 });
 ```
 
+#### Binding into nested records (opt-in, sub-path import)
+
+For forms on nested objects (`user.profile.email`, `settings.billing.plan`), use `bindPath` — same spread shape as `bind`/`bindField`, key-path instead of one key. Opt-in import so apps that don't need it pay no bundle cost.
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+input({ ...bindPath(user, ["profile", "email"]) });
+input({ type: "number", ...bindPath(user, ["profile", "age"], { as: "number" }) });
+input({ type: "checkbox", ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) });
+```
+
+Writes produce a new root with structural sharing on siblings — `user.prefs` stays `===` across writes to `user.profile.email`. Object paths only; array traversal goes through `bindField` at the array level.
+
 ### Async Data — resource()
 
 ```ts

--- a/packages/create-whisq/src/templates/minimal/CLAUDE.md
+++ b/packages/create-whisq/src/templates/minimal/CLAUDE.md
@@ -95,6 +95,25 @@ The `() => …` wrapper is uniform; what goes **inside** it depends on the sourc
 
 Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
 
+#### Accessors across component boundaries
+
+When you split a child component that needs a reactive item, **pass the accessor — don't call it at the parent**:
+
+```ts
+// parent
+each(() => todos.value, (todo) => TodoItem({ todo }), { key: t => t.id })
+
+// child — read inside each getter, never destructure props or snapshot at setup
+const TodoItem = component((props: { todo: () => Todo }) => {
+  return li(
+    span(() => props.todo().text),                  // re-reads on every source change
+    button({ onclick: () => remove(props.todo().id) }, "✕"),
+  );
+});
+```
+
+Snapshotting (`const todo = props.todo()` at setup) makes the row freeze at mount — no error, just silent staleness after the next array change. The [access-shapes.md](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md) doc covers the full mistake table and the prop-shape variants (pass a signal when the child needs to write; pass a getter when it only reads).
+
 ### Events
 
 ```ts

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.5"
+    "@whisq/core": "^0.1.0-alpha.6"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.6"
+    "@whisq/core": "^0.1.0-alpha.7"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -83,6 +83,18 @@ Four shapes cover every reactive position. The one-line decision flow: *"single 
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 
+#### Three ways to read inside a getter
+
+The `() => …` wrapper is uniform; what goes **inside** it depends on the source.
+
+| Source              | Read inside getter       |
+| ------------------- | ------------------------ |
+| Plain signal        | `() => sig.value`      |
+| Keyed `each` item | `() => todo().text`    |
+| `resource()` field | `() => users.loading()` |
+
+Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
 ### Events
 
 ```ts

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -72,14 +72,14 @@ div({ hidden: () => !visible.value }, "Now you see me")
 
 #### Reactive shapes — pick the right one
 
-Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → manual event pair."*
+Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."*
 
 | Shape            | Example                                                            | Use when                                             |
 | ---------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
 | Getter child     | `span(() => count.value)`                                          | A signal drives inline text                          |
 | Getter prop      | `{ class: () => active.value ? "on" : "off" }`                      | A signal drives an element attribute / class / style |
 | `bind()` spread  | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input       |
-| Manual event pair | `{ checked: () => todo().done, onchange: () => toggle(todo().id) }` | Field inside an item inside a keyed `each`          |
+| `bindField()` spread | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | Field inside an item inside a keyed `each`           |
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -12,7 +12,7 @@ import {
   div, span, h1, h2, h3, p, button, input, textarea, select, option,
   a, img, ul, ol, li, table, thead, tbody, tr, th, td, form, label,
   header, footer, nav, main, section, article, aside, strong, em,
-  h, raw, when, each, mount,
+  h, raw, when, match, each, mount,
   component, onMount, onCleanup, resource,
 } from "@whisq/core";
 ```
@@ -127,9 +127,10 @@ div({ onmouseenter: () => hovered.value = true })
 input({ onkeydown: (e) => e.key === "Enter" && submit() })
 ```
 
-### Conditional Rendering — when()
+### Conditional Rendering — when() / match()
 
 ```ts
+// when() — two-way (if / else). Third arg is the else branch.
 div(
   when(() => loggedIn.value,
     () => p("Welcome back!"),
@@ -141,7 +142,21 @@ div(
 div(
   () => isError.value ? p({ class: "error" }, "Something broke") : null,
 )
+
+// match() — predicate chain (if / else-if / ...). First-true-wins.
+// NOT pattern matching — branches are tuples [() => predicate, () => render].
+// Optional trailing bare function is the fallback.
+div(
+  match(
+    [() => users.loading(),  () => p("Loading...")],
+    [() => !!users.error(),  () => p({ class: "error" }, () => users.error().message)],
+    [() => !!users.data(),   () => List({ items: users.data() })],
+    () => p("No data yet."), // fallback — last position only
+  ),
+)
 ```
+
+Use `when()` for if/else, `match()` for if / else-if chains. For value dispatch (switch on a signal), use an inline getter: `() => { switch (status.value) { case "ready": return ReadyView(); /* ... */ } }` — that's a different shape from `match`.
 
 ### List Rendering — each()
 

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -260,6 +260,22 @@ export const addItem = (item) => { items.value = [...items.value, item]; };
 import { items, total, addItem } from "./stores/cart";
 ```
 
+### Persisted stores (opt-in, sub-path import)
+
+Use `persistedSignal` when a store should survive reloads. It is in a sub-path export so apps that don't need it pay no bundle cost.
+
+```ts
+// stores/todos.ts
+import { persistedSignal } from "@whisq/core/persistence";
+
+export const todos = persistedSignal<Todo[]>("todos", []);
+// - reads from localStorage on init, writes on change
+// - SSR-safe (returns initial when window is undefined)
+// - falls back to initial on parse/schema error; warns on quota-exceeded
+```
+
+Call at module scope in `stores/` — the write effect lives for the module lifetime by design.
+
 ## Anti-Patterns (DO NOT)
 
 - ❌ `html\`...\`` — use element functions instead (div, span, button...)

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -254,6 +254,20 @@ const LoginForm = component(() => {
 });
 ```
 
+#### Binding into nested records (opt-in, sub-path import)
+
+For forms on nested objects (`user.profile.email`, `settings.billing.plan`), use `bindPath` — same spread shape as `bind`/`bindField`, key-path instead of one key. Opt-in import so apps that don't need it pay no bundle cost.
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+input({ ...bindPath(user, ["profile", "email"]) });
+input({ type: "number", ...bindPath(user, ["profile", "age"], { as: "number" }) });
+input({ type: "checkbox", ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) });
+```
+
+Writes produce a new root with structural sharing on siblings — `user.prefs` stays `===` across writes to `user.profile.email`. Object paths only; array traversal goes through `bindField` at the array level.
+
 ### Async Data — resource()
 
 ```ts

--- a/packages/create-whisq/src/templates/ssr/CLAUDE.md
+++ b/packages/create-whisq/src/templates/ssr/CLAUDE.md
@@ -95,6 +95,25 @@ The `() => …` wrapper is uniform; what goes **inside** it depends on the sourc
 
 Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
 
+#### Accessors across component boundaries
+
+When you split a child component that needs a reactive item, **pass the accessor — don't call it at the parent**:
+
+```ts
+// parent
+each(() => todos.value, (todo) => TodoItem({ todo }), { key: t => t.id })
+
+// child — read inside each getter, never destructure props or snapshot at setup
+const TodoItem = component((props: { todo: () => Todo }) => {
+  return li(
+    span(() => props.todo().text),                  // re-reads on every source change
+    button({ onclick: () => remove(props.todo().id) }, "✕"),
+  );
+});
+```
+
+Snapshotting (`const todo = props.todo()` at setup) makes the row freeze at mount — no error, just silent staleness after the next array change. The [access-shapes.md](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md) doc covers the full mistake table and the prop-shape variants (pass a signal when the child needs to write; pass a getter when it only reads).
+
 ### Events
 
 ```ts

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.6",
-    "@whisq/ssr": "^0.1.0-alpha.6"
+    "@whisq/core": "^0.1.0-alpha.7",
+    "@whisq/ssr": "^0.1.0-alpha.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.5",
-    "@whisq/ssr": "^0.1.0-alpha.5"
+    "@whisq/core": "^0.1.0-alpha.6",
+    "@whisq/ssr": "^0.1.0-alpha.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -83,6 +83,18 @@ Four shapes cover every reactive position. The one-line decision flow: *"single 
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 
+#### Three ways to read inside a getter
+
+The `() => …` wrapper is uniform; what goes **inside** it depends on the source.
+
+| Source              | Read inside getter       |
+| ------------------- | ------------------------ |
+| Plain signal        | `() => sig.value`      |
+| Keyed `each` item | `() => todo().text`    |
+| `resource()` field | `() => users.loading()` |
+
+Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
 ### Events
 
 ```ts

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -72,14 +72,14 @@ div({ hidden: () => !visible.value }, "Now you see me")
 
 #### Reactive shapes — pick the right one
 
-Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → manual event pair."*
+Four shapes cover every reactive position. The one-line decision flow: *"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."*
 
 | Shape            | Example                                                            | Use when                                             |
 | ---------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
 | Getter child     | `span(() => count.value)`                                          | A signal drives inline text                          |
 | Getter prop      | `{ class: () => active.value ? "on" : "off" }`                      | A signal drives an element attribute / class / style |
 | `bind()` spread  | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input       |
-| Manual event pair | `{ checked: () => todo().done, onchange: () => toggle(todo().id) }` | Field inside an item inside a keyed `each`          |
+| `bindField()` spread | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | Field inside an item inside a keyed `each`           |
 
 Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
 

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -12,7 +12,7 @@ import {
   div, span, h1, h2, h3, p, button, input, textarea, select, option,
   a, img, ul, ol, li, table, thead, tbody, tr, th, td, form, label,
   header, footer, nav, main, section, article, aside, strong, em,
-  h, raw, when, each, mount,
+  h, raw, when, match, each, mount,
   component, onMount, onCleanup, resource,
 } from "@whisq/core";
 ```
@@ -127,9 +127,10 @@ div({ onmouseenter: () => hovered.value = true })
 input({ onkeydown: (e) => e.key === "Enter" && submit() })
 ```
 
-### Conditional Rendering — when()
+### Conditional Rendering — when() / match()
 
 ```ts
+// when() — two-way (if / else). Third arg is the else branch.
 div(
   when(() => loggedIn.value,
     () => p("Welcome back!"),
@@ -141,7 +142,21 @@ div(
 div(
   () => isError.value ? p({ class: "error" }, "Something broke") : null,
 )
+
+// match() — predicate chain (if / else-if / ...). First-true-wins.
+// NOT pattern matching — branches are tuples [() => predicate, () => render].
+// Optional trailing bare function is the fallback.
+div(
+  match(
+    [() => users.loading(),  () => p("Loading...")],
+    [() => !!users.error(),  () => p({ class: "error" }, () => users.error().message)],
+    [() => !!users.data(),   () => List({ items: users.data() })],
+    () => p("No data yet."), // fallback — last position only
+  ),
+)
 ```
+
+Use `when()` for if/else, `match()` for if / else-if chains. For value dispatch (switch on a signal), use an inline getter: `() => { switch (status.value) { case "ready": return ReadyView(); /* ... */ } }` — that's a different shape from `match`.
 
 ### List Rendering — each()
 

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -260,6 +260,22 @@ export const addItem = (item) => { items.value = [...items.value, item]; };
 import { items, total, addItem } from "./stores/cart";
 ```
 
+### Persisted stores (opt-in, sub-path import)
+
+Use `persistedSignal` when a store should survive reloads. It is in a sub-path export so apps that don't need it pay no bundle cost.
+
+```ts
+// stores/todos.ts
+import { persistedSignal } from "@whisq/core/persistence";
+
+export const todos = persistedSignal<Todo[]>("todos", []);
+// - reads from localStorage on init, writes on change
+// - SSR-safe (returns initial when window is undefined)
+// - falls back to initial on parse/schema error; warns on quota-exceeded
+```
+
+Call at module scope in `stores/` — the write effect lives for the module lifetime by design.
+
 ## Anti-Patterns (DO NOT)
 
 - ❌ `html\`...\`` — use element functions instead (div, span, button...)

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -254,6 +254,20 @@ const LoginForm = component(() => {
 });
 ```
 
+#### Binding into nested records (opt-in, sub-path import)
+
+For forms on nested objects (`user.profile.email`, `settings.billing.plan`), use `bindPath` — same spread shape as `bind`/`bindField`, key-path instead of one key. Opt-in import so apps that don't need it pay no bundle cost.
+
+```ts
+import { bindPath } from "@whisq/core/forms";
+
+input({ ...bindPath(user, ["profile", "email"]) });
+input({ type: "number", ...bindPath(user, ["profile", "age"], { as: "number" }) });
+input({ type: "checkbox", ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }) });
+```
+
+Writes produce a new root with structural sharing on siblings — `user.prefs` stays `===` across writes to `user.profile.email`. Object paths only; array traversal goes through `bindField` at the array level.
+
 ### Async Data — resource()
 
 ```ts

--- a/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
+++ b/packages/create-whisq/src/templates/vite-plugin/CLAUDE.md
@@ -95,6 +95,25 @@ The `() => …` wrapper is uniform; what goes **inside** it depends on the sourc
 
 Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
 
+#### Accessors across component boundaries
+
+When you split a child component that needs a reactive item, **pass the accessor — don't call it at the parent**:
+
+```ts
+// parent
+each(() => todos.value, (todo) => TodoItem({ todo }), { key: t => t.id })
+
+// child — read inside each getter, never destructure props or snapshot at setup
+const TodoItem = component((props: { todo: () => Todo }) => {
+  return li(
+    span(() => props.todo().text),                  // re-reads on every source change
+    button({ onclick: () => remove(props.todo().id) }, "✕"),
+  );
+});
+```
+
+Snapshotting (`const todo = props.todo()` at setup) makes the row freeze at mount — no error, just silent staleness after the next array change. The [access-shapes.md](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md) doc covers the full mistake table and the prop-shape variants (pass a signal when the child needs to write; pass a getter when it only reads).
+
 ### Events
 
 ```ts

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.5",
-    "@whisq/router": "^0.1.0-alpha.5"
+    "@whisq/core": "^0.1.0-alpha.6",
+    "@whisq/router": "^0.1.0-alpha.6"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.5",
+    "@whisq/vite-plugin": "^0.1.0-alpha.6",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.6",
-    "@whisq/router": "^0.1.0-alpha.6"
+    "@whisq/core": "^0.1.0-alpha.7",
+    "@whisq/router": "^0.1.0-alpha.7"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.6",
+    "@whisq/vite-plugin": "^0.1.0-alpha.7",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @whisq/devtools
 
+## 0.1.0-alpha.6
+
+### Patch Changes
+
+- Updated dependencies [4f557c9]
+- Updated dependencies [6978011]
+- Updated dependencies [ea8d760]
+  - @whisq/core@0.1.0-alpha.6
+
 ## 0.1.0-alpha.5
 
 ### Minor Changes

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @whisq/devtools
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- Updated dependencies [757049d]
+- Updated dependencies [34a2c7a]
+- Updated dependencies [97203c8]
+- Updated dependencies [3a31d18]
+- Updated dependencies [c84e495]
+  - @whisq/core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ### Patch Changes

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/mcp-server
 
+## 0.1.0-alpha.6
+
 ## 0.1.0-alpha.5
 
 ### Minor Changes

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/mcp-server
 
+## 0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ## 0.1.0-alpha.5

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @whisq/router
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- Updated dependencies [757049d]
+- Updated dependencies [34a2c7a]
+- Updated dependencies [97203c8]
+- Updated dependencies [3a31d18]
+- Updated dependencies [c84e495]
+  - @whisq/core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ### Patch Changes

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @whisq/router
 
+## 0.1.0-alpha.6
+
+### Patch Changes
+
+- Updated dependencies [4f557c9]
+- Updated dependencies [6978011]
+- Updated dependencies [ea8d760]
+  - @whisq/core@0.1.0-alpha.6
+
 ## 0.1.0-alpha.5
 
 ### Minor Changes

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/sandbox
 
+## 0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ## 0.1.0-alpha.5

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/sandbox
 
+## 0.1.0-alpha.6
+
 ## 0.1.0-alpha.5
 
 ### Minor Changes

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @whisq/ssr
 
+## 0.1.0-alpha.6
+
+### Patch Changes
+
+- Updated dependencies [4f557c9]
+- Updated dependencies [6978011]
+- Updated dependencies [ea8d760]
+  - @whisq/core@0.1.0-alpha.6
+
 ## 0.1.0-alpha.5
 
 ### Minor Changes

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @whisq/ssr
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- Updated dependencies [757049d]
+- Updated dependencies [34a2c7a]
+- Updated dependencies [97203c8]
+- Updated dependencies [3a31d18]
+- Updated dependencies [c84e495]
+  - @whisq/core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ### Patch Changes

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @whisq/testing
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- Updated dependencies [757049d]
+- Updated dependencies [34a2c7a]
+- Updated dependencies [97203c8]
+- Updated dependencies [3a31d18]
+- Updated dependencies [c84e495]
+  - @whisq/core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ### Patch Changes

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @whisq/testing
 
+## 0.1.0-alpha.6
+
+### Patch Changes
+
+- Updated dependencies [4f557c9]
+- Updated dependencies [6978011]
+- Updated dependencies [ea8d760]
+  - @whisq/core@0.1.0-alpha.6
+
 ## 0.1.0-alpha.5
 
 ### Minor Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/vite-plugin
 
+## 0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ## 0.1.0-alpha.5

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/vite-plugin
 
+## 0.1.0-alpha.6
+
 ## 0.1.0-alpha.5
 
 ### Minor Changes

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Highlights

Seven framework features shipped this cycle, with docs and templates updated in lockstep so AI-generated code for scaffolded projects picks up the new patterns from the first prompt.

### Features (`@whisq/core`)

- **`bindField(source, item, key, opts?)`** ([#85](https://github.com/whisqjs/whisq/pull/85), closes [#78](https://github.com/whisqjs/whisq/issues/78)) — two-way binding for a field on an item inside a signal-held array. Closes the bind() gap for the most common UI pattern.
- **`WhisqStructureError` + dev-mode guards** ([#87](https://github.com/whisqjs/whisq/pull/87), closes [#81](https://github.com/whisqjs/whisq/issues/81)) — friendlier runtime errors for malformed children / `each` items / `component` return / `match` branches. Stripped in production.
- **`persistedSignal(key, initial, opts?)`** at `@whisq/core/persistence` ([#88](https://github.com/whisqjs/whisq/pull/88), closes [#82](https://github.com/whisqjs/whisq/issues/82)) — `Signal<T>` backed by localStorage / sessionStorage. SSR-safe, schema-validated, quota-safe.
- **`bindPath(source, path, opts?)`** at `@whisq/core/forms` ([#93](https://github.com/whisqjs/whisq/pull/93), closes [#86](https://github.com/whisqjs/whisq/issues/86)) — two-way binding for a nested-object path in a signal-held record.
- **`match()` dev-mode validation** ([#92](https://github.com/whisqjs/whisq/pull/92), closes [#83](https://github.com/whisqjs/whisq/issues/83)) — throws `WhisqStructureError` on object-dispatch-table shape, malformed tuples, misplaced fallback. JSDoc tightened: _"predicate chain, not pattern matching"_.

### Docs (`packages/core/docs/`)

- **`access-shapes.md`** ([#89](https://github.com/whisqjs/whisq/pull/89), closes [#79](https://github.com/whisqjs/whisq/issues/79)) — canonical reference for the three reactive-read patterns (signal / keyed-`each` accessor / resource field). Answers the _"is it really uniform?"_ question honestly.
- **`access-shapes.md` — Accessors across component boundaries** ([#91](https://github.com/whisqjs/whisq/pull/91), closes [#80](https://github.com/whisqjs/whisq/issues/80)) — worked example + counter-example (silent-staleness bug) + prop-shape variants + mistakes table.
- **`reactive-shapes.md`** — shape #4 updated from "manual event pair" to `bindField()` and `bindPath()`; manual pair demoted to escape-hatch. Cross-links with access-shapes.md.

### Templates (`create-whisq`)

All four scaffolded `CLAUDE.md` files updated so AI-generated code for new projects picks up:

- `match` added to canonical imports line (was missing entirely — papercut fixed alongside [#83](https://github.com/whisqjs/whisq/issues/83)).
- Expanded "Conditional Rendering" section documents `when()` vs `match()` side-by-side with a tri-state example.
- "Three ways to read inside a getter" table with link to `access-shapes.md`.
- "Accessors across component boundaries" block with parent/child skeleton and the "don't snapshot" rule.
- "Persisted stores (opt-in, sub-path import)" block under Shared State.
- "Binding into nested records (opt-in, sub-path import)" block under Forms.

### Chore

- `notify-docs-on-release.yml` now fires only on `@whisq/core@*` release tags ([#77](https://github.com/whisqjs/whisq/pull/77), closes [#75](https://github.com/whisqjs/whisq/issues/75)). Prevents the 9-tracking-issues-per-release churn seen on alpha.6.
- README refined around AI-native positioning ([#76](https://github.com/whisqjs/whisq/pull/76)).

## Bundle size

- **`@whisq/core`** (top-level): **5.25 KB gzipped** (cap 5.5 KB). Dev-mode guards strip in production via `process.env.NODE_ENV` define.
- `@whisq/core/collections` — unchanged.
- `@whisq/core/persistence` — 1.45 KB gzipped (new).
- `@whisq/core/forms` — 0.86 KB gzipped (new, `bindPath` only).

## Test plan

- [x] `pnpm check:versions` — 9 released packages at 0.1.0-alpha.7, 4 templates aligned.
- [x] `pnpm build` — all 9 workspace packages pass.
- [x] `pnpm -r test` — 571 tests across 9 packages, all green.
- [x] `pnpm --filter @whisq/core exec size-limit` — 5.25 KB, under 5.5 KB cap.
- [ ] CI end-to-end (this PR's run — watch before merge).
- [ ] Post-merge: confirm `npm view @whisq/core version` returns `0.1.0-alpha.7`.
- [ ] Post-merge: confirm `unpkg.com/@whisq/core@0.1.0-alpha.7/dist/public-api.json` returns 200.
- [ ] Post-merge: confirm exactly **one** tracking issue appears on `whisqjs/whisq.dev` (coalescing from [#77](https://github.com/whisqjs/whisq/pull/77)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)