### PR TITLE
WHISQ-102: scaffold canonical full-app shape — components/, lib/, errorBoundary

### DIFF
--- a/.changeset/full-app-template-canonical-shape.md
+++ b/.changeset/full-app-template-canonical-shape.md
@@ -1,0 +1,14 @@
+---
+"create-whisq": minor
+---
+
+`full-app` template now scaffolds the canonical multi-file shape that the project-structure docs describe:
+
+- **`src/components/`** — `CounterRow.ts` demonstrates the pattern for reusable UI pulled out of a page.
+- **`src/lib/`** — `format.ts` demonstrates a pure utility module (no `@whisq/*` imports), including `formatCount()` and `clamp()` used by the scaffolded `CounterRow`.
+- **`src/App.ts`** — now wraps `RouterView` in `errorBoundary`, so a thrown error in any page degrades to a retry UI instead of tearing down the whole app. Demonstrates the canonical error-boundary shape `App.ts` should own.
+- **`src/pages/Home.ts`** — rewritten to consume `CounterRow` + `clamp`, connecting all four directories (`pages/` → `components/` → `lib/`) in one working example.
+
+Closes the framework-side half of WHISQ-102. A whisq.dev companion page (`/examples/canonical-app-structure/`) is tracked for a follow-up PR.
+
+Existing `full-app` behavior (router, stores/, styles.ts, pages/About.ts) is unchanged.

--- a/packages/create-whisq/src/__tests__/cli.test.ts
+++ b/packages/create-whisq/src/__tests__/cli.test.ts
@@ -175,6 +175,50 @@ describe("createProject — full-app", () => {
     expect(fs.existsSync(path.join(projectDir, "CLAUDE.md"))).toBe(true);
     expect(fs.existsSync(path.join(projectDir, ".cursorrules"))).toBe(true);
   });
+
+  it("scaffolds components/ with at least one reusable component", () => {
+    const projectDir = path.join(tmpDir, "full-app-components");
+
+    createProject({ projectName: projectDir, template: "full-app" });
+
+    const componentsDir = path.join(projectDir, "src", "components");
+    expect(fs.existsSync(componentsDir)).toBe(true);
+    const componentFiles = fs
+      .readdirSync(componentsDir)
+      .filter((f) => f.endsWith(".ts"));
+    expect(componentFiles.length).toBeGreaterThan(0);
+  });
+
+  it("scaffolds lib/ with at least one utility (no Whisq imports)", () => {
+    const projectDir = path.join(tmpDir, "full-app-lib");
+
+    createProject({ projectName: projectDir, template: "full-app" });
+
+    const libDir = path.join(projectDir, "src", "lib");
+    expect(fs.existsSync(libDir)).toBe(true);
+    const libFiles = fs
+      .readdirSync(libDir)
+      .filter((f) => f.endsWith(".ts"));
+    expect(libFiles.length).toBeGreaterThan(0);
+
+    // lib/ is Whisq-free: utilities should be testable in isolation.
+    for (const file of libFiles) {
+      const contents = fs.readFileSync(path.join(libDir, file), "utf-8");
+      expect(contents).not.toMatch(/from\s+["']@whisq\//);
+    }
+  });
+
+  it("App.ts wraps route content in errorBoundary", () => {
+    const projectDir = path.join(tmpDir, "full-app-error-boundary");
+
+    createProject({ projectName: projectDir, template: "full-app" });
+
+    const app = fs.readFileSync(
+      path.join(projectDir, "src", "App.ts"),
+      "utf-8",
+    );
+    expect(app).toContain("errorBoundary");
+  });
 });
 
 // ── createProject — ssr ───────────────────────────────────────────────────

--- a/packages/create-whisq/src/templates/full-app/src/App.ts
+++ b/packages/create-whisq/src/templates/full-app/src/App.ts
@@ -1,4 +1,8 @@
-import { component, div } from "@whisq/core";
+// App.ts owns the top-level shell: routing, layout, error boundary, head
+// setup. Business logic goes in `stores/`; route targets in `pages/`;
+// reusable UI in `components/`; pure utilities in `lib/`.
+
+import { component, div, p, button, errorBoundary } from "@whisq/core";
 import { createRouter, RouterView, Link } from "@whisq/router";
 import { Home } from "./pages/Home";
 import { About } from "./pages/About";
@@ -19,6 +23,24 @@ const Nav = component(() =>
   ),
 );
 
+// The boundary wraps the route content so a thrown error in any page (or
+// its child components / effects) degrades gracefully to a retry UI instead
+// of tearing down the whole app.
 export const App = component(() =>
-  div({ class: s.app }, Nav({}), div({ class: s.content }, RouterView(router))),
+  div(
+    { class: s.app },
+    Nav({}),
+    div(
+      { class: s.content },
+      errorBoundary(
+        (error, retry) =>
+          div(
+            p({ class: s.heading }, "Something broke"),
+            p({ class: s.text }, error.message),
+            button({ class: s.btn, onclick: retry }, "Retry"),
+          ),
+        () => RouterView(router),
+      ),
+    ),
+  ),
 );

--- a/packages/create-whisq/src/templates/full-app/src/components/CounterRow.ts
+++ b/packages/create-whisq/src/templates/full-app/src/components/CounterRow.ts
@@ -1,0 +1,25 @@
+// Reusable UI component. One component per file, PascalCase — the filename
+// matches the named export. Pulled out of pages/Home.ts so it can be reused
+// on other pages without copy/paste.
+
+import { component, div, button, span } from "@whisq/core";
+import { s } from "../styles";
+import { formatCount } from "../lib/format";
+
+interface CounterRowProps {
+  /** Reactive getter for the current count. */
+  count: () => number;
+  /** Increment handler. */
+  onIncrement: () => void;
+  /** Decrement handler. */
+  onDecrement: () => void;
+}
+
+export const CounterRow = component((props: CounterRowProps) =>
+  div(
+    { class: s.row },
+    button({ class: s.btn, onclick: props.onDecrement }, "-"),
+    span({ class: s.count }, () => formatCount(props.count())),
+    button({ class: s.btn, onclick: props.onIncrement }, "+"),
+  ),
+);

