### PR TITLE
WHISQ-99: SSR-guard theme() and sheet() via injectCSS early-return

### DIFF
--- a/.changeset/theme-sheet-ssr-guard.md
+++ b/.changeset/theme-sheet-ssr-guard.md
@@ -1,0 +1,14 @@
+---
+"@whisq/core": patch
+---
+
+Fix `theme()` and `sheet()` throwing `ReferenceError: document is not defined` under SSR (server-side rendering). The shared internal `injectCSS()` helper now short-circuits when `typeof document === "undefined"`, matching the SSR-safe pattern that `persistedSignal` already uses.
+
+User-observable impact:
+
+- **`theme()`**: SSR call is a no-op (no `<style>` tag is written; client-side hydration takes over on mount). Previously threw.
+- **`sheet()`**: SSR call returns the in-memory classMap (so server-rendered HTML can reference the correct class names for the client to hydrate against), but skips the DOM injection step. Previously threw on the injection line.
+
+Also clarified `theme()` JSDoc: **"call once at module scope"** and **"duplicate calls = last-call-wins"** are now explicit (the duplicate-calls behavior already held; the docs didn't say so).
+
+Closes WHISQ-99 (framework side). Docs work on whisq.dev — the `/core-concepts/styling/` and `/api/theme/` pages — will land as a companion PR in that repo.

--- a/packages/core/src/__tests__/styling.test.ts
+++ b/packages/core/src/__tests__/styling.test.ts
@@ -273,3 +273,52 @@ describe("theme()", () => {
     expect(styleTags[0].textContent).not.toContain("--color-primary:red");
   });
 });
+
+// ── SSR safety ──────────────────────────────────────────────────────────────
+
+describe("styling SSR safety", () => {
+  // Simulate a server environment where `document` is undefined (the usual
+  // Node SSR shape). We do it via Object.defineProperty because jsdom exposes
+  // `document` as a non-configurable global in some setups.
+  function withoutDocument<T>(fn: () => T): T {
+    const originalDocument = globalThis.document;
+    // @ts-expect-error intentional delete for SSR simulation
+    delete (globalThis as { document?: Document }).document;
+    try {
+      return fn();
+    } finally {
+      (globalThis as { document?: Document }).document = originalDocument;
+    }
+  }
+
+  it("theme() no-ops when document is undefined (server)", () => {
+    expect(() =>
+      withoutDocument(() => {
+        theme({ color: { primary: "red" }, space: { md: "1rem" } });
+      }),
+    ).not.toThrow();
+  });
+
+  it("sheet() returns the classMap when document is undefined (server)", () => {
+    const result = withoutDocument(() =>
+      sheet({
+        card: { padding: "1rem" },
+        title: { fontSize: "1.5rem" },
+      }),
+    );
+
+    // Class names must be generated — they're referenced by server-rendered
+    // markup that the client will then hydrate against.
+    expect(typeof result.card).toBe("string");
+    expect(typeof result.title).toBe("string");
+    expect(result.card).not.toBe(result.title);
+  });
+
+  it("sheet() does not throw when document is undefined", () => {
+    expect(() =>
+      withoutDocument(() => {
+        sheet({ btn: { color: "red", "&:hover": { color: "blue" } } });
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/core/src/styling.ts
+++ b/packages/core/src/styling.ts
@@ -338,6 +338,20 @@ type ThemeTokens = Record<
  *   }
  * })
  * ```
+ *
+ * ### Call-site conventions
+ *
+ * - **Call once, at module scope** of your `styles.ts` file. The tokens
+ *   become CSS custom properties on `:root` and are available everywhere.
+ * - **Duplicate calls = last-call-wins.** A second `theme()` call replaces
+ *   the first `<style id="whisq-style-whisq-theme">` block entirely; the
+ *   new tokens take effect immediately. This is intentional — it enables
+ *   theme-switching (e.g., `theme(lightTokens)` → `theme(darkTokens)` in a
+ *   toggle handler) without leaking old tokens.
+ * - **SSR-safe.** On the server (`typeof document === "undefined"`), the
+ *   call is a no-op. The CSS variables won't appear in server-rendered
+ *   HTML; attach theme tokens in a `<style>` block in your SSR template
+ *   until a dedicated server renderer ships.
  */
 export function theme(tokens: ThemeTokens): void {
   let cssText = ":root{";
@@ -389,6 +403,12 @@ function splitRules(rules: Record<string, any>): {
 }
 
 function injectCSS(id: string, cssText: string): void {
+  // SSR-safe: on the server there is no `document` to inject into. We still
+  // want `sheet()` to return its in-memory classMap (so server-rendered
+  // markup can reference the correct class names that the client will then
+  // hydrate against), but the actual DOM injection is skipped.
+  if (typeof document === "undefined") return;
+
   // Remove existing style with same id
   const existing = document.getElementById(`whisq-style-${id}`);
   if (existing) existing.remove();


### PR DESCRIPTION
Closes #99 (framework-side).

## Summary

Fix `theme()` and `sheet()` throwing `ReferenceError: document is not defined` under SSR.

The shared internal `injectCSS()` helper unconditionally touched `document` — which meant every `sheet()` and `theme()` call threw at server-render time. Guarding at `injectCSS` (the single choke point) makes both SSR-safe via one change, matching the `persistedSignal` pattern already established in this codebase.

- **`sheet()`** — still constructs and returns its in-memory classMap on the server (so server-rendered HTML can reference the correct class names for client hydration). Only the DOM write is skipped.
- **`theme()`** — no-ops on the server. CSS variables won't appear in server-rendered HTML until a dedicated server renderer ships (`renderThemeCSS(tokens)` is deferred per #99's recommendation).

Also clarified `theme()` JSDoc with the three call-site conventions Claude's alpha.7 feedback asked for:

- "Call once, at module scope" of your `styles.ts` file.
- "Duplicate calls = last-call-wins" — already true; now documented. Enables theme-switching.
- "SSR-safe" — now a runtime reality, not just a note.

## Test plan

- [x] New test: `theme()` inside a `withoutDocument()` simulation doesn't throw.
- [x] New test: `sheet()` inside `withoutDocument()` returns the classMap with correct scoped class names.
- [x] New test: `sheet()` with nested selectors inside `withoutDocument()` doesn't throw (exercises the full code path).
- [x] All 28 pre-existing styling tests still pass (including `replaces existing theme on second call` — the last-call-wins AC from #99).
- [x] Full suite: `pnpm -w test` → 371 tests pass across 23 files (was 368 → +3 new).
- [x] `pnpm -w build` clean across all 9 packages.

## Out of scope

- `renderThemeCSS(tokens)` helper for streaming SSR-rendered tokens — deferred per #99's Recommendation A until `@whisq/ssr` has a concrete need.
- whisq.dev docs updates (`/core-concepts/styling/` + `/api/theme/` + LLM reference card) — cross-repo; companion PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)