### PR TITLE
WHISQ-96: hybrid accessor — callable + signal-shaped for keyed each()

### DIFF
--- a/.changeset/hybrid-item-accessor-keyed-each.md
+++ b/.changeset/hybrid-item-accessor-keyed-each.md
@@ -1,0 +1,24 @@
+---
+"@whisq/core": minor
+---
+
+Keyed `each()`'s render callback now receives a **hybrid accessor** — callable (`todo()`) **and** signal-shaped (`todo.value`, `todo.peek()`). Joins the uniform `() => sig.value` reactive-access rule that holds everywhere else in the API; closes the last pocket of divergence both reviewers flagged in alpha.7 feedback.
+
+```ts
+each(() => todos.value, (todo) =>
+  li(
+    { class: () => todo.value.done ? "done" : "" },   // new canonical shape
+    span(() => todo.value.text),
+    button({ onclick: () => remove(todo.value.id) }, "✕"),
+  ),
+  { key: (t) => t.id },
+)
+```
+
+**Non-breaking.** The accessor is still a plain function at call sites that want `todo()`, and structurally assignable to `() => T` — so `bindField(todos, todo, "done", { as: "checkbox" })` and every other helper that types its input as `() => T` works unchanged. Existing call sites do not need to migrate; new code should prefer `todo.value.<field>` for consistency with the rest of the reactive-access rule.
+
+`index` follows the same pattern — `index()` (legacy) and `index.value` / `index.peek()` (new) both work.
+
+New exported type: `ItemAccessor<T>` (from `@whisq/core`).
+
+Addresses WHISQ-96 with the hybrid approach — option A's `.value` shape without the breaking-change downside. Partially closes the issue; the docs-side cookbook in `whisq.dev#108` (D-1) should adopt the `.value` shape as the canonical example going forward.

--- a/packages/core/src/__tests__/each.test.ts
+++ b/packages/core/src/__tests__/each.test.ts
@@ -609,3 +609,146 @@ describe("each() with key — accessor callback", () => {
     expect(liAfter!.textContent).toBe("a-v2");
   });
 });
