### PR TITLE
WHISQ-101: partition() and randomId() helpers (sub-path exports)

### DIFF
--- a/.changeset/partition-and-random-id-helpers.md
+++ b/.changeset/partition-and-random-id-helpers.md
@@ -1,0 +1,25 @@
+---
+"@whisq/core": minor
+---
+
+Two opt-in utility helpers, both on sub-path imports so apps that don't use them pay no bundle cost.
+
+- **`partition(source, predicate)`** from `@whisq/core/collections` — split a signal-held array into two `ReadonlySignal<T[]>` sides (matching / not-matching). Source order is preserved on both sides; each side is an independent `computed()` that only re-runs effects subscribed to it. The canonical use is "active" vs "done" on a todo list without hand-rolling two `computed`s.
+
+  ```ts
+  import { partition } from "@whisq/core/collections";
+
+  const todos = signal<Todo[]>([...]);
+  const [pending, done] = partition(() => todos.value, (t) => !t.done);
+  button({ onclick: () => (todos.value = pending.value) }, "Clear completed");
+  ```
+
+- **`randomId()`** from `@whisq/core/ids` — UUID-v4-shaped random identifier. Uses native `crypto.randomUUID()` when available (all modern browsers, Node 19+, Deno, Bun); falls back to a `Math.random`-based synthesis with the same v4 shape for older targets (old Safari, pre-19 Node). Same output shape on both paths, so callers don't have to branch. Suitable for UI row ids and keyed-`each` keys — **not** for security tokens (the fallback is not cryptographically strong).
+
+  ```ts
+  import { randomId } from "@whisq/core/ids";
+
+  const newTodo = { id: randomId(), text, done: false };
+  ```
+
+Top-level `@whisq/core` bundle stays at 5.5 KB gzipped. Closes WHISQ-101.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,10 @@
     "./forms": {
       "types": "./dist/forms.d.ts",
       "import": "./dist/forms.js"
+    },
+    "./ids": {
+      "types": "./dist/ids.d.ts",
+      "import": "./dist/ids.js"
     }
   },
   "files": [

--- a/packages/core/src/__tests__/collections.test.ts
+++ b/packages/core/src/__tests__/collections.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { effect } from "../reactive.js";
+import { signal, effect } from "../reactive.js";
 // Imported from the internal module path. Public API is
 // `@whisq/core/collections` (see packages/core/package.json exports).
-import { signalMap, signalSet } from "../collections.js";
+import { signalMap, signalSet, partition } from "../collections.js";
 
 describe("signalMap()", () => {
   it("accepts initial entries", () => {
@@ -261,5 +261,92 @@ describe("signalSet()", () => {
     const res = s.add("a").add("b");
     expect(res).toBe(s);
     expect(s.size).toBe(2);
+  });
+});
+
+// ── partition (WHISQ-101) ───────────────────────────────────────────────────
+
+describe("partition()", () => {
+  type Todo = { id: string; done: boolean };
+
+  it("splits a static source into matching / not-matching tuples", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", done: false },
+      { id: "b", done: true },
+      { id: "c", done: false },
+    ]);
+    const [pending, done] = partition(() => todos.value, (t) => !t.done);
+    expect(pending.value.map((t) => t.id)).toEqual(["a", "c"]);
+    expect(done.value.map((t) => t.id)).toEqual(["b"]);
+  });
+
+  it("re-derives both sides when the source changes", () => {
+    const todos = signal<Todo[]>([{ id: "a", done: false }]);
+    const [pending, done] = partition(() => todos.value, (t) => !t.done);
+
+    expect(pending.value).toHaveLength(1);
+    expect(done.value).toHaveLength(0);
+
+    todos.value = [
+      { id: "a", done: true },
+      { id: "b", done: false },
+    ];
+    expect(pending.value.map((t) => t.id)).toEqual(["b"]);
+    expect(done.value.map((t) => t.id)).toEqual(["a"]);
+  });
+
+  it("returns two empty arrays when the source is empty", () => {
+    const src = signal<Todo[]>([]);
+    const [yes, no] = partition(() => src.value, (t) => t.done);
+    expect(yes.value).toEqual([]);
+    expect(no.value).toEqual([]);
+  });
+
+  it("handles all-match and all-not-match cases", () => {
+    const allDone = signal<Todo[]>([
+      { id: "a", done: true },
+      { id: "b", done: true },
+    ]);
+    const [done, pending] = partition(() => allDone.value, (t) => t.done);
+    expect(done.value).toHaveLength(2);
+    expect(pending.value).toHaveLength(0);
+
+    allDone.value = [
+      { id: "c", done: false },
+      { id: "d", done: false },
+    ];
+    expect(done.value).toHaveLength(0);
+    expect(pending.value).toHaveLength(2);
+  });
+
+  it("each signal participates in effect tracking independently", () => {
+    const todos = signal<Todo[]>([{ id: "a", done: false }]);
+    const [pending, done] = partition(() => todos.value, (t) => !t.done);
+    const pendingRuns: number[] = [];
+    const doneRuns: number[] = [];
+
+    effect(() => {
+      pendingRuns.push(pending.value.length);
+    });
+    effect(() => {
+      doneRuns.push(done.value.length);
+    });
+
+    expect(pendingRuns).toEqual([1]);
+    expect(doneRuns).toEqual([0]);
+
+    todos.value = [
+      { id: "a", done: true },
+      { id: "b", done: false },
+    ];
+    expect(pendingRuns.at(-1)).toBe(1);
+    expect(doneRuns.at(-1)).toBe(1);
+  });
+
+  it("preserves source order in both output arrays", () => {
+    const nums = signal<number[]>([1, 2, 3, 4, 5, 6]);
+    const [even, odd] = partition(() => nums.value, (n) => n % 2 === 0);
+    expect(even.value).toEqual([2, 4, 6]);
+    expect(odd.value).toEqual([1, 3, 5]);
   });
 });

