### PR TITLE
WHISQ-98: add onSchemaFailure callback to persistedSignal

### DIFF
--- a/.changeset/persistedsignal-onschemafailure.md
+++ b/.changeset/persistedsignal-onschemafailure.md
@@ -1,0 +1,18 @@
+---
+"@whisq/core": minor
+---
+
+Add `onSchemaFailure?: (err: unknown, raw: string) => void` option to `persistedSignal`. Invoked synchronously **before** fallback to `initial` when `deserialize` throws (malformed stored JSON) or `schema` throws (validator rejects). Receives the thrown error and the exact raw string read from storage — use it to log to Sentry / show a recovery UI / decide between migrate-vs-reset.
+
+```ts
+const todos = persistedSignal<Todo[]>("todos", [], {
+  schema: validateTodosShape,
+  onSchemaFailure: (err, raw) => {
+    Sentry.captureException(err, { extra: { key: "todos", raw } });
+  },
+});
+```
+
+The callback is **not** invoked on first-visit (`raw` would be `null`, not a failure) or on storage-access errors (private mode, disabled storage — environment faults, not schema faults). If the callback itself throws, the exception is caught and logged via `console.warn` so a broken diagnostic pipeline can't prevent signal construction.
+
+Closes WHISQ-98.

--- a/packages/core/src/__tests__/persistence.test.ts
+++ b/packages/core/src/__tests__/persistence.test.ts
@@ -169,3 +169,100 @@ describe("persistedSignal() — reactivity", () => {
     expect(seen).toEqual([0, 1, 2]);
   });
 });
