### PR TITLE
WHISQ-112: internal docs + template CLAUDE.md show todo.value shape

### DIFF
--- a/packages/core/docs/access-shapes.md
+++ b/packages/core/docs/access-shapes.md
@@ -6,25 +6,23 @@ Canonical reference for **how you read** reactive values. Paired with [`reactive
 
 ## Is "uniform `() => value`" actually uniform?
 
-The marketing line you'll see on whisq.dev is _"wrap reactive reads in `() => ...` everywhere."_ The **wrapper** is uniform — every reactive position in the API accepts `() => value`. What varies is **what goes inside the wrapper**, because Whisq exposes three different source shapes: plain signals, keyed-`each` accessors, and `resource()` fields.
+The marketing line you'll see on whisq.dev is _"wrap reactive reads in `() => ...` everywhere."_ The **wrapper** is uniform — every reactive position in the API accepts `() => value`. Since WHISQ-96 shipped the **hybrid accessor**, signals and keyed-`each` items now read with the *same* `.value` shape, so the simple rule is:
 
-So the rule to remember is:
+> _Wrap reactive reads in `() => ...` and read `.value` on the source. `resource()` fields are the single exception — they're callable (`users.loading()`, `users.data()`) because loading / error / data are semantic states, not signals._
 
-> _Wrap reactive reads in `() => ...`. Unwrap the source:_
-> _- Signal → `.value`_
-> _- Keyed-`each` item or `resource()` field → `()` (it's already an accessor)._
-
-Two tokens to remember instead of one, but one consistent wrapper — and _zero_ hidden dependency arrays, stale closures, or re-render caveats.
+The old "call the keyed-`each` accessor with `()`" form still works for backwards compatibility and for handing the accessor to `bindField`-style helpers that type their input as `() => T`.
 
 ---
 
 ## The three shapes at a glance
 
-| # | Source                    | Outside reactive context              | Inside reactive context (getter) |
-| - | ------------------------- | ------------------------------------- | -------------------------------- |
-| 1 | Plain signal              | `sig.value` / `sig.peek()`            | `() => sig.value`                |
-| 2 | Keyed `each()` item       | _(only exists inside the render fn)_  | `() => todo().text`              |
-| 3 | `resource()` field        | `users.loading()` / `users.data()` …  | `() => users.loading()`          |
+| # | Source                    | Outside reactive context              | Inside reactive context (getter)      |
+| - | ------------------------- | ------------------------------------- | ------------------------------------- |
+| 1 | Plain signal              | `sig.value` / `sig.peek()`            | `() => sig.value`                     |
+| 2 | Keyed `each()` item       | _(only exists inside the render fn)_  | `() => todo.value.text` (canonical)   |
+| 3 | `resource()` field        | `users.loading()` / `users.data()` …  | `() => users.loading()`               |
+
+Shape 2 also accepts the legacy call form — `() => todo().text` — which remains the shape `bindField(source, todo, "done")` expects when the accessor is passed as a `() => T` argument.
 
 ---
 
@@ -51,9 +49,9 @@ const snap = count.peek();
 - **Common mistake:** passing `count.value` directly as a child → reads once, not reactive.
 - **Writes:** `count.value = n` or `count.set(n)` or `count.update(fn)`.
 
-## Shape 2 — Keyed `each()` item: `todo()`
+## Shape 2 — Keyed `each()` item: `todo.value` (or `todo()` for legacy consumers)
 
-Inside a keyed `each(items, (item) => …, { key })`, the `item` argument is an **accessor function** — you call it with `()` to get the current value. Wrapping the read in `() => todo().text` is what makes the child re-render when the array is replaced with new objects at the same key. Closing over `todo` and writing `.text` would be stale at the next array replacement (see WHISQ-62 for the fix that introduced this).
+Inside a keyed `each(items, (item) => …, { key })`, the `item` argument is a **hybrid accessor** — both callable (`todo()`) and signal-shaped (`todo.value`, `todo.peek()`). Prefer `todo.value.<field>` inside reactive getters to join the uniform `() => sig.value` rule from Shape 1. The `todo()` call form stays because it's what `bindField(source, todo, "done")` and other `() => T` consumers take as input. Wrapping the read in `() => todo.value.text` is what makes the child re-render when the array is replaced with new objects at the same key — closing over `todo.value` at setup (without the wrapper) snapshots the first value and freezes the row at the next array replacement (see WHISQ-62 for the original stale-read fix, WHISQ-96 for the `.value` shape).
 
 ```ts
 type Todo = { id: string; text: string; done: boolean };
@@ -64,17 +62,22 @@ ul(
     () => todos.value,
     (todo) =>
       li(
-        span(() => todo().text),                      // reactive text via accessor
-        input({ type: "checkbox",
-          ...bindField(todos, todo, "done", { as: "checkbox" }) }),
+        span(() => todo.value.text),                  // canonical — joins Shape 1
+        input({
+          type: "checkbox",
+          // bindField takes `() => T`; the hybrid accessor is assignable to that
+          ...bindField(todos, todo, "done", { as: "checkbox" }),
+        }),
       ),
     { key: (t) => t.id },
   ),
 );
 ```
 
-- **`todo` is a function, not an object** — `todo.text` is `undefined`; TypeScript flags this.
-- **Always wrap `todo()` in `() => ...`** for reactive reads — a bare `todo()` outside a getter is a one-shot snapshot.
+- **`todo.value.<field>`** is the canonical read — uniform with plain signals.
+- **`todo()` still works** and is structurally `() => T`, so `bindField` and every other `() => T` consumer accepts the accessor unchanged.
+- **Wrap reads in `() => ...`** for reactive positions — a bare `todo.value.text` at setup is a one-shot snapshot, same as reading a signal's `.value` without the wrapper.
+- **`todo.peek()`** reads the current value without tracking — mirrors `signal.peek()`.
 - **Writes** go through the source signal, not the accessor. Use `bindField(source, item, key)` for the common "update field on an item" case; fall back to a manual event pair for arbitrary mutations.
 
 Non-keyed `each(items, (item) => …)` (no `{ key }`) still passes plain `T`, because the whole list re-renders on every change — no stale-accessor risk. See [`reactive-shapes.md`](./reactive-shapes.md) for when to reach for `each` keyed vs. non-keyed.
@@ -115,6 +118,8 @@ The common rule: **the thing you hand to the child must be re-readable**. A raw 
 
 ### Worked example: split a todo row into its own component
 
+The child has two reasonable prop-type choices — pick by whether it needs access to the `.value` / `.peek()` API or just wants the narrowest `() => T` capability that accepts any source.
+
 ```ts
 // parent: owns the todos signal
 type Todo = { id: string; text: string; done: boolean };
