### PR TITLE
WHISQ-100: bindField dev-strict mode + WhisqKeyByError

### DIFF
--- a/.changeset/bindfield-dev-strict-mode.md
+++ b/.changeset/bindfield-dev-strict-mode.md
@@ -1,0 +1,19 @@
+---
+"@whisq/core": minor
+---
+
+`bindField` now throws a `WhisqKeyByError` on no-match writes in dev mode (default `process.env.NODE_ENV !== "production"`) instead of silently logging to the console. A stale accessor or broken `keyBy` now surfaces immediately at the first click in `vite dev` instead of drowning in the console.
+
+New option `strict?: boolean` lets callers pin the behaviour explicitly — `strict: true` throws in both envs; `strict: false` keeps the legacy warn-and-discard even in dev. Production behaviour is unchanged (warn-and-discard) unless `strict: true` is set.
+
+```ts
+// Default in vite dev: throws WhisqKeyByError
+input({ ...bindField(todos, todo, "done", { as: "checkbox" }) })
+
+// Opt out if a test deliberately exercises the no-match path:
+input({ ...bindField(todos, todo, "done", { as: "checkbox", strict: false }) })
+```
+
+`WhisqKeyByError` carries `sourceKeys`, `targetKey`, and `field` so the error tells you what was in the source at write time vs. what the accessor was looking for. Both the error class and its `WhisqKeyByErrorFields` type are exported from `@whisq/core`.
+
+Closes WHISQ-100.

--- a/packages/core/src/__tests__/bindField.test.ts
+++ b/packages/core/src/__tests__/bindField.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { signal } from "../reactive.js";
 import { input, mount, each, ul } from "../elements.js";
 import { bindField } from "../bindField.js";