+
+describe("persistedSignal() — onSchemaFailure callback", () => {
+  it("fires with the parse error and the raw string when JSON is malformed", () => {
+    window.localStorage.setItem("bad-json", "{not json}");
+    const onSchemaFailure = vi.fn();
+    const s = persistedSignal("bad-json", { ok: true }, { onSchemaFailure });
+    expect(s.value).toEqual({ ok: true });
+    expect(onSchemaFailure).toHaveBeenCalledTimes(1);
+    const [err, raw] = onSchemaFailure.mock.calls[0]!;
+    expect(err).toBeInstanceOf(SyntaxError);
+    expect(raw).toBe("{not json}");
+  });
+
+  it("fires with the schema error and the raw string when the validator throws", () => {
+    const rawStored = '{"name":"alice","age":"oops"}';
+    window.localStorage.setItem("bad-schema", rawStored);
+    const onSchemaFailure = vi.fn();
+    const s = persistedSignal<{ name: string; age: number }>(
+      "bad-schema",
+      { name: "anon", age: 0 },
+      {
+        schema: (raw) => {
+          const v = raw as { name: string; age: unknown };
+          if (typeof v.age !== "number") throw new TypeError("age");
+          return v as { name: string; age: number };
+        },
+        onSchemaFailure,
+      },
+    );
+    expect(s.value).toEqual({ name: "anon", age: 0 });
+    expect(onSchemaFailure).toHaveBeenCalledTimes(1);
+    const [err, raw] = onSchemaFailure.mock.calls[0]!;
+    expect(err).toBeInstanceOf(TypeError);
+    expect((err as Error).message).toBe("age");
+    expect(raw).toBe(rawStored);
+  });
+
+  it("is NOT invoked on first visit (no stored value)", () => {
+    const onSchemaFailure = vi.fn();
+    const s = persistedSignal("first-visit", "default", { onSchemaFailure });
+    expect(s.value).toBe("default");
+    expect(onSchemaFailure).not.toHaveBeenCalled();
+  });
+
+  it("is NOT invoked on the happy path (well-formed JSON + schema accepts)", () => {
+    window.localStorage.setItem("ok-json", '{"name":"alice","age":30}');
+    const onSchemaFailure = vi.fn();
+    const s = persistedSignal<{ name: string; age: number }>(
+      "ok-json",
+      { name: "anon", age: 0 },
+      {
+        schema: (raw) => raw as { name: string; age: number },
+        onSchemaFailure,
+      },
+    );
+    expect(s.value).toEqual({ name: "alice", age: 30 });
+    expect(onSchemaFailure).not.toHaveBeenCalled();
+  });
+
+  it("is NOT invoked on storage-access errors (getItem throws)", () => {
+    const onSchemaFailure = vi.fn();
+    const originalGet = Storage.prototype.getItem;
+    Storage.prototype.getItem = function throwingGet() {
+      throw new Error("access denied");
+    };
+    try {
+      const s = persistedSignal("storage-denied", "fallback", {
+        onSchemaFailure,
+      });
+      expect(s.value).toBe("fallback");
+      expect(onSchemaFailure).not.toHaveBeenCalled();
+    } finally {
+      Storage.prototype.getItem = originalGet;
+    }
+  });
+
+  it("still falls back to initial when the callback itself throws", () => {
+    window.localStorage.setItem("cb-throws", "{not json}");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onSchemaFailure = vi.fn(() => {
+      throw new Error("logger exploded");
+    });
+    try {
+      const s = persistedSignal("cb-throws", "initial", { onSchemaFailure });
+      expect(s.value).toBe("initial");
+      expect(onSchemaFailure).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'persistedSignal: onSchemaFailure callback for "cb-throws" threw',
+        ),
+        expect.any(Error),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/persistence.ts
+++ b/packages/core/src/persistence.ts
@@ -24,6 +24,24 @@ export interface PersistedSignalOptions<T> {
    * and fall back to `initial`. Useful when the stored shape may have changed.
    */
   schema?: (raw: unknown) => T;
+  /**
+   * Called synchronously **before** falling back to `initial` when the stored
+   * payload can't be loaded. Fires on:
+   *
+   * - `deserialize(raw)` throwing (malformed stored JSON), or
+   * - `schema(parsed)` throwing (stored value rejected by the validator).
+   *
+   * Receives the thrown error and the exact `raw` string read from storage.
+   * Use for diagnostics (Sentry, analytics, migration prompts) — the fallback
+   * to `initial` still happens regardless of what the callback does.
+   *
+   * NOT invoked on first visit (no stored value — `raw` would be `null`, not
+   * a failure) or on storage-access errors (private mode, disabled storage
+   * — those are environment faults, not schema faults). If the callback
+   * itself throws, the exception is caught and logged via `console.warn` so
+   * a broken diagnostic pipeline can't prevent signal construction.
+   */
+  onSchemaFailure?: (err: unknown, raw: string) => void;
 }
 
 const getStorage = (which: "local" | "session"): Storage | null => {
@@ -68,17 +86,34 @@ export function persistedSignal<T>(
 
   let starting: T = initial;
   if (storage) {
+    let raw: string | null = null;
     try {
-      const raw = storage.getItem(key);
-      if (raw !== null) {
+      raw = storage.getItem(key);
+    } catch {
+      // Storage-access error (cross-origin iframe, privacy mode, etc.) —
+      // leave raw as null. This is an environment fault, not a schema
+      // fault, so `onSchemaFailure` does not fire.
+    }
+    if (raw !== null) {
+      try {
         const parsed = deserialize(raw) as unknown;
         starting = options?.schema
           ? options.schema(parsed)
           : (parsed as T);
+      } catch (err) {
+        starting = initial;
+        if (options?.onSchemaFailure) {
+          try {
+            options.onSchemaFailure(err, raw);
+          } catch (callbackError) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `persistedSignal: onSchemaFailure callback for "${key}" threw.`,
+              callbackError,
+            );
+          }
+        }
       }
-    } catch {
-      // Parse error, schema rejection, storage-access-error — fall through.
-      starting = initial;
     }
   }
 


### PR DESCRIPTION
Closes #98.

## Summary

- Adds optional `onSchemaFailure?: (err: unknown, raw: string) => void` to `PersistedSignalOptions<T>` in `@whisq/core/persistence`.
- Fires synchronously **before** the fallback to `initial` when `deserialize` throws (malformed stored JSON) or `schema` throws (validator rejection), with the thrown error and the exact raw string from storage.
- **Not** invoked on first-visit (null raw) or storage-access errors (private mode, disabled storage — those are environment faults, not schema faults).
- A callback that throws is caught and logged via `console.warn` so a broken diagnostic pipeline can't prevent signal construction.

Addresses the alpha.7 reviewer's concern that the bare `catch {}` in the load path erased all signal about *why* a fallback fired — distinguishing "corrupted JSON → reset", "schema rejected → migrate", and "first visit → no stored state" was impossible.

```ts
const todos = persistedSignal<Todo[]>("todos", [], {
  schema: validateTodosShape,
  onSchemaFailure: (err, raw) => {
    Sentry.captureException(err, { extra: { key: "todos", raw } });
  },
});
```

Minor refactor: the `getItem` call is now wrapped in its own try/catch, so a storage read failure is distinguishable from a parse/schema failure. Behavior for existing callers is preserved — if `onSchemaFailure` is not supplied, the user-observable behavior is identical to alpha.7.

## Test plan

- [x] New test: callback fires with `SyntaxError` + raw string on malformed stored JSON.
- [x] New test: callback fires with validator's thrown error + raw string on schema reject.
- [x] New test: callback NOT invoked on first visit (no stored value).
- [x] New test: callback NOT invoked on happy path (well-formed JSON + schema accepts).
- [x] New test: callback NOT invoked on `storage.getItem` throwing (storage-access denial).
- [x] New test: throwing callback doesn't prevent fallback to `initial` and surfaces a `console.warn`.
- [x] All 14 pre-existing persistence tests still pass.
- [x] Full suite: `pnpm -w test` → 368 tests pass across 23 files.
- [x] `pnpm -w build` clean (tsc on 9 packages).

## Out of scope

- Option B from #98 (publish a `lastLoadError` ReadonlySignal) — deferred per the issue's Recommendation A.
- Docs on whisq.dev (`/core-concepts/state-management/`, LLM reference card) — cross-repo; will be filed as a whisq.dev companion PR once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)