### PR TITLE
WHISQ-97: array-accepting class prop for mixed static/reactive composition

### DIFF
--- a/.changeset/array-accepting-class-prop.md
+++ b/.changeset/array-accepting-class-prop.md
@@ -1,0 +1,22 @@
+---
+"@whisq/core": minor
+---
+
+The `class:` prop on every element now accepts an **array of sources** with per-source reactivity. Strings are class names; falsy values (`false | null | undefined | 0 | ""`) are filtered out — enabling the `cond && "active"` shorthand inline; functions are reactive — each function is called during the render effect and re-reads when its tracked signals change.
+
+```ts
+div({
+  class: [
+    "btn",
+    () => `btn-${variant.value}`,       // reactive
+    loading.value && "btn-loading",     // static conditional — cond && "…"
+    () => isDisabled.value && "disabled", // reactive conditional
+  ],
+});
+```
+
+If any array element is a function, the array is applied reactively; otherwise it's applied once at mount. This removes the `cx` vs `rcx` migration footgun Claude's alpha.7 feedback flagged — you no longer have to remember which helper to import when a class prop grows a reactive branch mid-edit.
+
+`cx` and `rcx` continue to work unchanged — this is a pure addition. A future release may collapse them into a single composition helper (see WHISQ-97 option A) but that change is deferred.
+
+Closes WHISQ-97 option B. Options A (unified `cx`) and the `rcx` deprecation path remain open on the issue for a follow-up cycle.

--- a/packages/core/src/__tests__/elements.test.ts
+++ b/packages/core/src/__tests__/elements.test.ts
@@ -59,6 +59,96 @@ describe("h()", () => {
     expect(container.firstElementChild!.className).toBe("on");
   });
 