+import { WhisqKeyByError } from "../dev-errors.js";
 
 interface Todo {
   id: string;
@@ -298,7 +299,7 @@ describe("bindField() — keyBy", () => {
     expect(rows.value[0].done).toBe(true);
   });
 
-  it("warns and discards the write when no item matches", () => {
+  it("warns and discards the write when no item matches (strict: false)", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const todos = signal<Todo[]>([
       { id: "a", text: "x", done: false, priority: 0 },
@@ -307,6 +308,7 @@ describe("bindField() — keyBy", () => {
     const accessor = () => todos.value[0] ?? { id: "missing" };
     const props = bindField(todos, accessor as () => Todo, "done", {
       as: "checkbox",
+      strict: false, // opt out of the dev-strict default that would throw
     });
     todos.value = []; // item gone
     (props as { onchange: (e: Event) => void }).onchange({
@@ -336,5 +338,121 @@ describe("bindField() — input validation", () => {
     expect(() =>
       bindField(todos, "not a function" as unknown as () => Todo, "done"),
     ).toThrow(TypeError);
+  });
+});
+
+// ── Dev-strict mode (WHISQ-100) ────────────────────────────────────────────
+//
+// Dev mode (NODE_ENV !== "production") throws WhisqKeyByError on a no-match
+// write so a stale accessor or broken keyBy surfaces in the dev loop instead
+// of hiding in the console. Production degrades to warn-and-discard unless
+// the caller opts in via `strict: true`. These tests cover every cell of
+// the env × strict truth table plus the error's field shape.
+
+describe("bindField() — dev-strict no-match writes", () => {
+  function makeStaleWrite(strict?: boolean) {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+    ]);
+    const accessor = () => todos.value[0] ?? { id: "missing" };
+    const options: { as: "checkbox"; strict?: boolean } = { as: "checkbox" };
+    if (strict !== undefined) options.strict = strict;
+    const props = bindField(todos, accessor as () => Todo, "done", options);
+    todos.value = []; // stale accessor now points at an id not in source
+    return {
+      todos,
+      fire: () =>
+        (props as { onchange: (e: Event) => void }).onchange({
+          target: { checked: true } as HTMLInputElement,
+        } as unknown as Event),
+    };
+  }
+
+  it("throws WhisqKeyByError in dev by default (strict omitted)", () => {
+    // Vitest runs with NODE_ENV === "test", which is !== "production",
+    // so dev-strict is the default here.
+    const { fire } = makeStaleWrite();
+    expect(fire).toThrow(WhisqKeyByError);
+  });
+
+  it("error carries sourceKeys, targetKey, and field fields", () => {
+    const { fire } = makeStaleWrite();
+    try {
+      fire();
+      expect.fail("expected WhisqKeyByError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(WhisqKeyByError);
+      const keyErr = err as WhisqKeyByError;
+      expect(keyErr.sourceKeys).toEqual([]); // source was emptied before the write
+      expect(keyErr.targetKey).toBe("missing");
+      expect(keyErr.field).toBe("done");
+      expect(keyErr.name).toBe("WhisqKeyByError");
+      expect(keyErr.message).toContain("no item in source matched");
+    }
+  });
+
+  it("throws when strict: true is explicitly set (overrides env default)", () => {
+    // Simulate production env; explicit strict:true wins.
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const { fire } = makeStaleWrite(true);
+      expect(fire).toThrow(WhisqKeyByError);
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it("warns (does not throw) when strict: false is explicitly set in dev", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { fire, todos } = makeStaleWrite(false);
+      expect(fire).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("no item in source matched"),
+      );
+      expect(todos.value).toEqual([]); // write was discarded
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("warns (does not throw) in production by default", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { fire, todos } = makeStaleWrite();
+      expect(fire).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("no item in source matched"),
+      );
+      expect(todos.value).toEqual([]);
+    } finally {
+      warn.mockRestore();
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it("happy path unaffected — successful matching writes never throw or warn in dev-strict", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const todos = signal<Todo[]>([
+        { id: "a", text: "first", done: false, priority: 0 },
+      ]);
+      const accessor = () => todos.value[0]!;
+      const props = bindField(todos, accessor as () => Todo, "done", {
+        as: "checkbox",
+      });
+      expect(() =>
+        (props as { onchange: (e: Event) => void }).onchange({
+          target: { checked: true } as HTMLInputElement,
+        } as unknown as Event),
+      ).not.toThrow();
+      expect(todos.value[0].done).toBe(true);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/core/src/bindField.ts
+++ b/packages/core/src/bindField.ts
@@ -8,9 +8,20 @@
 
 import { type Signal, isSignal } from "./reactive.js";
 import type { TextBind, NumberBind, CheckboxBind, RadioBind } from "./bind.js";
+import { WhisqKeyByError } from "./dev-errors.js";
 
 interface Common<T> {
   keyBy?: (item: T) => unknown;
+  /**
+   * Error on no-match writes instead of warning. Defaults to `true` in dev
+   * (`process.env.NODE_ENV !== "production"`) and `false` in production, so
+   * a stale accessor or broken `keyBy` surfaces as a `WhisqKeyByError` in
+   * the dev loop but degrades to `console.warn` + discard in a shipped
+   * build. Pass `strict: false` in tests that deliberately exercise the
+   * no-match path, or `strict: true` in production if you want throws in
+   * both environments.
+   */
+  strict?: boolean;
 }
 
 export type BindFieldOptions<T> =
@@ -78,6 +89,8 @@ export function bindField<T, K extends keyof T>(
     (options as Common<T>)?.keyBy ??
     ((t: T) => (t as { id?: unknown }).id);
 
+  const strictOpt = (options as Common<T>)?.strict;
+
   const write = (next: T[K]): void => {
     const target = keyBy(item());
     let matched = false;
@@ -89,6 +102,15 @@ export function bindField<T, K extends keyof T>(
       return t;
     });
     if (!matched) {
+      const strict =
+        strictOpt ?? process.env.NODE_ENV !== "production";
+      if (strict) {
+        throw new WhisqKeyByError({
+          sourceKeys: source.value.map((t) => keyBy(t)),
+          targetKey: target,
+          field: String(key),
+        });
+      }
       // eslint-disable-next-line no-console
       console.warn(
         `bindField: no item in source matched ${String(target)}; write to "${String(key)}" discarded.`,

--- a/packages/core/src/dev-errors.ts
+++ b/packages/core/src/dev-errors.ts
@@ -48,6 +48,41 @@ export class WhisqStructureError extends Error {
   }
 }
 
+export interface WhisqKeyByErrorFields {
+  /** All keys present in the source array at write time, in source order. */
+  sourceKeys: unknown[];
+  /** The key the write was trying to match against. */
+  targetKey: unknown;
+  /** The field name being written (from bindField's `key` argument). */
+  field: string;
+}
+
+/**
+ * Thrown by `bindField()` in dev mode (or with `strict: true`) when a write
+ * can't find an item in the source array whose `keyBy(...)` matches the
+ * current accessor's key. The typical cause is a stale accessor (the item
+ * was removed from the source after the accessor was created) or a broken
+ * `keyBy` function (returns a different key for read vs write).
+ *
+ * Production builds without `strict: true` log a warning and discard the
+ * write instead of throwing.
+ */
+export class WhisqKeyByError extends Error {
+  readonly sourceKeys: unknown[];
+  readonly targetKey: unknown;
+  readonly field: string;
+
+  constructor(fields: WhisqKeyByErrorFields) {
+    super(
+      `bindField: no item in source matched ${String(fields.targetKey)}; write to "${fields.field}" discarded. Source keys at write time: [${fields.sourceKeys.map(String).join(", ")}].`,
+    );
+    this.name = "WhisqKeyByError";
+    this.sourceKeys = fields.sourceKeys;
+    this.targetKey = fields.targetKey;
+    this.field = fields.field;
+  }
+}
+
 /**
  * Short human description of any value — used for the `received` field of a
  * structure error. Deliberately terse so the composed message stays short.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,8 +118,11 @@ export { sheet, styles, cx, rcx, sx, theme } from "./styling.js";
 export type { StyleObject } from "./elements.js";
 
 // Dev-mode diagnostics
-export { WhisqStructureError } from "./dev-errors.js";
-export type { WhisqStructureErrorFields } from "./dev-errors.js";
+export { WhisqStructureError, WhisqKeyByError } from "./dev-errors.js";
+export type {
+  WhisqStructureErrorFields,
+  WhisqKeyByErrorFields,
+} from "./dev-errors.js";
 
 // Forms
 export { bind } from "./bind.js";


### PR DESCRIPTION
Closes #100.

## Summary

`bindField` now throws a `WhisqKeyByError` on no-match writes in dev (default when `process.env.NODE_ENV !== "production"`) instead of silently logging to the console. A stale accessor or a broken `keyBy` function surfaces at the first click in `vite dev` instead of drowning in page-console noise. Production behaviour (warn-and-discard) is unchanged unless the caller explicitly opts in via `strict: true`.

Addresses Claude's alpha.7 feedback F4: _"In a dev-loop where I've just introduced a bug in my `keyBy`, the warning is easy to miss amid the page console noise. Consider a strict mode … that throws instead of logs for no-match writes."_

## API

```ts
// Default in vite dev: WhisqKeyByError thrown on stale-accessor / keyBy-bug writes
input({ ...bindField(todos, todo, "done", { as: "checkbox" }) })

// Opt out — tests that deliberately exercise the no-match path:
input({ ...bindField(todos, todo, "done", { as: "checkbox", strict: false }) })

// Opt in — production that wants throws in both environments:
input({ ...bindField(todos, todo, "done", { as: "checkbox", strict: true }) })
```

| env | strict unset | strict: true | strict: false |
| --- | --- | --- | --- |
| dev (`NODE_ENV !== "production"`) | **throws** | throws | warns |
| prod (`NODE_ENV === "production"`) | warns | **throws** | warns |

`WhisqKeyByError` carries `sourceKeys`, `targetKey`, and `field` — the message names both what the source had at write time and what the accessor was looking for. The error class + its `WhisqKeyByErrorFields` type are exported from `@whisq/core` (sibling of the existing `WhisqStructureError`).

## Test plan

- [x] New: dev default (test env) throws `WhisqKeyByError` on stale-accessor write.
- [x] New: error carries `sourceKeys: []`, `targetKey: "missing"`, `field: "done"` after the source was emptied mid-write.
- [x] New: `strict: true` + `NODE_ENV = "production"` throws (explicit override beats env default).
- [x] New: `strict: false` in dev warns-and-discards (explicit opt-out).
- [x] New: `NODE_ENV = "production"` default warns-and-discards (legacy behaviour preserved).
- [x] New: happy-path matching writes never throw or warn in dev-strict.
- [x] Existing "warns and discards" test updated to set `strict: false` — keeps asserting the warn-path as an explicit opt-out rather than the default.
- [x] `pnpm -w build` clean across all 9 packages.
- [x] Full suite: 385 core tests pass (was 379 → +6 new); all 18 workspace tasks green.

## Out of scope

- LLM reference + Forms guide updates on whisq.dev — cross-repo, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)