+
+// ── Hybrid accessor shape (WHISQ-96) ────────────────────────────────────────
+//
+// The keyed `each()` callback's `item` / `index` arguments are callable
+// (`item()`, `index()` — backwards-compatible) AND expose signal-like
+// `.value` / `.peek()` reads. The new `.value` shape joins the uniform
+// reactive-access pattern; the call form stays so helpers like `bindField`
+// (which expect `() => T`) keep working.
+
+describe("each() keyed — hybrid accessor shape (callable + .value + .peek)", () => {
+  type Item = { id: number; text: string };
+
+  it("item.value returns the current item (initial render)", () => {
+    const items = signal<Item[]>([{ id: 1, text: "a" }]);
+    let capturedValue: Item | undefined;
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item) => {
+          capturedValue = item.value;
+          return li(() => item.value.text);
+        },
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+
+    expect(capturedValue).toEqual({ id: 1, text: "a" });
+    expect(container.firstElementChild!.querySelector("li")!.textContent).toBe(
+      "a",
+    );
+  });
+
+  it("item.value stays live after reconciliation reuses an entry", () => {
+    const items = signal<Item[]>([{ id: 1, text: "a" }]);
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item) => li(() => item.value.text),
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+    const liBefore = container.firstElementChild!.querySelector("li");
+
+    items.value = [{ id: 1, text: "a-v2" }];
+    const liAfter = container.firstElementChild!.querySelector("li");
+
+    expect(liAfter).toBe(liBefore);
+    expect(liAfter!.textContent).toBe("a-v2");
+  });
+
+  it("item() and item.value return the same value at every read", () => {
+    const items = signal<Item[]>([{ id: 1, text: "a" }]);
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item) => li(() => `${item().text}|${item.value.text}`),
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+    const liEl = container.firstElementChild!.querySelector("li")!;
+    expect(liEl.textContent).toBe("a|a");
+
+    items.value = [{ id: 1, text: "updated" }];
+    expect(liEl.textContent).toBe("updated|updated");
+  });
+
+  it("item.peek() returns the current item", () => {
+    const items = signal<Item[]>([{ id: 1, text: "a" }]);
+    const peeks: string[] = [];
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item) =>
+          li(() => {
+            const tracked = item.value.text;
+            peeks.push(`peek=${item.peek().text}`);
+            return tracked;
+          }),
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+    expect(peeks[0]).toBe("peek=a");
+
+    items.value = [{ id: 1, text: "b" }];
+    expect(peeks[peeks.length - 1]).toBe("peek=b");
+  });
+
+  it("index.value returns the current index; updates on reorder", () => {
+    const items = signal<Item[]>([
+      { id: 1, text: "one" },
+      { id: 2, text: "two" },
+    ]);
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item, index) => li(() => `${index.value}:${item.value.text}`),
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+    const lisBefore = container.firstElementChild!.querySelectorAll("li");
+    expect(lisBefore[0].textContent).toBe("0:one");
+    expect(lisBefore[1].textContent).toBe("1:two");
+
+    items.value = [
+      { id: 2, text: "two" },
+      { id: 1, text: "one" },
+    ];
+    const lisAfter = container.firstElementChild!.querySelectorAll("li");
+    expect(lisAfter[0].textContent).toBe("0:two");
+    expect(lisAfter[1].textContent).toBe("1:one");
+  });
+
+  it("hybrid accessor satisfies the `() => T` shape for bindField-style helpers", () => {
+    // The hybrid accessor must be assignable to `() => T` so helpers like
+    // bindField (which expect that shape) continue to work unchanged.
+    const items = signal<Item[]>([{ id: 1, text: "a" }]);
+    const readText = (accessor: () => Item) => accessor().text;
+    let capturedViaCallShape: string | undefined;
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item) => {
+          capturedViaCallShape = readText(item);
+          return li(item.value.text);
+        },
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+    expect(capturedViaCallShape).toBe("a");
+  });
+});

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -75,6 +75,34 @@ type StyleValue = string | number | null | undefined;
 export type StyleObject = Record<string, StyleValue | (() => StyleValue)>;
 
 /**
+ * The accessor passed to a keyed `each()`'s render callback. It is both
+ * **callable** (`todo()` returns the current item — backwards-compatible
+ * with pre-alpha.8 code) **and** **signal-shaped** (`todo.value`,
+ * `todo.peek()`) — new code should prefer `todo.value.<field>` for the
+ * uniform reactive-access rule.
+ *
+ * ```ts
+ * // new canonical shape — joins the `() => sig.value` pattern
+ * each(() => todos.value, (todo) =>
+ *   li(() => todo.value.text),
+ *   { key: (t) => t.id },
+ * )
+ *
+ * // still works (call form) — bindField and other `() => T` consumers
+ * // continue to accept the accessor without modification
+ * each(() => todos.value, (todo) =>
+ *   input({ ...bindField(todos, todo, "done", { as: "checkbox" }) }),
+ *   { key: (t) => t.id },
+ * )
+ * ```
+ */
+export interface ItemAccessor<T> {
+  (): T;
+  readonly value: T;
+  peek(): T;
+}
+
+/**
  * A single source inside a `class: [...]` array. Strings become class names;
  * falsy values (`false | null | undefined | 0 | ""`) are filtered out,
  * enabling the `cond && "active"` shorthand; functions are reactive — each
@@ -709,14 +737,20 @@ export function each<T>(
 ): () => Child[];
 export function each<T>(
   items: () => T[],
-  render: (item: () => T, index: () => number) => WhisqNode,
+  render: (
+    item: ItemAccessor<T>,
+    index: ItemAccessor<number>,
+  ) => WhisqNode,
   options: { key: (item: T) => unknown },
 ): WhisqNode;
 export function each<T>(
   items: () => T[],
   render:
     | ((item: T, index: number) => WhisqNode)
-    | ((item: () => T, index: () => number) => WhisqNode),
+    | ((
+        item: ItemAccessor<T>,
+        index: ItemAccessor<number>,
+      ) => WhisqNode),
   options?: { key: (item: T) => unknown },
 ): (() => Child[]) | WhisqNode {
   if (process.env.NODE_ENV !== "production") {
@@ -766,8 +800,8 @@ export function each<T>(
   // array is replaced with new items at the same key (WHISQ-62).
   const keyFn = options.key;
   const renderAccessor = render as (
-    item: () => T,
-    index: () => number,
+    item: ItemAccessor<T>,
+    index: ItemAccessor<number>,
   ) => WhisqNode;
   const marker = document.createComment("whisq-each");
   const disposers: (() => void)[] = [];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,7 @@ export type {
   EventHandler,
   WhisqEvent,
   ClassArraySource,
+  ItemAccessor,
 } from "./elements.js";
 
 // Component model

--- a/packages/core/src/reconcile.ts
+++ b/packages/core/src/reconcile.ts
@@ -11,7 +11,7 @@
 // ============================================================================
 
 import { signal, type Signal } from "./reactive.js";
-import type { WhisqNode } from "./elements.js";
+import type { WhisqNode, ItemAccessor } from "./elements.js";
 
 export interface KeyedEntry<T = unknown> {
   key: unknown;
@@ -20,6 +20,22 @@ export interface KeyedEntry<T = unknown> {
   itemSig: Signal<T>;
   /** Updated on reorder so `() => indexSig.value` getters see the new position. */
   indexSig: Signal<number>;