--- a/packages/create-whisq/src/templates/full-app/src/lib/format.ts
+++ b/packages/create-whisq/src/templates/full-app/src/lib/format.ts
@@ -1,0 +1,18 @@
+// Pure utilities. NO Whisq imports — `lib/` modules stay testable in
+// isolation. If a helper needs a signal, it belongs in `stores/` instead.
+
+/**
+ * Format a count as a human-readable string. Uses locale-aware grouping so
+ * 1234 renders as "1,234" in en-US, "1.234" in de-DE, etc.
+ */
+export function formatCount(n: number): string {
+  return n.toLocaleString();
+}
+
+/**
+ * Clamp a number between a min and a max. Useful for bounding user input
+ * before handing it to a signal write.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/packages/create-whisq/src/templates/full-app/src/pages/Home.ts
+++ b/packages/create-whisq/src/templates/full-app/src/pages/Home.ts
@@ -1,14 +1,7 @@
-import {
-  signal,
-  computed,
-  component,
-  div,
-  h1,
-  button,
-  span,
-  p,
-} from "@whisq/core";
+import { signal, computed, component, div, h1, p } from "@whisq/core";
 import { s } from "../styles";
+import { CounterRow } from "../components/CounterRow";
+import { clamp } from "../lib/format";
 
 export const Home = component(() => {
   const count = signal(0);
@@ -16,14 +9,21 @@ export const Home = component(() => {
     count.value === 0 ? "Click to start" : `Count: ${count.value}`,
   );
 
+  // Keep count bounded — clamp is a pure utility from lib/, Whisq-free.
+  const increment = () => {
+    count.value = clamp(count.value + 1, -99, 99);
+  };
+  const decrement = () => {
+    count.value = clamp(count.value - 1, -99, 99);
+  };
+
   return div(
     h1({ class: s.heading }, "Home"),
     p({ class: s.text }, () => label.value),
-    div(
-      { class: s.row },
-      button({ class: s.btn, onclick: () => count.value-- }, "-"),
-      span({ class: s.count }, () => `${count.value}`),
-      button({ class: s.btn, onclick: () => count.value++ }, "+"),
-    ),
+    CounterRow({
+      count: () => count.value,
+      onIncrement: increment,
+      onDecrement: decrement,
+    }),
   );
 });


### PR DESCRIPTION
Closes #102 (framework side).

## Summary

`full-app` template now scaffolds the canonical multi-file shape the project-structure docs describe. Before this PR, the template had `App.ts`, `main.ts`, `pages/`, `stores/`, `styles.ts` — close to the documented shape but missing `components/`, `lib/`, and any canonical `errorBoundary` usage. GPT's alpha.7 feedback flagged the gap: docs say one shape, scaffold produces another, and AI tools generating Whisq code default to the scaffold's shape on first try.

- **`src/components/CounterRow.ts`** — reusable UI extracted from `pages/Home.ts`. Demonstrates the accessor-prop pattern (`count: () => number`) and consumes a `lib/` utility.
- **`src/lib/format.ts`** — pure utilities (`formatCount`, `clamp`). No `@whisq/*` imports, per the `lib/` convention that keeps modules testable in isolation.
- **`src/App.ts`** — now wraps `RouterView` in `errorBoundary` so a thrown error in any page degrades to a retry UI instead of tearing down the whole app.
- **`src/pages/Home.ts`** — rewritten to use `CounterRow` + `clamp`, connecting `pages/` → `components/` → `lib/` in one working example.

Existing router, `stores/`, `styles.ts`, `pages/About.ts`, `CLAUDE.md`, and `.cursorrules` are unchanged — `CLAUDE.md` already described the canonical shape; now the scaffold matches.

## Test plan

- [x] New test: `components/` exists with at least one `.ts` file.
- [x] New test: `lib/` exists with at least one `.ts` file AND no `@whisq/*` imports (enforces the lib-is-Whisq-free rule mechanically).
- [x] New test: `App.ts` contains `errorBoundary` usage.
- [x] All 22 pre-existing `create-whisq` tests still pass.
- [x] Full suite: 25 create-whisq tests pass (was 22 → +3 new); 379 core tests still pass; all 18 workspace test tasks green.
- [x] `pnpm -w build` clean across all 9 packages.
- [x] Smoke-test: scaffolded `/tmp/whisq-full-app-smoke` produces the correct tree (`src/App.ts`, `src/components/CounterRow.ts`, `src/lib/format.ts`, `src/main.ts`, `src/pages/{Home,About}.ts`, `src/stores/counter.ts`, `src/styles.ts`).

## Out of scope

- `whisq.dev /examples/canonical-app-structure/` page — cross-repo, companion PR.

## Adjacent bug observed during smoke test (not fixed here)

While scaffolding a real project and running its `pnpm build` (i.e., `tsc && vite build`), the published types for `component()` declare `setup: (props) => WhisqTemplate` — a legacy template-literal shape — but every element function returns `WhisqNode`, and `component()`'s runtime check also expects `WhisqNode`-shaped output. This means every alpha.7 scaffold fails `tsc --strict` with `WhisqNode is missing properties: fragment, bindings`. The error pre-exists this PR (reproduced against the `develop` HEAD pre-branch) and is independent of the template shape. Will file as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)