+  // ── Array-form class prop (WHISQ-97, option B) ────────────────────────────
+
+  it("accepts a static class array and joins with spaces", () => {
+    const node = h("div", { class: ["btn", "primary"] });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("btn primary");
+  });
+
+  it("filters falsy values from a static class array", () => {
+    const node = h("div", {
+      class: ["btn", false, null, undefined, 0, "", "primary"],
+    });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("btn primary");
+  });
+
+  it("supports the `cond && 'active'` shorthand in class array", () => {
+    const isActive = true;
+    const isDisabled = false;
+    const node = h("div", {
+      class: ["btn", isActive && "active", isDisabled && "disabled"],
+    });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("btn active");
+  });
+
+  it("applies a class array reactively when any source is a function", () => {
+    const variant = signal<"primary" | "secondary">("primary");
+    const loading = signal(false);
+    const node = h("div", {
+      class: [
+        "btn",
+        () => `btn-${variant.value}`,
+        () => loading.value && "btn-loading",
+      ],
+    });
+    dispose = mount(node, container);
+
+    expect(container.firstElementChild!.className).toBe("btn btn-primary");
+
+    variant.value = "secondary";
+    expect(container.firstElementChild!.className).toBe("btn btn-secondary");
+
+    loading.value = true;
+    expect(container.firstElementChild!.className).toBe(
+      "btn btn-secondary btn-loading",
+    );
+  });
+
+  it("filters falsy returns from reactive sources in a class array", () => {
+    const show = signal(false);
+    const node = h("div", {
+      class: ["base", () => (show.value ? "on" : null)],
+    });
+    dispose = mount(node, container);
+
+    expect(container.firstElementChild!.className).toBe("base");
+
+    show.value = true;
+    expect(container.firstElementChild!.className).toBe("base on");
+
+    show.value = false;
+    expect(container.firstElementChild!.className).toBe("base");
+  });
+
+  it("treats an empty class array as an empty className", () => {
+    const node = h("div", { class: [] });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("");
+  });
+
+  it("treats an all-falsy class array as an empty className", () => {
+    const node = h("div", { class: [false, null, undefined, 0, ""] });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("");
+  });
+
+  it("does not create a reactive effect for a purely static class array", () => {
+    // Cover the common case — static array doesn't leak an effect that
+    // would fire on unrelated signal changes. We verify indirectly: the
+    // className matches expectation and mutating an unrelated signal in
+    // the same frame doesn't affect rendering.
+    const unrelated = signal("x");
+    const node = h("div", { class: ["btn", "primary"] });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("btn primary");
+    unrelated.value = "y"; // must not cause any re-read
+    expect(container.firstElementChild!.className).toBe("btn primary");
+  });
+
   it("applies reactive style prop", () => {
     const color = signal("red");
     const node = h("div", { style: () => `color: ${color.value}` });

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -74,9 +74,26 @@ type ReactiveProp<T> = T | (() => T);
 type StyleValue = string | number | null | undefined;
 export type StyleObject = Record<string, StyleValue | (() => StyleValue)>;
 
+/**
+ * A single source inside a `class: [...]` array. Strings become class names;
+ * falsy values (`false | null | undefined | 0 | ""`) are filtered out,
+ * enabling the `cond && "active"` shorthand; functions are reactive — each
+ * function is called during the render effect, so reads inside it track.
+ */
+export type ClassArraySource =
+  | string
+  | false
+  | null
+  | undefined
+  | 0
+  | ""
+  | (() => string | false | null | undefined);
+
 interface BaseProps {
   ref?: Ref;
-  class?: ReactiveProp<string | undefined>;
+  class?:
+    | ReactiveProp<string | undefined>
+    | readonly ClassArraySource[];
   id?: ReactiveProp<string | undefined>;
   style?: ReactiveProp<string | undefined> | StyleObject;
   hidden?: ReactiveProp<boolean>;
@@ -224,6 +241,22 @@ export function h(
       if (key === "style" && isPlainStyleObject(value)) {
         // Style object — per-property reactive subscriptions
         applyStyleObject(el as HTMLElement, value, disposers);
+        continue;
+      }
+      if (key === "class" && Array.isArray(value)) {
+        // Array form (WHISQ-97): class: ["btn", () => ..., cond && "x"].
+        // Reactive if any source is a function; static otherwise. Falsy
+        // sources (false / null / undefined / 0 / "") are filtered out.
+        const sources = value as readonly ClassArraySource[];
+        const hasReactive = sources.some((s) => typeof s === "function");
+        if (hasReactive) {
+          const dispose = effect(() => {
+            applyProp(el, "class", joinClassArray(sources));
+          });
+          disposers.push(dispose);
+        } else {
+          applyProp(el, "class", joinClassArray(sources));
+        }
         continue;
       }
       if (key.startsWith("on") && typeof value === "function") {
@@ -1004,6 +1037,20 @@ function isPlainStyleObject(value: unknown): value is StyleObject {
   }
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
+}
+
+function joinClassArray(sources: readonly ClassArraySource[]): string {
+  const parts: string[] = [];
+  for (const src of sources) {
+    if (!src) continue; // filters false / null / undefined / 0 / ""
+    if (typeof src === "string") {
+      parts.push(src);
+    } else if (typeof src === "function") {
+      const result = src();
+      if (result) parts.push(result);
+    }
+  }
+  return parts.join(" ");
 }
 
 function camelToKebab(str: string): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,7 +83,12 @@ export {
   hr,
   iframe,
 } from "./elements.js";
-export type { WhisqNode, EventHandler, WhisqEvent } from "./elements.js";
+export type {
+  WhisqNode,
+  EventHandler,
+  WhisqEvent,
+  ClassArraySource,
+} from "./elements.js";
 
 // Component model
 export {


### PR DESCRIPTION
Closes #97 (option B; options A + rcx deprecation deferred).

## Summary

`class:` now accepts a `readonly ClassArraySource[]` alongside its existing `string | (() => string)` shapes. Strings become class names; falsy values (`false | null | undefined | 0 | \"\"`) are filtered out — enabling the `cond && \"active\"` shorthand inline; functions are reactive — each is called inside the same render effect and tracks its signal reads.

```ts
div({
  class: [
    "btn",
    () => `btn-${variant.value}`,          // reactive
    loading.value && "btn-loading",         // static conditional
    () => isDisabled.value && "disabled",   // reactive conditional
  ],
});
```

If **any** element is a function, the array is applied reactively; otherwise once at mount (no effect allocated for the common static case).

This closes the main user-facing pain Claude's alpha.7 feedback flagged — the `cx` → `rcx` migration footgun where a class silently freezes when a `cx` call grows a reactive branch and the caller forgets to switch helpers. With array composition in the `class:` prop directly, that choice is no longer required at the call site.

## Test plan

- [x] Static array joined with spaces.
- [x] Falsy filter — `false | null | undefined | 0 | \"\"` all excluded.
- [x] `cond && \"active\"` shorthand works (static).
- [x] Reactive getter re-renders className on signal change.
- [x] Falsy returns from reactive getters filtered dynamically (toggle on/off).
- [x] Empty array → empty className.
- [x] All-falsy array → empty className.
- [x] Purely static array doesn't create a tracking effect (unrelated signal mutation doesn't trigger re-read).
- [x] All 31 pre-existing element tests still pass.
- [x] Full suite: `pnpm -w test` → 379 core tests pass (was 371 → +8 new).
- [x] `pnpm -w build` clean across all 9 packages; `ClassArraySource` added to `public-api.json` via `@whisq/core` export.

## Out of scope — tracked on #97 for follow-up

- Option A: widening `cx()` return type to `string | (() => string)` based on whether any argument is a function.
- Deprecating `rcx` as a dev-only alias with migration hint.
- LLM reference card update to collapse the `cx` + `rcx` split into one \"Composing classes\" section.

`cx` and `rcx` are **unchanged** — this is a pure addition. Existing code keeps working exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)