+}
+
+/**
+ * Wrap a per-entry signal as the hybrid accessor that the render callback
+ * receives. Callable (`acc()` → current value, tracks) AND signal-shaped
+ * (`acc.value` → tracks; `acc.peek()` → untracked). Both call paths read
+ * the same underlying `Signal<T>` that the reconciler updates on reuse.
+ */
+function makeItemAccessor<T>(sig: Signal<T>): ItemAccessor<T> {
+  const fn = (() => sig.value) as ItemAccessor<T>;
+  Object.defineProperty(fn, "value", {
+    get: () => sig.value,
+    enumerable: true,
+  });
+  (fn as { peek: () => T }).peek = () => sig.peek();
+  return fn;
 }
 
 /**
@@ -40,7 +56,10 @@ export function reconcileKeyed<T>(
   oldEntries: KeyedEntry<T>[],
   newItems: T[],
   keyFn: (item: T) => unknown,
-  renderFn: (item: () => T, index: () => number) => WhisqNode,
+  renderFn: (
+    item: ItemAccessor<T>,
+    index: ItemAccessor<number>,
+  ) => WhisqNode,
 ): KeyedEntry<T>[] {
   const newLen = newItems.length;
   const oldLen = oldEntries.length;
@@ -53,8 +72,8 @@ export function reconcileKeyed<T>(
       const itemSig = signal(newItems[i]);
       const indexSig = signal(i);
       const node = renderFn(
-        () => itemSig.value,
-        () => indexSig.value,
+        makeItemAccessor(itemSig),
+        makeItemAccessor(indexSig),
       );
       fragment.appendChild(node.el);
       entries[i] = { key: keyFn(newItems[i]), node, itemSig, indexSig };
@@ -135,8 +154,8 @@ export function reconcileKeyed<T>(
       const itemSig = signal(newItems[i]);
       const indexSig = signal(i);
       const node = renderFn(
-        () => itemSig.value,
-        () => indexSig.value,
+        makeItemAccessor(itemSig),
+        makeItemAccessor(indexSig),
       );
       newEntries[i] = { key: newKeys[i], node, itemSig, indexSig };
     }


### PR DESCRIPTION
Closes #96 with option A's `.value` shape, shipped non-breaking.

## Decision

The issue's recommendation was option A (breaking change: keyed-each item accessor becomes a `ReadonlySignal`-shaped wrapper). My session-long concern was that A forces every existing caller — docs, LLM reference, create-whisq templates, the `bindField` helper that types its input as `() => T` — to migrate.

Shipping a **hybrid accessor** captures the entire benefit of A without the migration cost: the accessor is both **callable** (`todo()` — backwards compatible) and **signal-shaped** (`todo.value`, `todo.peek()` — new canonical shape). Every existing call site keeps working; new code can use the uniform `() => todo.value.text` pattern.

## Summary

```ts
each(() => todos.value, (todo) =>
  li(
    { class: () => todo.value.done ? "done" : "" },   // new canonical
    span(() => todo.value.text),
    button({ onclick: () => remove(todo.value.id) }, "✕"),
  ),
  { key: (t) => t.id },
)

// Legacy call form still works — and bindField-style helpers that type
// their arg as `() => T` accept the accessor unchanged:
input({ ...bindField(todos, todo, "done", { as: "checkbox" }) })
```

- New exported type: `ItemAccessor<T>` — `(): T; readonly value: T; peek(): T`.
- Runtime: `reconcile.ts` builds the hybrid accessor from the existing per-entry `Signal<T>` — the call form and `.value` both track; `.peek()` doesn't.
- `each()`'s render signature widened from `(item: () => T, index: () => number)` to `(item: ItemAccessor<T>, index: ItemAccessor<number>)`. Structurally still `() => T`, so **every existing `() => T` consumer type-checks without modification**.
- `index` follows the same shape — `index()` (legacy) and `index.value` / `index.peek()` (new).

## Test plan

- [x] `item.value` returns the current item on initial render.
- [x] `item.value` stays live after reconciliation reuses an entry (same DOM node, new text).
- [x] `item()` and `item.value` return the same value at every read (both tracking paths wired to the same underlying signal).
- [x] `item.peek()` returns the current item.
- [x] `index.value` updates on reorder, not just on array replacement.
- [x] Hybrid accessor satisfies `(accessor: () => T)` — `bindField`-style helpers accept it unchanged (compile-time check via a test function typed as `(accessor: () => Item) => string`).
- [x] All 27 pre-existing keyed-each tests still pass (backwards compatibility).
- [x] Scaffolded `create-whisq` full-app still `tsc --noEmit` exits 0.
- [x] `pnpm -w build` clean across all 9 packages.
- [x] Full suite: 391 core tests pass (was 385 → +6 new); all 18 workspace tasks green.

## Out of scope — tracked for follow-up

- Updating LLM reference / cookbook docs on whisq.dev to adopt `todo.value.text` as the canonical shape — cross-repo, separate PR. Issue whisq.dev#108 (nested item editing cookbook) is the natural home.
- Deprecating the call form `todo()` (option C on the original issue) — deferred; no deprecation planned since it remains structurally necessary for `bindField` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)