@@ -133,30 +138,41 @@ function TodoList() {
   );
 }
 
-// child: reads props.todo() inside its own getters
-const TodoItem = component((props: { todo: () => Todo }) => {
+// child: typed as ItemAccessor<Todo> — reads via .value (canonical Shape 2)
+import type { ItemAccessor } from "@whisq/core";
+
+const TodoItem = component((props: { todo: ItemAccessor<Todo> }) => {
   return li(
     input({
       type: "checkbox",
+      // bindField wants `() => T`; the hybrid accessor is assignable to that
       ...bindField(todos, props.todo, "done", { as: "checkbox" }),
     }),
-    span(() => props.todo().text),              // re-reads on every source change
+    span(() => props.todo.value.text),             // canonical — joins Shape 1
     button(
-      { onclick: () => remove(props.todo().id) },
+      { onclick: () => remove(props.todo.value.id) },
       "✕",
     ),
   );
 });
+
+// Alternative: typed as `() => Todo` — the narrowest shape, accepts any
+// getter-style source (keyed-each accessor, resource fields, `() => sig.value`).
+// Read inside the child with `props.todo()` — same freshness, fewer capabilities.
+const TodoItemCompat = component((props: { todo: () => Todo }) => {
+  return li(span(() => props.todo().text));
+});
 ```
 
-Everything the child needs is reachable from `props.todo()`. Nothing is captured in a local variable at setup. When the parent replaces `todos.value` with a new array that still contains the same `id`, the reconciler reuses this `TodoItem` instance; the per-entry `itemSig` gets the new object; `props.todo()` returns that new object; every getter in the child re-reads.
+Everything the child needs is reachable from `props.todo`. Nothing is captured in a local variable at setup. When the parent replaces `todos.value` with a new array that still contains the same `id`, the reconciler reuses this `TodoItem` instance; the per-entry `itemSig` gets the new object; both `props.todo.value` and `props.todo()` return that new object; every getter in the child re-reads.
 
 ### Counter-example: snapshot at setup (the bug you can't reproduce in a unit test)
 
 ```ts
 // DON'T DO THIS
-const TodoItem = component((props: { todo: () => Todo }) => {
-  const todo = props.todo();                    // snapshot captured once
+const TodoItem = component((props: { todo: ItemAccessor<Todo> }) => {
+  const todo = props.todo.value;                // snapshot captured once
+  // Or the legacy equivalent: `const todo = props.todo()` — same bug.
   return li(
     span(todo.text),                            // static — never updates
     button(
@@ -183,20 +199,21 @@ Both shapes work; pick by who "owns" the binding.
 | --------------------- | ----------------------------------- | ---------------------- |
 | A `Signal<T>`          | `{ count: sig }` (the signal itself) | `() => props.count.value` |
 | A `Signal<T>` — child should only read  | `{ count: () => sig.value }` (pre-wrapped getter) | `() => props.count()` |
-| A keyed-`each` item    | `{ todo }` (the accessor)            | `() => props.todo()`   |
+| A keyed-`each` item    | `{ todo }` (the hybrid accessor)     | `() => props.todo.value.x` or `() => props.todo().x` |
 | A `resource()` field   | `{ data: users.data }` (the accessor) | `() => props.data()`   |
 
 - Pass the raw signal when the child might need to **write** (`bind(props.sig)`). The signal object carries both read and write.
 - Pass a pre-wrapped getter `() => sig.value` when the child should **only read** — the type `() => T` is the smallest capability and is identical-shaped to the keyed-each/resource case, so generic child components can accept any of them.
-- **Never call the accessor at the parent** — `TodoItem({ todo: todo() })` snapshots it.
+- **Never call the accessor at the parent** — `TodoItem({ todo: todo() })` or `TodoItem({ todo: todo.value })` both snapshot and freeze the child.
 
 ### Common mistakes at the boundary
 
 | Mistake                                         | What happens                                                      | Fix                                             |
 | ----------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------- |
 | `TodoItem({ todo: todo() })` (call at parent)   | Child receives frozen item; stale after array replacement.       | `TodoItem({ todo })` — pass the accessor.       |
-| `const todo = props.todo()` inside child setup   | Snapshots at first mount; ignores later updates.                 | Read inside each getter: `() => props.todo().x`. |
-| Destructuring props in setup (`const { todo } = props`) | Loses per-render re-read if Whisq ever swaps props (and is a footgun elsewhere too). | Read fields off `props` directly: `() => props.todo().text`. |
+| `TodoItem({ todo: todo.value })` (`.value` at parent) | Same bug in a different dress — reads the current value and snapshots it. | `TodoItem({ todo })` — pass the accessor. |
+| `const todo = props.todo.value` inside child setup | Snapshots at first mount; ignores later updates.               | Read inside each getter: `() => props.todo.value.x`. |
+| Destructuring props in setup (`const { todo } = props`) | Loses per-render re-read if Whisq ever swaps props (and is a footgun elsewhere too). | Read fields off `props` directly: `() => props.todo.value.text`. |
 | Passing `todos.value[0]` as a prop              | Same as snapshotting — you read `.value` at the parent.          | Pass a getter: `{ first: () => todos.value[0] }`. |
 
 See also the structural guards shipped in [#81](https://github.com/whisqjs/whisq/issues/81) — `WhisqStructureError` catches wrong-shaped children at the boundary and points at the fix.

--- a/packages/core/docs/reactive-shapes.md
+++ b/packages/core/docs/reactive-shapes.md
@@ -15,7 +15,7 @@ Every reactive position in the API accepts `() => value` — that wrapper is uni
 | 3 | **`bind()`** spread       | `input({ ...bind(email) })`                                                        | Two-way binding one signal into one form input you own                                  |
 | 4 | **`bindField()`** spread  | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | A field inside an item inside a signal-backed array (inside keyed `each`)               |
 
-Escape hatch: when `bindField()` doesn't fit (deep paths, custom write logic), fall back to a **manual event pair** — `{ checked: () => todo().done, onchange: e => toggle(todo().id) }`. Same idea, more code.
+Escape hatch: when `bindField()` doesn't fit (deep paths, custom write logic), fall back to a **manual event pair** — `{ checked: () => todo.value.done, onchange: e => toggle(todo.value.id) }`. Same idea, more code.
 
 A one-sentence decision flow:
 
@@ -97,14 +97,14 @@ ul(
           type: "checkbox",
           ...bindField(todos, todo, "done", { as: "checkbox" }),
         }),
-        span(() => todo().text),
+        span(() => todo.value.text),
       ),
     { key: (t) => t.id },
   ),
 );
 ```
 
-- **`todo` is an accessor** (post WHISQ-62) — call it as `todo()` to read the current item. `bindField()` reads it internally to find the target item at write time.
+- **`todo` is a hybrid accessor** (post WHISQ-96) — read it as `todo.value.<field>` inside getters (canonical, matches the `() => sig.value` rule for plain signals) or as `todo()` when handing it to `() => T` consumers like `bindField()`. Both return the same live item.
 - **`keyBy` defaults to `t => t.id`** — supply `{ keyBy: (t) => t.uuid }` for items keyed on something else.
 - **Writes produce a new array** — `source.value` is replaced with an immutably-updated copy, so downstream `computed` / `effect` / keyed `each()` re-run correctly.
 
@@ -125,8 +125,8 @@ When none of the helpers fit — deep nested paths that cross arrays, writes tha
 ```ts
 input({
   type: "checkbox",
-  checked: () => todo().done,                      // reactive read via accessor
-  onchange: () => toggle(todo().id),               // writer — reads latest id
+  checked: () => todo.value.done,                  // reactive read via accessor
+  onchange: () => toggle(todo.value.id),           // writer — reads latest id
 }),
 ```
 
@@ -141,7 +141,7 @@ The manual pair is strictly more powerful but also strictly more verbose. Prefer
 | `span(count.value)`                                                           | Reads once at render. Not reactive.                                                   | `span(() => count.value)`                           |
 | `div({ class: active.value ? "on" : "off" })`                                 | Evaluated once.                                                                       | `div({ class: () => active.value ? "on" : "off" })` |
 | `input({ value: email.value, oninput: e => email.value = e.target.value })`   | Works but verbose; risks forgetting both sides.                                       | `input({ ...bind(email) })`                         |
-| `each(..., (todo) => li(() => todo.done ? ...))` (closes over a stale `todo`) | `todo` is the accessor — `.done` on a function is `undefined`. TypeScript flags this. | `li(() => todo().done ? ...)`                       |
+| `each(..., (todo) => li(() => todo.done ? ...))` (reads `.done` directly on the accessor) | `todo` is a hybrid accessor — `.done` on the function itself is `undefined`. TypeScript flags this. | `li(() => todo.value.done ? ...)` (canonical) or `li(() => todo().done ? ...)` (legacy call form). |
 | `items.value.push(x)`                                                         | In-place mutation doesn't notify.                                                     | `items.value = [...items.value, x]`                 |
 | `bind(todo, { as: "checkbox" })` inside keyed `each`                          | `todo` is an accessor, not a signal with `.value`.                                    | `bindField(source, todo, "done", { as: "checkbox" })` (shape 4). |
 

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -81,38 +81,44 @@ Four shapes cover every reactive position. The one-line decision flow: *"single 
 | `bind()` spread  | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input       |
 | `bindField()` spread | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | Field inside an item inside a keyed `each`           |
 
-Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
+Inside a keyed `each(..., { key })`, the callback's `item` is a **hybrid accessor** — read it as `todo.value.<field>` inside getters (canonical, matches the `() => sig.value` rule for signals) or as `todo()` when handing it to `() => T` consumers like `bindField`. Both return the current item; getters that close over `todo` without unwrapping via `.value` or `()` go stale when the array is replaced.
 
 #### Three ways to read inside a getter
 
 The `() => …` wrapper is uniform; what goes **inside** it depends on the source.
 
-| Source              | Read inside getter       |
-| ------------------- | ------------------------ |
-| Plain signal        | `() => sig.value`      |
-| Keyed `each` item | `() => todo().text`    |
-| `resource()` field | `() => users.loading()` |
+| Source              | Read inside getter              |
+| ------------------- | ------------------------------- |
+| Plain signal        | `() => sig.value`               |
+| Keyed `each` item   | `() => todo.value.text` (canonical — matches signals) |
+| `resource()` field  | `() => users.loading()`         |
 
-Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+Signals and keyed-`each` items both read via `.value`; `resource()` fields are callable (`users.loading()`, `users.data()`) because loading / error / data are semantic states. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
 
 #### Accessors across component boundaries
 
 When you split a child component that needs a reactive item, **pass the accessor — don't call it at the parent**:
 
 ```ts
+import type { ItemAccessor } from "@whisq/core";
+
 // parent
 each(() => todos.value, (todo) => TodoItem({ todo }), { key: t => t.id })
 
 // child — read inside each getter, never destructure props or snapshot at setup
-const TodoItem = component((props: { todo: () => Todo }) => {
+const TodoItem = component((props: { todo: ItemAccessor<Todo> }) => {
   return li(
-    span(() => props.todo().text),                  // re-reads on every source change
-    button({ onclick: () => remove(props.todo().id) }, "✕"),
+    span(() => props.todo.value.text),                 // canonical — matches Shape 1
+    button({ onclick: () => remove(props.todo.value.id) }, "✕"),
   );
 });
+
+// Legacy shape — type the prop as `() => Todo` if the child should accept
+// any `() => T` source (keyed-each accessors, pre-wrapped signal readers,
+// resource fields). Read with `props.todo()`.
 ```
 
-Snapshotting (`const todo = props.todo()` at setup) makes the row freeze at mount — no error, just silent staleness after the next array change. The [access-shapes.md](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md) doc covers the full mistake table and the prop-shape variants (pass a signal when the child needs to write; pass a getter when it only reads).
+Snapshotting (`const todo = props.todo.value` or `const todo = props.todo()` at setup) makes the row freeze at mount — no error, just silent staleness after the next array change. The [access-shapes.md](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md) doc covers the full mistake table and the prop-shape variants (pass a signal when the child needs to write; pass a getter when it only reads).
 
 ### Events
 
@@ -171,23 +177,24 @@ ul(
 )
 
 // 2. Keyed — DOM nodes are reused for matching keys. The render callback
-//    receives ACCESSORS, not snapshots, so field reads inside reactive
-//    getters see fresh values when the source array is replaced:
+//    receives HYBRID ACCESSORS that are both signal-shaped (.value/.peek())
+//    and callable, so field reads inside reactive getters see fresh values
+//    when the source array is replaced:
 ul(
   each(
     () => todos.value,
     (todo) =>
       li(
-        { class: () => todo().done ? "done" : "" },  // getter reads accessor
-        span(() => todo().text),                      // getter reads accessor
-        button({ onclick: () => remove(todo().id) }, "✕"),
+        { class: () => todo.value.done ? "done" : "" },    // signal-shape — canonical
+        span(() => todo.value.text),                        // signal-shape
+        button({ onclick: () => remove(todo.value.id) }, "✕"),
       ),
     { key: (t) => t.id },
   ),
 )
 ```
 
-When you pass `{ key }`, the callback’s `item` / `index` are **accessor functions** — call them (`todo()`, `index()`) to read the current value. Wrap them in `() =>` for reactive children/props so they re-read when the source array changes.
+When you pass `{ key }`, the callback's `item` / `index` are **hybrid accessors**. Prefer `todo.value.<field>` inside reactive getters — it joins the uniform `() => sig.value` rule. The call form `todo()` (and `index()`) still works for legacy code and for helpers like `bindField` that type their argument as `() => T`.
 
 Inline `.map()` also works for simple cases:
 


### PR DESCRIPTION
Closes #112. Follow-up to #111 (WHISQ-96 hybrid accessor).

## Summary

WHISQ-96 shipped the hybrid accessor runtime in #111 — keyed-`each` items are now both callable (`todo()`) and signal-shaped (`todo.value`, `todo.peek()`), with `todo.value.<field>` the new canonical shape. The runtime was live but the framework repo's internal docs and the `create-whisq` template still demonstrated the legacy `todo()` call form, so readers landing in `packages/core/docs/` or scaffolding via `create-whisq` defaulted to the old shape.

This PR brings the docs consistent with the canonical shape:

- **`packages/core/docs/access-shapes.md`** — Shape 2's heading, example, and commentary rewritten around `todo.value.<field>`. The call form is retained as the legacy / `() => T` consumer shape. Worked example uses `ItemAccessor<Todo>` typing; the counter-example and the boundary-mistakes table cover both the `.value` and `()` snapshot bugs.
- **`packages/core/docs/reactive-shapes.md`** — cheat-sheet row for keyed-`each` items, the manual event-pair escape hatch, and the `bindField` example all updated to `todo.value.<field>`.
- **`packages/create-whisq/src/templates/full-app/CLAUDE.md`** — every scaffolded full-app inherits this verbatim. Keyed-`each` and accessor-boundary sections now show `todo.value.<field>`; the boundary example imports `ItemAccessor<Todo>` from `@whisq/core`, with the legacy `() => Todo` shape kept as an alternative for generic children that accept any `() => T` source.

## Discovered constraint

Root `CLAUDE.md` (the framework repo's own AI context file) is **gitignored** (`.gitignore:32`), so it's a local-only file and out of scope for a PR. Noted in the commit; no action needed.

## Test plan

- [x] `pnpm -w build` clean across all 9 packages.
- [x] Full suite: 391 core tests pass (unchanged — docs-only PR).
- [x] Smoke-test: scaffolded `create-whisq` full-app still `tsc --noEmit` exits 0.
- [x] Markdown links in edited docs resolve (verified by eye; no URL restructuring).

## Out of scope

- whisq.dev docs (cookbook, LLM reference page) — cross-repo, tracked in whisq.dev#108.
- Deprecating the `todo()` call form — option C on #96, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)