--- a/packages/core/src/__tests__/ids.test.ts
+++ b/packages/core/src/__tests__/ids.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+// Internal import path. Public API is `@whisq/core/ids` (see
+// packages/core/package.json exports).
+import { randomId } from "../ids.js";
+
+const V4_UUID_SHAPE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe("randomId() — primary path (crypto.randomUUID)", () => {
+  it("returns a string", () => {
+    expect(typeof randomId()).toBe("string");
+  });
+
+  it("returns a UUID-v4-shaped string", () => {
+    const id = randomId();
+    expect(id).toMatch(V4_UUID_SHAPE);
+  });
+
+  it("returns different values on successive calls", () => {
+    const a = randomId();
+    const b = randomId();
+    expect(a).not.toBe(b);
+  });
+
+  it("uses crypto.randomUUID when available", () => {
+    const spy = vi
+      .spyOn(crypto, "randomUUID")
+      .mockReturnValue("00000000-0000-4000-8000-000000000000");
+    try {
+      const id = randomId();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(id).toBe("00000000-0000-4000-8000-000000000000");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("randomId() — fallback path (crypto.randomUUID unavailable)", () => {
+  function withoutRandomUUID<T>(fn: () => T): T {
+    const original = (crypto as { randomUUID?: () => string }).randomUUID;
+    (crypto as { randomUUID?: () => string }).randomUUID = undefined;
+    try {
+      return fn();
+    } finally {
+      (crypto as { randomUUID?: () => string }).randomUUID = original;
+    }
+  }
+
+  it("still returns a UUID-v4-shaped string", () => {
+    const id = withoutRandomUUID(() => randomId());
+    expect(id).toMatch(V4_UUID_SHAPE);
+  });
+
+  it("still returns different values on successive calls", () => {
+    const [a, b, c] = withoutRandomUUID(() => [
+      randomId(),
+      randomId(),
+      randomId(),
+    ]);
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+
+  it("does not throw when both crypto.randomUUID and global crypto are absent", () => {
+    const originalCrypto = globalThis.crypto;
+    // @ts-expect-error intentional delete — simulate pre-Web-Crypto env
+    delete (globalThis as { crypto?: Crypto }).crypto;
+    try {
+      expect(() => randomId()).not.toThrow();
+      const id = randomId();
+      expect(id).toMatch(V4_UUID_SHAPE);
+    } finally {
+      globalThis.crypto = originalCrypto;
+    }
+  });
+});

--- a/packages/core/src/collections.ts
+++ b/packages/core/src/collections.ts
@@ -7,7 +7,12 @@
 // as the rest of the reactive core.
 // ============================================================================
 
-import { signal, type Signal } from "./reactive.js";
+import {
+  signal,
+  computed,
+  type Signal,
+  type ReadonlySignal,
+} from "./reactive.js";
 
 const MISSING: unique symbol = Symbol("whisq.collections.missing");
 type Missing = typeof MISSING;
@@ -240,4 +245,36 @@ export function signalSet<T>(initial?: Iterable<T>): SignalSet<T> {
   };
 
   return set;
+}
+
+// ── partition ──────────────────────────────────────────────────────────────
+
+/**
+ * Split a signal-held array into two derived signals — one with items that
+ * match the predicate, one with items that don't. Both sides re-compute
+ * when the source changes; source order is preserved on both sides.
+ *
+ * ```ts
+ * const todos = signal<Todo[]>([...]);
+ * const [pending, done] = partition(() => todos.value, (t) => !t.done);
+ *
+ * p(() => `${pending.value.length} left`);
+ * p(() => `${done.value.length} done`);
+ * button({ onclick: () => todos.value = pending.value }, "Clear completed");
+ * ```
+ *
+ * Each side is an independent `ReadonlySignal<T[]>` — subscribing to one
+ * does not subscribe to the other, and each re-runs its own effects only
+ * when its portion of the result would change in content. (That's
+ * reference-equality on the produced arrays, matching `computed()`
+ * semantics — structural equality is the caller's job if they need it.)
+ */
+export function partition<T>(
+  source: () => T[],
+  predicate: (item: T) => boolean,
+): [ReadonlySignal<T[]>, ReadonlySignal<T[]>] {
+  return [
+    computed(() => source().filter(predicate)),
+    computed(() => source().filter((item) => !predicate(item))),
+  ];
 }

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -1,0 +1,52 @@
+// ============================================================================
+// Whisq Core — IDs
+//
+// randomId() — UUID-v4-shaped string. Uses `crypto.randomUUID()` when
+// available (all modern browsers, Node 19+). Falls back to a Math.random
+// synthesis for older targets (old Safari, old Node) where the native API
+// isn't exposed. The fallback is NOT cryptographically strong — suitable
+// for client-side row ids / keys, not for security tokens.
+//
+// Import path: `@whisq/core/ids` — kept off the top-level bundle so apps
+// that don't use it pay no size cost.
+// ============================================================================
+
+/**
+ * Generate a UUID-v4-shaped random identifier.
+ *
+ * ```ts
+ * import { randomId } from "@whisq/core/ids";
+ *
+ * const todo = { id: randomId(), text, done: false };
+ * ```
+ *
+ * Prefers `crypto.randomUUID()` when the platform provides it (all modern
+ * browsers; Node 19+; Deno; Bun). Otherwise falls back to a `Math.random`
+ * synthesis — same v4 shape (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` where
+ * `y ∈ {8, 9, a, b}`), but with weaker entropy. Good enough for UI row
+ * ids and keyed-`each` keys; not for tokens, secrets, or deduplication
+ * across independent clients.
+ */
+export function randomId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return fallbackUuid();
+}
+
+function fallbackUuid(): string {
+  // Compose 32 hex digits, then splice in the v4 version (4) and variant
+  // (8/9/a/b) bits at positions 12 and 16. Output shape matches RFC 4122 v4.
+  const hex = (digits: number): string => {
+    let out = "";
+    for (let i = 0; i < digits; i++) {
+      out += Math.floor(Math.random() * 16).toString(16);
+    }
+    return out;
+  };
+  const variant = ((Math.random() * 4) | 0) + 8; // 8..11 → 8,9,a,b
+  return `${hex(8)}-${hex(4)}-4${hex(3)}-${variant.toString(16)}${hex(3)}-${hex(12)}`;
+}


### PR DESCRIPTION
Closes #101.

## Summary

Two opt-in utility helpers from the alpha.7 reviewer follow-up. Both behind sub-path imports so apps that don't use them pay no bundle cost — top-level `@whisq/core` stays at **5.5 KB gzipped** (verified via `pnpm size`).

### `partition(source, predicate)` — `@whisq/core/collections`

Split a signal-held array into `[matching, notMatching]` — both sides are independent `ReadonlySignal<T[]>`. Source order preserved on both sides; each side is a plain `computed()` so effects subscribed to one side don't fire for changes in the other (unless both partition outcomes change, which they generally do when source changes).

```ts
import { partition } from "@whisq/core/collections";

const todos = signal<Todo[]>([...]);
const [pending, done] = partition(() => todos.value, (t) => !t.done);

p(() => `${pending.value.length} left`);
button({ onclick: () => (todos.value = pending.value) }, "Clear completed");
```

### `randomId()` — `@whisq/core/ids`

UUID-v4-shaped random identifier. Uses native `crypto.randomUUID()` when available (all modern browsers, Node 19+, Deno, Bun); falls back to a `Math.random`-based synthesis with the same v4 shape for older targets (Safari <15.4, pre-19 Node). **NOT cryptographically strong** in the fallback path — fine for UI row ids and keyed-`each` keys; don't use for security tokens.

```ts
import { randomId } from "@whisq/core/ids";

const newTodo = { id: randomId(), text, done: false };
```

## Test plan

### `partition` (6 new tests)

- [x] Splits a static source into matching / not-matching tuples correctly.
- [x] Both sides re-derive when the source changes.
- [x] Empty source → two empty arrays.
- [x] All-match / all-not-match edge cases flip correctly on source replacement.
- [x] Each signal participates in `effect()` tracking independently.
- [x] Source order is preserved on both outputs.

### `randomId` (7 new tests)

- [x] Returns a string.
- [x] Returns a UUID-v4-shaped string (regex-matched).
- [x] Successive calls return different values.
- [x] Uses `crypto.randomUUID()` when available (verified via `vi.spyOn`).
- [x] Fallback path still returns v4-shaped strings.
- [x] Fallback path still returns distinct values on successive calls.
- [x] Does not throw when global `crypto` is entirely absent.

### Full suite

- [x] 404 core tests pass (was 391 → +13 new).
- [x] `pnpm -w build` clean across all 9 packages.
- [x] `pnpm size` — top-level bundle unchanged at 5.5 KB gzipped.
- [x] New `./ids` sub-path export verified in `packages/core/package.json`.

## Out of scope

- LLM reference / template CLAUDE.md updates to mention the new helpers — docs on whisq.dev handle the user-facing reference; template CLAUDE.md can pick these up in a future pass if patterns warrant.
- whisq.dev#111 (todo-app `randomUUID` + nested-signals design Q) — unblocks on docs side but the `randomId()` helper is ready to import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)