### PR TITLE
Release v0.1.0-alpha.8

### DIFF
--- a/.changeset/array-accepting-class-prop.md
+++ b/.changeset/array-accepting-class-prop.md
@@ -1,0 +1,22 @@
+---
+"@whisq/core": minor
+---
+
+The `class:` prop on every element now accepts an **array of sources** with per-source reactivity. Strings are class names; falsy values (`false | null | undefined | 0 | ""`) are filtered out — enabling the `cond && "active"` shorthand inline; functions are reactive — each function is called during the render effect and re-reads when its tracked signals change.
+
+```ts
+div({
+  class: [
+    "btn",
+    () => `btn-${variant.value}`,       // reactive
+    loading.value && "btn-loading",     // static conditional — cond && "…"
+    () => isDisabled.value && "disabled", // reactive conditional
+  ],
+});
+```
+
+If any array element is a function, the array is applied reactively; otherwise it's applied once at mount. This removes the `cx` vs `rcx` migration footgun Claude's alpha.7 feedback flagged — you no longer have to remember which helper to import when a class prop grows a reactive branch mid-edit.
+
+`cx` and `rcx` continue to work unchanged — this is a pure addition. A future release may collapse them into a single composition helper (see WHISQ-97 option A) but that change is deferred.
+
+Closes WHISQ-97 option B. Options A (unified `cx`) and the `rcx` deprecation path remain open on the issue for a follow-up cycle.

--- a/.changeset/bindfield-dev-strict-mode.md
+++ b/.changeset/bindfield-dev-strict-mode.md
@@ -1,0 +1,19 @@
+---
+"@whisq/core": minor
+---
+
+`bindField` now throws a `WhisqKeyByError` on no-match writes in dev mode (default `process.env.NODE_ENV !== "production"`) instead of silently logging to the console. A stale accessor or broken `keyBy` now surfaces immediately at the first click in `vite dev` instead of drowning in the console.
+
+New option `strict?: boolean` lets callers pin the behaviour explicitly — `strict: true` throws in both envs; `strict: false` keeps the legacy warn-and-discard even in dev. Production behaviour is unchanged (warn-and-discard) unless `strict: true` is set.
+
+```ts
+// Default in vite dev: throws WhisqKeyByError
+input({ ...bindField(todos, todo, "done", { as: "checkbox" }) })
+
+// Opt out if a test deliberately exercises the no-match path:
+input({ ...bindField(todos, todo, "done", { as: "checkbox", strict: false }) })
+```
+
+`WhisqKeyByError` carries `sourceKeys`, `targetKey`, and `field` so the error tells you what was in the source at write time vs. what the accessor was looking for. Both the error class and its `WhisqKeyByErrorFields` type are exported from `@whisq/core`.
+
+Closes WHISQ-100.

--- a/.changeset/component-types-and-sheet-nested-selectors.md
+++ b/.changeset/component-types-and-sheet-nested-selectors.md
@@ -1,0 +1,17 @@
+---
+"@whisq/core": minor
+---
+
+Fix `component()` and `sheet()` type signatures so that apps scaffolded from `create-whisq@latest` type-check cleanly under `tsc --strict`.
+
+Previously, `component()` was typed as `(props) => WhisqTemplate` — a legacy template-literal shape (`{ fragment, bindings, dispose }`) — while every element function (`div`, `span`, etc.) returns `WhisqNode` (`{ el, disposers, dispose, __whisq }`). The two shapes were incompatible, so **every** hyperscript component setup failed `tsc --strict` with _"Type 'WhisqNode' is missing properties: fragment, bindings"_. The runtime check in `component.ts` already required `WhisqNode`-shaped output, so the types were wrong for the documented and actually-supported API.
+
+Changes:
+
+- **`component<P>(setup: (props: P) => WhisqNode): ComponentDef<P>`** — setup now returns `WhisqNode`, matching the runtime guard and the hyperscript API that the LLM reference, docs, and starter templates all use. The JSDoc example switches from the legacy `html\`...\`` form to the hyperscript form.
+- **`ComponentDef<P>` call signature** — returns `WhisqNode` so components compose inside elements (`div(MyComponent({}))` now type-checks).
+- **`sheet()` nested selectors** — `StyleRule` is now recursive (`{ [key: string]: StyleValue | StyleRule }`), so mixing base CSS properties and nested rules (`"&:hover": { … }`, `"& a": { "&:hover": { … } }`, `"@media (…)": { … }`) under the same top-level key type-checks. The runtime behaviour is unchanged — the prefix convention is still the source of truth for which keys are nested vs base.
+
+Breaking: if any code relied on the old `(props) => WhisqTemplate` signature (the tagged-template `html\`...\`` path was already rejected by `component()`'s runtime check, so it couldn't actually have been in production use), it needs to return a `WhisqNode` instead.
+
+Closes WHISQ-108. The `html` tagged-template API and `WhisqTemplate` type remain in `@whisq/core/template` for internal use; fully removing them is tracked as a follow-up to #108.

--- a/.changeset/full-app-template-canonical-shape.md
+++ b/.changeset/full-app-template-canonical-shape.md
@@ -1,0 +1,14 @@
+---
+"create-whisq": minor
+---
+
+`full-app` template now scaffolds the canonical multi-file shape that the project-structure docs describe:
+
+- **`src/components/`** — `CounterRow.ts` demonstrates the pattern for reusable UI pulled out of a page.
+- **`src/lib/`** — `format.ts` demonstrates a pure utility module (no `@whisq/*` imports), including `formatCount()` and `clamp()` used by the scaffolded `CounterRow`.
+- **`src/App.ts`** — now wraps `RouterView` in `errorBoundary`, so a thrown error in any page degrades to a retry UI instead of tearing down the whole app. Demonstrates the canonical error-boundary shape `App.ts` should own.
+- **`src/pages/Home.ts`** — rewritten to consume `CounterRow` + `clamp`, connecting all four directories (`pages/` → `components/` → `lib/`) in one working example.
+
+Closes the framework-side half of WHISQ-102. A whisq.dev companion page (`/examples/canonical-app-structure/`) is tracked for a follow-up PR.
+
+Existing `full-app` behavior (router, stores/, styles.ts, pages/About.ts) is unchanged.

--- a/.changeset/hybrid-item-accessor-keyed-each.md
+++ b/.changeset/hybrid-item-accessor-keyed-each.md
@@ -1,0 +1,24 @@
+---
+"@whisq/core": minor
+---
+
+Keyed `each()`'s render callback now receives a **hybrid accessor** — callable (`todo()`) **and** signal-shaped (`todo.value`, `todo.peek()`). Joins the uniform `() => sig.value` reactive-access rule that holds everywhere else in the API; closes the last pocket of divergence both reviewers flagged in alpha.7 feedback.
+
+```ts
+each(() => todos.value, (todo) =>
+  li(
+    { class: () => todo.value.done ? "done" : "" },   // new canonical shape
+    span(() => todo.value.text),
+    button({ onclick: () => remove(todo.value.id) }, "✕"),
+  ),
+  { key: (t) => t.id },
+)
+```
+
+**Non-breaking.** The accessor is still a plain function at call sites that want `todo()`, and structurally assignable to `() => T` — so `bindField(todos, todo, "done", { as: "checkbox" })` and every other helper that types its input as `() => T` works unchanged. Existing call sites do not need to migrate; new code should prefer `todo.value.<field>` for consistency with the rest of the reactive-access rule.
+
+`index` follows the same pattern — `index()` (legacy) and `index.value` / `index.peek()` (new) both work.
+
+New exported type: `ItemAccessor<T>` (from `@whisq/core`).
+
+Addresses WHISQ-96 with the hybrid approach — option A's `.value` shape without the breaking-change downside. Partially closes the issue; the docs-side cookbook in `whisq.dev#108` (D-1) should adopt the `.value` shape as the canonical example going forward.

--- a/.changeset/partition-and-random-id-helpers.md
+++ b/.changeset/partition-and-random-id-helpers.md
@@ -1,0 +1,25 @@
+---
+"@whisq/core": minor
+---
+
+Two opt-in utility helpers, both on sub-path imports so apps that don't use them pay no bundle cost.
+
+- **`partition(source, predicate)`** from `@whisq/core/collections` — split a signal-held array into two `ReadonlySignal<T[]>` sides (matching / not-matching). Source order is preserved on both sides; each side is an independent `computed()` that only re-runs effects subscribed to it. The canonical use is "active" vs "done" on a todo list without hand-rolling two `computed`s.
+
+  ```ts
+  import { partition } from "@whisq/core/collections";
+
+  const todos = signal<Todo[]>([...]);
+  const [pending, done] = partition(() => todos.value, (t) => !t.done);
+  button({ onclick: () => (todos.value = pending.value) }, "Clear completed");
+  ```
+
+- **`randomId()`** from `@whisq/core/ids` — UUID-v4-shaped random identifier. Uses native `crypto.randomUUID()` when available (all modern browsers, Node 19+, Deno, Bun); falls back to a `Math.random`-based synthesis with the same v4 shape for older targets (old Safari, pre-19 Node). Same output shape on both paths, so callers don't have to branch. Suitable for UI row ids and keyed-`each` keys — **not** for security tokens (the fallback is not cryptographically strong).
+
+  ```ts
+  import { randomId } from "@whisq/core/ids";
+
+  const newTodo = { id: randomId(), text, done: false };
+  ```
+
+Top-level `@whisq/core` bundle stays at 5.5 KB gzipped. Closes WHISQ-101.

--- a/.changeset/persistedsignal-onschemafailure.md
+++ b/.changeset/persistedsignal-onschemafailure.md
@@ -1,0 +1,18 @@
+---
+"@whisq/core": minor
+---
+
+Add `onSchemaFailure?: (err: unknown, raw: string) => void` option to `persistedSignal`. Invoked synchronously **before** fallback to `initial` when `deserialize` throws (malformed stored JSON) or `schema` throws (validator rejects). Receives the thrown error and the exact raw string read from storage — use it to log to Sentry / show a recovery UI / decide between migrate-vs-reset.
+
+```ts
+const todos = persistedSignal<Todo[]>("todos", [], {
+  schema: validateTodosShape,
+  onSchemaFailure: (err, raw) => {
+    Sentry.captureException(err, { extra: { key: "todos", raw } });
+  },
+});
+```
+
+The callback is **not** invoked on first-visit (`raw` would be `null`, not a failure) or on storage-access errors (private mode, disabled storage — environment faults, not schema faults). If the callback itself throws, the exception is caught and logged via `console.warn` so a broken diagnostic pipeline can't prevent signal construction.
+
+Closes WHISQ-98.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,10 +13,17 @@
     "@whisq/vite-plugin": "0.1.0-alpha.4"
   },
   "changesets": [
+    "access-shapes-canonical-doc",
+    "accessor-boundaries-docs",
     "alpha-5-batch",
+    "bindfield-for-array-items",
+    "bindpath-for-nested-records",
     "clarify-ref-accessor",
     "each-keyed-accessor-callback",
     "export-event-types",
+    "friendlier-runtime-errors",
+    "match-api-clarity",
+    "persisted-signal",
     "project-structure-conventions",
     "reactive-shapes-taxonomy"
   ]

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -16,15 +16,23 @@
     "access-shapes-canonical-doc",
     "accessor-boundaries-docs",
     "alpha-5-batch",
+    "array-accepting-class-prop",
+    "bindfield-dev-strict-mode",
     "bindfield-for-array-items",
     "bindpath-for-nested-records",
     "clarify-ref-accessor",
+    "component-types-and-sheet-nested-selectors",
     "each-keyed-accessor-callback",
     "export-event-types",
     "friendlier-runtime-errors",
+    "full-app-template-canonical-shape",
+    "hybrid-item-accessor-keyed-each",
     "match-api-clarity",
+    "partition-and-random-id-helpers",
     "persisted-signal",
+    "persistedsignal-onschemafailure",
     "project-structure-conventions",
-    "reactive-shapes-taxonomy"
+    "reactive-shapes-taxonomy",
+    "theme-sheet-ssr-guard"
   ]
 }

--- a/.changeset/theme-sheet-ssr-guard.md
+++ b/.changeset/theme-sheet-ssr-guard.md
@@ -1,0 +1,14 @@
+---
+"@whisq/core": patch
+---
+
+Fix `theme()` and `sheet()` throwing `ReferenceError: document is not defined` under SSR (server-side rendering). The shared internal `injectCSS()` helper now short-circuits when `typeof document === "undefined"`, matching the SSR-safe pattern that `persistedSignal` already uses.
+
+User-observable impact:
+
+- **`theme()`**: SSR call is a no-op (no `<style>` tag is written; client-side hydration takes over on mount). Previously threw.
+- **`sheet()`**: SSR call returns the in-memory classMap (so server-rendered HTML can reference the correct class names for the client to hydrate against), but skips the DOM injection step. Previously threw on the injection line.
+
+Also clarified `theme()` JSDoc: **"call once at module scope"** and **"duplicate calls = last-call-wins"** are now explicit (the duplicate-calls behavior already held; the docs didn't say so).
+
+Closes WHISQ-99 (framework side). Docs work on whisq.dev — the `/core-concepts/styling/` and `/api/theme/` pages — will land as a companion PR in that repo.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,114 @@
 # @whisq/core
 
+## 0.1.0-alpha.7
+
+### Minor Changes
+
+- 757049d: Add `bindField(source, item, key, opts?)` — two-way binding for a field on an item inside a signal-held array. Closes the ergonomic gap `bind()` didn't reach: the most common UI shape in real applications (todos, carts, forms-with-rows, CRUD grids).
+
+  ```ts
+  each(
+    () => todos.value,
+    (todo) =>
+      input({
+        type: "checkbox",
+        ...bindField(todos, todo, "done", { as: "checkbox" }),
+      }),
+    { key: (t) => t.id },
+  );
+  ```
+
+  Mirrors `bind()`'s discriminator shapes (text / number / checkbox / radio). `keyBy` identifies which item to rewrite — defaults to `t => t.id`; override for items keyed on something else. Writes produce an immutable array update so downstream `computed` / `effect` re-run correctly.
+
+  All four scaffolded templates' `CLAUDE.md` reactive-shapes tables now lead with `bindField()` for this case instead of the manual event pair. The decision flow also updates to _"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."_
+
+  `@whisq/core` size budget raised from 5 KB to 5.5 KB gzipped (current: 5.08 KB). The README updates "Under 5 KB gzipped" → "~5 KB gzipped" to match. `bindField` is exported from the top-level `@whisq/core` so LLMs and autocompletion discover it alongside `bind()`.
+
+  Closes #78.
+
+- 34a2c7a: Add `bindPath(source, path, opts?)` — two-way binding for a field at an arbitrary **object path** in a signal-held record. Use when `bind()` doesn't apply because the field lives two or more levels deep (e.g. `user.profile.email`, `settings.billing.plan`). Follow-up to WHISQ-78 (`bindField`) for the nested-object case the feedback docs flagged as friction against the flat-binding primitives.
+
+  Exported from a new sub-path, `@whisq/core/forms`, so apps that only need `bind()` + `bindField()` (the 80% case) pay no bundle cost. Top-level `@whisq/core` stays at 5.25 KB gzipped.
+
+  ```ts
+  import { bindPath } from "@whisq/core/forms";
+
+  form(
+    input({ ...bindPath(user, ["profile", "name"]) }),
+    input({ type: "email", ...bindPath(user, ["profile", "email"]) }),
+    input({
+      type: "number",
+      ...bindPath(user, ["profile", "age"], { as: "number" }),
+    }),
+    input({
+      type: "checkbox",
+      ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }),
+    }),
+  );
+  ```
+
+  ### Behaviors worth leading with
+  - **Structural sharing on writes.** Writes produce a new root and new objects at every level on the path; sibling branches keep their reference identity so downstream `computed` / `effect` re-runs stay narrow.
+  - **Missing-intermediate creation.** Reading through a missing intermediate returns `undefined`; writing creates the object structure as needed.
+  - **Object keys only.** Array traversal is not supported in the path — use `bindField()` at the array level and compose. This keeps `bindPath` predictable and its implementation small.
+  - **Typed overloads** for depths 1–4; deeper paths work via the loose signature (same runtime, just less TS inference).
+
+  Mirrors `bind()` and `bindField()`'s discriminator shapes — text / number / checkbox / radio.
+
+  Scaffolded `CLAUDE.md` files gain a "Binding into nested records (opt-in, sub-path import)" block under Forms so AI-generated code for new projects discovers the pattern without reinventing it.
+
+  Closes #86.
+
+- 97203c8: Dev-mode runtime errors now tell you what's wrong and how to fix it. `div(...)`, `each()`, and `component()` validate their inputs at the boundary and throw a new `WhisqStructureError` with an expected/received mismatch plus a short hint when malformed children, non-array `each()` items, or invalid component return values show up.
+
+  Where the old behaviors were "`Uncaught TypeError: .for is not iterable`" or a silent drop, you now see:
+
+  ```
+  each: expected items() to return an array, received undefined.
+  Hint: Data hasn't loaded yet. Gate the list with `when(() => data(), () => ul(each(...)))` or return `[]` while loading.
+  ```
+
+  The guard code is wrapped in `if (process.env.NODE_ENV !== "production")` blocks so bundlers (Vite, Rollup, webpack, esbuild) strip it from production bundles — `@whisq/core` size-limit is measured with the same define and stays under budget at 5.25 KB gzipped.
+
+  Public surface: `WhisqStructureError` (class) and `WhisqStructureErrorFields` (type) are both exported so apps can `instanceof`-check and render friendly error boundaries.
+
+  Closes #81.
+
+- c84e495: Add `persistedSignal(key, initial, opts?)` — a `Signal<T>` backed by `localStorage` / `sessionStorage`, exported from the new sub-path `@whisq/core/persistence` so apps that don't need it pay zero bundle cost.
+
+  ```ts
+  import { persistedSignal } from "@whisq/core/persistence";
+
+  export const todos = persistedSignal<Todo[]>("todos", []);
+  ```
+
+  Closes the "every Whisq app reinvents the guarded-localStorage-read-with-effect-writer pattern" problem identified by the alpha.6 feedback. Blessed shape, one import, no hand-rolling.
+
+  ### Behaviors worth leading with
+  - **SSR-safe.** On the server (`typeof window === "undefined"`) returns a plain signal initialized to `initial` with no storage subscription.
+  - **Schema-validated.** If the stored JSON is malformed, or an optional `schema(raw)` validator throws, the signal falls back to `initial` rather than crashing at mount.
+  - **Quota-safe.** If a write throws (`QuotaExceededError`, private mode), logs a warning and keeps the in-memory value — the app keeps working.
+  - **Module-scope intent.** Call `persistedSignal` at module scope in your `stores/` file, not inside components — the write effect lives for the module lifetime by design.
+
+  Options: `storage: "local" | "session"`, `serialize` / `deserialize` (default JSON), `schema` (validation on load).
+
+  Scaffolded templates' `CLAUDE.md` files gain a "Persisted stores (opt-in, sub-path import)" block under Shared State so AI-generated code for new projects can discover the pattern without reinventing it.
+
+  Closes #82.
+
+### Patch Changes
+
+- 3a31d18: Clarify `match()` as a **predicate chain, not pattern matching**.
+
+  Audit finding: `match()` has always had exactly one shape — variadic tuple branches `[predicate, render]` with an optional trailing bare render fn as fallback. The GPT-side alpha.6 feedback flagged "object vs tuple form" confusion, but no object form exists in the code; GPT was pattern-matching against Rust/Scala/Vue conventions where `match(value, { case1, case2 })` is common.
+
+  Changes:
+  - **JSDoc** now leads with _"Predicate-chain conditional renderer — not pattern matching"_ and calls out the canonical shape, first-true-wins ordering, and fallback-position rules explicitly.
+  - **Dev-mode validation** (stripped in production builds) throws a `WhisqStructureError` when `match()` receives a plain object (the exact GPT-style confusion), a malformed tuple, or a fallback that isn't in the last position. Production bundle unchanged at 5.25 KB gzipped.
+  - **Scaffolded templates** — all four `CLAUDE.md` files now include `match` in the canonical imports line and expand the "Conditional Rendering" section to document `when()` vs `match()` with a ready example. AI-generated code for new projects will reach for `match` instead of nesting `when()`.
+
+  Closes #83.
+
 ## 0.1.0-alpha.6
 
 ### Minor Changes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,130 @@
 # @whisq/core
 
+## 0.1.0-alpha.8
+
+### Minor Changes
+
+- 8f645a8: The `class:` prop on every element now accepts an **array of sources** with per-source reactivity. Strings are class names; falsy values (`false | null | undefined | 0 | ""`) are filtered out — enabling the `cond && "active"` shorthand inline; functions are reactive — each function is called during the render effect and re-reads when its tracked signals change.
+
+  ```ts
+  div({
+    class: [
+      "btn",
+      () => `btn-${variant.value}`, // reactive
+      loading.value && "btn-loading", // static conditional — cond && "…"
+      () => isDisabled.value && "disabled", // reactive conditional
+    ],
+  });
+  ```
+
+  If any array element is a function, the array is applied reactively; otherwise it's applied once at mount. This removes the `cx` vs `rcx` migration footgun Claude's alpha.7 feedback flagged — you no longer have to remember which helper to import when a class prop grows a reactive branch mid-edit.
+
+  `cx` and `rcx` continue to work unchanged — this is a pure addition. A future release may collapse them into a single composition helper (see WHISQ-97 option A) but that change is deferred.
+
+  Closes WHISQ-97 option B. Options A (unified `cx`) and the `rcx` deprecation path remain open on the issue for a follow-up cycle.
+
+- 401bfca: `bindField` now throws a `WhisqKeyByError` on no-match writes in dev mode (default `process.env.NODE_ENV !== "production"`) instead of silently logging to the console. A stale accessor or broken `keyBy` now surfaces immediately at the first click in `vite dev` instead of drowning in the console.
+
+  New option `strict?: boolean` lets callers pin the behaviour explicitly — `strict: true` throws in both envs; `strict: false` keeps the legacy warn-and-discard even in dev. Production behaviour is unchanged (warn-and-discard) unless `strict: true` is set.
+
+  ```ts
+  // Default in vite dev: throws WhisqKeyByError
+  input({ ...bindField(todos, todo, "done", { as: "checkbox" }) });
+
+  // Opt out if a test deliberately exercises the no-match path:
+  input({
+    ...bindField(todos, todo, "done", { as: "checkbox", strict: false }),
+  });
+  ```
+
+  `WhisqKeyByError` carries `sourceKeys`, `targetKey`, and `field` so the error tells you what was in the source at write time vs. what the accessor was looking for. Both the error class and its `WhisqKeyByErrorFields` type are exported from `@whisq/core`.
+
+  Closes WHISQ-100.
+
+- 0c1dccf: Fix `component()` and `sheet()` type signatures so that apps scaffolded from `create-whisq@latest` type-check cleanly under `tsc --strict`.
+
+  Previously, `component()` was typed as `(props) => WhisqTemplate` — a legacy template-literal shape (`{ fragment, bindings, dispose }`) — while every element function (`div`, `span`, etc.) returns `WhisqNode` (`{ el, disposers, dispose, __whisq }`). The two shapes were incompatible, so **every** hyperscript component setup failed `tsc --strict` with _"Type 'WhisqNode' is missing properties: fragment, bindings"_. The runtime check in `component.ts` already required `WhisqNode`-shaped output, so the types were wrong for the documented and actually-supported API.
+
+  Changes:
+  - **`component<P>(setup: (props: P) => WhisqNode): ComponentDef<P>`** — setup now returns `WhisqNode`, matching the runtime guard and the hyperscript API that the LLM reference, docs, and starter templates all use. The JSDoc example switches from the legacy `html\`...\`` form to the hyperscript form.
+  - **`ComponentDef<P>` call signature** — returns `WhisqNode` so components compose inside elements (`div(MyComponent({}))` now type-checks).
+  - **`sheet()` nested selectors** — `StyleRule` is now recursive (`{ [key: string]: StyleValue | StyleRule }`), so mixing base CSS properties and nested rules (`"&:hover": { … }`, `"& a": { "&:hover": { … } }`, `"@media (…)": { … }`) under the same top-level key type-checks. The runtime behaviour is unchanged — the prefix convention is still the source of truth for which keys are nested vs base.
+
+  Breaking: if any code relied on the old `(props) => WhisqTemplate` signature (the tagged-template `html\`...\``path was already rejected by`component()`'s runtime check, so it couldn't actually have been in production use), it needs to return a `WhisqNode` instead.
+
+  Closes WHISQ-108. The `html` tagged-template API and `WhisqTemplate` type remain in `@whisq/core/template` for internal use; fully removing them is tracked as a follow-up to #108.
+
+- 91740a2: Keyed `each()`'s render callback now receives a **hybrid accessor** — callable (`todo()`) **and** signal-shaped (`todo.value`, `todo.peek()`). Joins the uniform `() => sig.value` reactive-access rule that holds everywhere else in the API; closes the last pocket of divergence both reviewers flagged in alpha.7 feedback.
+
+  ```ts
+  each(
+    () => todos.value,
+    (todo) =>
+      li(
+        { class: () => (todo.value.done ? "done" : "") }, // new canonical shape
+        span(() => todo.value.text),
+        button({ onclick: () => remove(todo.value.id) }, "✕"),
+      ),
+    { key: (t) => t.id },
+  );
+  ```
+
+  **Non-breaking.** The accessor is still a plain function at call sites that want `todo()`, and structurally assignable to `() => T` — so `bindField(todos, todo, "done", { as: "checkbox" })` and every other helper that types its input as `() => T` works unchanged. Existing call sites do not need to migrate; new code should prefer `todo.value.<field>` for consistency with the rest of the reactive-access rule.
+
+  `index` follows the same pattern — `index()` (legacy) and `index.value` / `index.peek()` (new) both work.
+
+  New exported type: `ItemAccessor<T>` (from `@whisq/core`).
+
+  Addresses WHISQ-96 with the hybrid approach — option A's `.value` shape without the breaking-change downside. Partially closes the issue; the docs-side cookbook in `whisq.dev#108` (D-1) should adopt the `.value` shape as the canonical example going forward.
+
+- 2809555: Two opt-in utility helpers, both on sub-path imports so apps that don't use them pay no bundle cost.
+  - **`partition(source, predicate)`** from `@whisq/core/collections` — split a signal-held array into two `ReadonlySignal<T[]>` sides (matching / not-matching). Source order is preserved on both sides; each side is an independent `computed()` that only re-runs effects subscribed to it. The canonical use is "active" vs "done" on a todo list without hand-rolling two `computed`s.
+
+    ```ts
+    import { partition } from "@whisq/core/collections";
+
+    const todos = signal<Todo[]>([...]);
+    const [pending, done] = partition(() => todos.value, (t) => !t.done);
+    button({ onclick: () => (todos.value = pending.value) }, "Clear completed");
+    ```
+
+  - **`randomId()`** from `@whisq/core/ids` — UUID-v4-shaped random identifier. Uses native `crypto.randomUUID()` when available (all modern browsers, Node 19+, Deno, Bun); falls back to a `Math.random`-based synthesis with the same v4 shape for older targets (old Safari, pre-19 Node). Same output shape on both paths, so callers don't have to branch. Suitable for UI row ids and keyed-`each` keys — **not** for security tokens (the fallback is not cryptographically strong).
+
+    ```ts
+    import { randomId } from "@whisq/core/ids";
+
+    const newTodo = { id: randomId(), text, done: false };
+    ```
+
+  Top-level `@whisq/core` bundle stays at 5.5 KB gzipped. Closes WHISQ-101.
+
+- 1b669b4: Add `onSchemaFailure?: (err: unknown, raw: string) => void` option to `persistedSignal`. Invoked synchronously **before** fallback to `initial` when `deserialize` throws (malformed stored JSON) or `schema` throws (validator rejects). Receives the thrown error and the exact raw string read from storage — use it to log to Sentry / show a recovery UI / decide between migrate-vs-reset.
+
+  ```ts
+  const todos = persistedSignal<Todo[]>("todos", [], {
+    schema: validateTodosShape,
+    onSchemaFailure: (err, raw) => {
+      Sentry.captureException(err, { extra: { key: "todos", raw } });
+    },
+  });
+  ```
+
+  The callback is **not** invoked on first-visit (`raw` would be `null`, not a failure) or on storage-access errors (private mode, disabled storage — environment faults, not schema faults). If the callback itself throws, the exception is caught and logged via `console.warn` so a broken diagnostic pipeline can't prevent signal construction.
+
+  Closes WHISQ-98.
+
+### Patch Changes
+
+- 0afc98b: Fix `theme()` and `sheet()` throwing `ReferenceError: document is not defined` under SSR (server-side rendering). The shared internal `injectCSS()` helper now short-circuits when `typeof document === "undefined"`, matching the SSR-safe pattern that `persistedSignal` already uses.
+
+  User-observable impact:
+  - **`theme()`**: SSR call is a no-op (no `<style>` tag is written; client-side hydration takes over on mount). Previously threw.
+  - **`sheet()`**: SSR call returns the in-memory classMap (so server-rendered HTML can reference the correct class names for the client to hydrate against), but skips the DOM injection step. Previously threw on the injection line.
+
+  Also clarified `theme()` JSDoc: **"call once at module scope"** and **"duplicate calls = last-call-wins"** are now explicit (the duplicate-calls behavior already held; the docs didn't say so).
+
+  Closes WHISQ-99 (framework side). Docs work on whisq.dev — the `/core-concepts/styling/` and `/api/theme/` pages — will land as a companion PR in that repo.
+
 ## 0.1.0-alpha.7
 
 ### Minor Changes

--- a/packages/core/docs/access-shapes.md
+++ b/packages/core/docs/access-shapes.md
@@ -6,25 +6,23 @@ Canonical reference for **how you read** reactive values. Paired with [`reactive
 
 ## Is "uniform `() => value`" actually uniform?
 
-The marketing line you'll see on whisq.dev is _"wrap reactive reads in `() => ...` everywhere."_ The **wrapper** is uniform — every reactive position in the API accepts `() => value`. What varies is **what goes inside the wrapper**, because Whisq exposes three different source shapes: plain signals, keyed-`each` accessors, and `resource()` fields.
+The marketing line you'll see on whisq.dev is _"wrap reactive reads in `() => ...` everywhere."_ The **wrapper** is uniform — every reactive position in the API accepts `() => value`. Since WHISQ-96 shipped the **hybrid accessor**, signals and keyed-`each` items now read with the *same* `.value` shape, so the simple rule is:
 
-So the rule to remember is:
+> _Wrap reactive reads in `() => ...` and read `.value` on the source. `resource()` fields are the single exception — they're callable (`users.loading()`, `users.data()`) because loading / error / data are semantic states, not signals._
 
-> _Wrap reactive reads in `() => ...`. Unwrap the source:_
-> _- Signal → `.value`_
-> _- Keyed-`each` item or `resource()` field → `()` (it's already an accessor)._
-
-Two tokens to remember instead of one, but one consistent wrapper — and _zero_ hidden dependency arrays, stale closures, or re-render caveats.
+The old "call the keyed-`each` accessor with `()`" form still works for backwards compatibility and for handing the accessor to `bindField`-style helpers that type their input as `() => T`.
 
 ---
 
 ## The three shapes at a glance
 
-| # | Source                    | Outside reactive context              | Inside reactive context (getter) |
-| - | ------------------------- | ------------------------------------- | -------------------------------- |
-| 1 | Plain signal              | `sig.value` / `sig.peek()`            | `() => sig.value`                |
-| 2 | Keyed `each()` item       | _(only exists inside the render fn)_  | `() => todo().text`              |
-| 3 | `resource()` field        | `users.loading()` / `users.data()` …  | `() => users.loading()`          |
+| # | Source                    | Outside reactive context              | Inside reactive context (getter)      |
+| - | ------------------------- | ------------------------------------- | ------------------------------------- |
+| 1 | Plain signal              | `sig.value` / `sig.peek()`            | `() => sig.value`                     |
+| 2 | Keyed `each()` item       | _(only exists inside the render fn)_  | `() => todo.value.text` (canonical)   |
+| 3 | `resource()` field        | `users.loading()` / `users.data()` …  | `() => users.loading()`               |
+
+Shape 2 also accepts the legacy call form — `() => todo().text` — which remains the shape `bindField(source, todo, "done")` expects when the accessor is passed as a `() => T` argument.
 
 ---
 
@@ -51,9 +49,9 @@ const snap = count.peek();
 - **Common mistake:** passing `count.value` directly as a child → reads once, not reactive.
 - **Writes:** `count.value = n` or `count.set(n)` or `count.update(fn)`.
 
-## Shape 2 — Keyed `each()` item: `todo()`
+## Shape 2 — Keyed `each()` item: `todo.value` (or `todo()` for legacy consumers)
 
-Inside a keyed `each(items, (item) => …, { key })`, the `item` argument is an **accessor function** — you call it with `()` to get the current value. Wrapping the read in `() => todo().text` is what makes the child re-render when the array is replaced with new objects at the same key. Closing over `todo` and writing `.text` would be stale at the next array replacement (see WHISQ-62 for the fix that introduced this).
+Inside a keyed `each(items, (item) => …, { key })`, the `item` argument is a **hybrid accessor** — both callable (`todo()`) and signal-shaped (`todo.value`, `todo.peek()`). Prefer `todo.value.<field>` inside reactive getters to join the uniform `() => sig.value` rule from Shape 1. The `todo()` call form stays because it's what `bindField(source, todo, "done")` and other `() => T` consumers take as input. Wrapping the read in `() => todo.value.text` is what makes the child re-render when the array is replaced with new objects at the same key — closing over `todo.value` at setup (without the wrapper) snapshots the first value and freezes the row at the next array replacement (see WHISQ-62 for the original stale-read fix, WHISQ-96 for the `.value` shape).
 
 ```ts
 type Todo = { id: string; text: string; done: boolean };
@@ -64,17 +62,22 @@ ul(
     () => todos.value,
     (todo) =>
       li(
-        span(() => todo().text),                      // reactive text via accessor
-        input({ type: "checkbox",
-          ...bindField(todos, todo, "done", { as: "checkbox" }) }),
+        span(() => todo.value.text),                  // canonical — joins Shape 1
+        input({
+          type: "checkbox",
+          // bindField takes `() => T`; the hybrid accessor is assignable to that
+          ...bindField(todos, todo, "done", { as: "checkbox" }),
+        }),
       ),
     { key: (t) => t.id },
   ),
 );
 ```
 
-- **`todo` is a function, not an object** — `todo.text` is `undefined`; TypeScript flags this.
-- **Always wrap `todo()` in `() => ...`** for reactive reads — a bare `todo()` outside a getter is a one-shot snapshot.
+- **`todo.value.<field>`** is the canonical read — uniform with plain signals.
+- **`todo()` still works** and is structurally `() => T`, so `bindField` and every other `() => T` consumer accepts the accessor unchanged.
+- **Wrap reads in `() => ...`** for reactive positions — a bare `todo.value.text` at setup is a one-shot snapshot, same as reading a signal's `.value` without the wrapper.
+- **`todo.peek()`** reads the current value without tracking — mirrors `signal.peek()`.
 - **Writes** go through the source signal, not the accessor. Use `bindField(source, item, key)` for the common "update field on an item" case; fall back to a manual event pair for arbitrary mutations.
 
 Non-keyed `each(items, (item) => …)` (no `{ key }`) still passes plain `T`, because the whole list re-renders on every change — no stale-accessor risk. See [`reactive-shapes.md`](./reactive-shapes.md) for when to reach for `each` keyed vs. non-keyed.
@@ -115,6 +118,8 @@ The common rule: **the thing you hand to the child must be re-readable**. A raw 
 
 ### Worked example: split a todo row into its own component
 
+The child has two reasonable prop-type choices — pick by whether it needs access to the `.value` / `.peek()` API or just wants the narrowest `() => T` capability that accepts any source.
+
 ```ts
 // parent: owns the todos signal
 type Todo = { id: string; text: string; done: boolean };
@@ -133,30 +138,41 @@ function TodoList() {
   );
 }
 
-// child: reads props.todo() inside its own getters
-const TodoItem = component((props: { todo: () => Todo }) => {
+// child: typed as ItemAccessor<Todo> — reads via .value (canonical Shape 2)
+import type { ItemAccessor } from "@whisq/core";
+
+const TodoItem = component((props: { todo: ItemAccessor<Todo> }) => {
   return li(
     input({
       type: "checkbox",
+      // bindField wants `() => T`; the hybrid accessor is assignable to that
       ...bindField(todos, props.todo, "done", { as: "checkbox" }),
     }),
-    span(() => props.todo().text),              // re-reads on every source change
+    span(() => props.todo.value.text),             // canonical — joins Shape 1
     button(
-      { onclick: () => remove(props.todo().id) },
+      { onclick: () => remove(props.todo.value.id) },
       "✕",
     ),
   );
 });
+
+// Alternative: typed as `() => Todo` — the narrowest shape, accepts any
+// getter-style source (keyed-each accessor, resource fields, `() => sig.value`).
+// Read inside the child with `props.todo()` — same freshness, fewer capabilities.
+const TodoItemCompat = component((props: { todo: () => Todo }) => {
+  return li(span(() => props.todo().text));
+});
 ```
 
-Everything the child needs is reachable from `props.todo()`. Nothing is captured in a local variable at setup. When the parent replaces `todos.value` with a new array that still contains the same `id`, the reconciler reuses this `TodoItem` instance; the per-entry `itemSig` gets the new object; `props.todo()` returns that new object; every getter in the child re-reads.
+Everything the child needs is reachable from `props.todo`. Nothing is captured in a local variable at setup. When the parent replaces `todos.value` with a new array that still contains the same `id`, the reconciler reuses this `TodoItem` instance; the per-entry `itemSig` gets the new object; both `props.todo.value` and `props.todo()` return that new object; every getter in the child re-reads.
 
 ### Counter-example: snapshot at setup (the bug you can't reproduce in a unit test)
 
 ```ts
 // DON'T DO THIS
-const TodoItem = component((props: { todo: () => Todo }) => {
-  const todo = props.todo();                    // snapshot captured once
+const TodoItem = component((props: { todo: ItemAccessor<Todo> }) => {
+  const todo = props.todo.value;                // snapshot captured once
+  // Or the legacy equivalent: `const todo = props.todo()` — same bug.
   return li(
     span(todo.text),                            // static — never updates
     button(
@@ -183,20 +199,21 @@ Both shapes work; pick by who "owns" the binding.
 | --------------------- | ----------------------------------- | ---------------------- |
 | A `Signal<T>`          | `{ count: sig }` (the signal itself) | `() => props.count.value` |
 | A `Signal<T>` — child should only read  | `{ count: () => sig.value }` (pre-wrapped getter) | `() => props.count()` |
-| A keyed-`each` item    | `{ todo }` (the accessor)            | `() => props.todo()`   |
+| A keyed-`each` item    | `{ todo }` (the hybrid accessor)     | `() => props.todo.value.x` or `() => props.todo().x` |
 | A `resource()` field   | `{ data: users.data }` (the accessor) | `() => props.data()`   |
 
 - Pass the raw signal when the child might need to **write** (`bind(props.sig)`). The signal object carries both read and write.
 - Pass a pre-wrapped getter `() => sig.value` when the child should **only read** — the type `() => T` is the smallest capability and is identical-shaped to the keyed-each/resource case, so generic child components can accept any of them.
-- **Never call the accessor at the parent** — `TodoItem({ todo: todo() })` snapshots it.
+- **Never call the accessor at the parent** — `TodoItem({ todo: todo() })` or `TodoItem({ todo: todo.value })` both snapshot and freeze the child.
 
 ### Common mistakes at the boundary
 
 | Mistake                                         | What happens                                                      | Fix                                             |
 | ----------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------- |
 | `TodoItem({ todo: todo() })` (call at parent)   | Child receives frozen item; stale after array replacement.       | `TodoItem({ todo })` — pass the accessor.       |
-| `const todo = props.todo()` inside child setup   | Snapshots at first mount; ignores later updates.                 | Read inside each getter: `() => props.todo().x`. |
-| Destructuring props in setup (`const { todo } = props`) | Loses per-render re-read if Whisq ever swaps props (and is a footgun elsewhere too). | Read fields off `props` directly: `() => props.todo().text`. |
+| `TodoItem({ todo: todo.value })` (`.value` at parent) | Same bug in a different dress — reads the current value and snapshots it. | `TodoItem({ todo })` — pass the accessor. |
+| `const todo = props.todo.value` inside child setup | Snapshots at first mount; ignores later updates.               | Read inside each getter: `() => props.todo.value.x`. |
+| Destructuring props in setup (`const { todo } = props`) | Loses per-render re-read if Whisq ever swaps props (and is a footgun elsewhere too). | Read fields off `props` directly: `() => props.todo.value.text`. |
 | Passing `todos.value[0]` as a prop              | Same as snapshotting — you read `.value` at the parent.          | Pass a getter: `{ first: () => todos.value[0] }`. |
 
 See also the structural guards shipped in [#81](https://github.com/whisqjs/whisq/issues/81) — `WhisqStructureError` catches wrong-shaped children at the boundary and points at the fix.

--- a/packages/core/docs/reactive-shapes.md
+++ b/packages/core/docs/reactive-shapes.md
@@ -15,7 +15,7 @@ Every reactive position in the API accepts `() => value` — that wrapper is uni
 | 3 | **`bind()`** spread       | `input({ ...bind(email) })`                                                        | Two-way binding one signal into one form input you own                                  |
 | 4 | **`bindField()`** spread  | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | A field inside an item inside a signal-backed array (inside keyed `each`)               |
 
-Escape hatch: when `bindField()` doesn't fit (deep paths, custom write logic), fall back to a **manual event pair** — `{ checked: () => todo().done, onchange: e => toggle(todo().id) }`. Same idea, more code.
+Escape hatch: when `bindField()` doesn't fit (deep paths, custom write logic), fall back to a **manual event pair** — `{ checked: () => todo.value.done, onchange: e => toggle(todo.value.id) }`. Same idea, more code.
 
 A one-sentence decision flow:
 
@@ -97,14 +97,14 @@ ul(
           type: "checkbox",
           ...bindField(todos, todo, "done", { as: "checkbox" }),
         }),
-        span(() => todo().text),
+        span(() => todo.value.text),
       ),
     { key: (t) => t.id },
   ),
 );
 ```
 
-- **`todo` is an accessor** (post WHISQ-62) — call it as `todo()` to read the current item. `bindField()` reads it internally to find the target item at write time.
+- **`todo` is a hybrid accessor** (post WHISQ-96) — read it as `todo.value.<field>` inside getters (canonical, matches the `() => sig.value` rule for plain signals) or as `todo()` when handing it to `() => T` consumers like `bindField()`. Both return the same live item.
 - **`keyBy` defaults to `t => t.id`** — supply `{ keyBy: (t) => t.uuid }` for items keyed on something else.
 - **Writes produce a new array** — `source.value` is replaced with an immutably-updated copy, so downstream `computed` / `effect` / keyed `each()` re-run correctly.
 
@@ -125,8 +125,8 @@ When none of the helpers fit — deep nested paths that cross arrays, writes tha
 ```ts
 input({
   type: "checkbox",
-  checked: () => todo().done,                      // reactive read via accessor
-  onchange: () => toggle(todo().id),               // writer — reads latest id
+  checked: () => todo.value.done,                  // reactive read via accessor
+  onchange: () => toggle(todo.value.id),           // writer — reads latest id
 }),
 ```
 
@@ -141,7 +141,7 @@ The manual pair is strictly more powerful but also strictly more verbose. Prefer
 | `span(count.value)`                                                           | Reads once at render. Not reactive.                                                   | `span(() => count.value)`                           |
 | `div({ class: active.value ? "on" : "off" })`                                 | Evaluated once.                                                                       | `div({ class: () => active.value ? "on" : "off" })` |
 | `input({ value: email.value, oninput: e => email.value = e.target.value })`   | Works but verbose; risks forgetting both sides.                                       | `input({ ...bind(email) })`                         |
-| `each(..., (todo) => li(() => todo.done ? ...))` (closes over a stale `todo`) | `todo` is the accessor — `.done` on a function is `undefined`. TypeScript flags this. | `li(() => todo().done ? ...)`                       |
+| `each(..., (todo) => li(() => todo.done ? ...))` (reads `.done` directly on the accessor) | `todo` is a hybrid accessor — `.done` on the function itself is `undefined`. TypeScript flags this. | `li(() => todo.value.done ? ...)` (canonical) or `li(() => todo().done ? ...)` (legacy call form). |
 | `items.value.push(x)`                                                         | In-place mutation doesn't notify.                                                     | `items.value = [...items.value, x]`                 |
 | `bind(todo, { as: "checkbox" })` inside keyed `each`                          | `todo` is an accessor, not a signal with `.value`.                                    | `bindField(source, todo, "done", { as: "checkbox" })` (shape 4). |
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,10 @@
     "./forms": {
       "types": "./dist/forms.d.ts",
       "import": "./dist/forms.js"
+    },
+    "./ids": {
+      "types": "./dist/ids.d.ts",
+      "import": "./dist/ids.js"
     }
   },
   "files": [

--- a/packages/core/src/__tests__/bindField.test.ts
+++ b/packages/core/src/__tests__/bindField.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { signal } from "../reactive.js";
 import { input, mount, each, ul } from "../elements.js";
 import { bindField } from "../bindField.js";
+import { WhisqKeyByError } from "../dev-errors.js";
 
 interface Todo {
   id: string;
@@ -298,7 +299,7 @@ describe("bindField() — keyBy", () => {
     expect(rows.value[0].done).toBe(true);
   });
 
-  it("warns and discards the write when no item matches", () => {
+  it("warns and discards the write when no item matches (strict: false)", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const todos = signal<Todo[]>([
       { id: "a", text: "x", done: false, priority: 0 },
@@ -307,6 +308,7 @@ describe("bindField() — keyBy", () => {
     const accessor = () => todos.value[0] ?? { id: "missing" };
     const props = bindField(todos, accessor as () => Todo, "done", {
       as: "checkbox",
+      strict: false, // opt out of the dev-strict default that would throw
     });
     todos.value = []; // item gone
     (props as { onchange: (e: Event) => void }).onchange({
@@ -336,5 +338,121 @@ describe("bindField() — input validation", () => {
     expect(() =>
       bindField(todos, "not a function" as unknown as () => Todo, "done"),
     ).toThrow(TypeError);
+  });
+});
+
+// ── Dev-strict mode (WHISQ-100) ────────────────────────────────────────────
+//
+// Dev mode (NODE_ENV !== "production") throws WhisqKeyByError on a no-match
+// write so a stale accessor or broken keyBy surfaces in the dev loop instead
+// of hiding in the console. Production degrades to warn-and-discard unless
+// the caller opts in via `strict: true`. These tests cover every cell of
+// the env × strict truth table plus the error's field shape.
+
+describe("bindField() — dev-strict no-match writes", () => {
+  function makeStaleWrite(strict?: boolean) {
+    const todos = signal<Todo[]>([
+      { id: "a", text: "x", done: false, priority: 0 },
+    ]);
+    const accessor = () => todos.value[0] ?? { id: "missing" };
+    const options: { as: "checkbox"; strict?: boolean } = { as: "checkbox" };
+    if (strict !== undefined) options.strict = strict;
+    const props = bindField(todos, accessor as () => Todo, "done", options);
+    todos.value = []; // stale accessor now points at an id not in source
+    return {
+      todos,
+      fire: () =>
+        (props as { onchange: (e: Event) => void }).onchange({
+          target: { checked: true } as HTMLInputElement,
+        } as unknown as Event),
+    };
+  }
+
+  it("throws WhisqKeyByError in dev by default (strict omitted)", () => {
+    // Vitest runs with NODE_ENV === "test", which is !== "production",
+    // so dev-strict is the default here.
+    const { fire } = makeStaleWrite();
+    expect(fire).toThrow(WhisqKeyByError);
+  });
+
+  it("error carries sourceKeys, targetKey, and field fields", () => {
+    const { fire } = makeStaleWrite();
+    try {
+      fire();
+      expect.fail("expected WhisqKeyByError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(WhisqKeyByError);
+      const keyErr = err as WhisqKeyByError;
+      expect(keyErr.sourceKeys).toEqual([]); // source was emptied before the write
+      expect(keyErr.targetKey).toBe("missing");
+      expect(keyErr.field).toBe("done");
+      expect(keyErr.name).toBe("WhisqKeyByError");
+      expect(keyErr.message).toContain("no item in source matched");
+    }
+  });
+
+  it("throws when strict: true is explicitly set (overrides env default)", () => {
+    // Simulate production env; explicit strict:true wins.
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const { fire } = makeStaleWrite(true);
+      expect(fire).toThrow(WhisqKeyByError);
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it("warns (does not throw) when strict: false is explicitly set in dev", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { fire, todos } = makeStaleWrite(false);
+      expect(fire).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("no item in source matched"),
+      );
+      expect(todos.value).toEqual([]); // write was discarded
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("warns (does not throw) in production by default", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { fire, todos } = makeStaleWrite();
+      expect(fire).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("no item in source matched"),
+      );
+      expect(todos.value).toEqual([]);
+    } finally {
+      warn.mockRestore();
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it("happy path unaffected — successful matching writes never throw or warn in dev-strict", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const todos = signal<Todo[]>([
+        { id: "a", text: "first", done: false, priority: 0 },
+      ]);
+      const accessor = () => todos.value[0]!;
+      const props = bindField(todos, accessor as () => Todo, "done", {
+        as: "checkbox",
+      });
+      expect(() =>
+        (props as { onchange: (e: Event) => void }).onchange({
+          target: { checked: true } as HTMLInputElement,
+        } as unknown as Event),
+      ).not.toThrow();
+      expect(todos.value[0].done).toBe(true);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/core/src/__tests__/collections.test.ts
+++ b/packages/core/src/__tests__/collections.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { effect } from "../reactive.js";
+import { signal, effect } from "../reactive.js";
 // Imported from the internal module path. Public API is
 // `@whisq/core/collections` (see packages/core/package.json exports).
-import { signalMap, signalSet } from "../collections.js";
+import { signalMap, signalSet, partition } from "../collections.js";
 
 describe("signalMap()", () => {
   it("accepts initial entries", () => {
@@ -261,5 +261,92 @@ describe("signalSet()", () => {
     const res = s.add("a").add("b");
     expect(res).toBe(s);
     expect(s.size).toBe(2);
+  });
+});
+
+// ── partition (WHISQ-101) ───────────────────────────────────────────────────
+
+describe("partition()", () => {
+  type Todo = { id: string; done: boolean };
+
+  it("splits a static source into matching / not-matching tuples", () => {
+    const todos = signal<Todo[]>([
+      { id: "a", done: false },
+      { id: "b", done: true },
+      { id: "c", done: false },
+    ]);
+    const [pending, done] = partition(() => todos.value, (t) => !t.done);
+    expect(pending.value.map((t) => t.id)).toEqual(["a", "c"]);
+    expect(done.value.map((t) => t.id)).toEqual(["b"]);
+  });
+
+  it("re-derives both sides when the source changes", () => {
+    const todos = signal<Todo[]>([{ id: "a", done: false }]);
+    const [pending, done] = partition(() => todos.value, (t) => !t.done);
+
+    expect(pending.value).toHaveLength(1);
+    expect(done.value).toHaveLength(0);
+
+    todos.value = [
+      { id: "a", done: true },
+      { id: "b", done: false },
+    ];
+    expect(pending.value.map((t) => t.id)).toEqual(["b"]);
+    expect(done.value.map((t) => t.id)).toEqual(["a"]);
+  });
+
+  it("returns two empty arrays when the source is empty", () => {
+    const src = signal<Todo[]>([]);
+    const [yes, no] = partition(() => src.value, (t) => t.done);
+    expect(yes.value).toEqual([]);
+    expect(no.value).toEqual([]);
+  });
+
+  it("handles all-match and all-not-match cases", () => {
+    const allDone = signal<Todo[]>([
+      { id: "a", done: true },
+      { id: "b", done: true },
+    ]);
+    const [done, pending] = partition(() => allDone.value, (t) => t.done);
+    expect(done.value).toHaveLength(2);
+    expect(pending.value).toHaveLength(0);
+
+    allDone.value = [
+      { id: "c", done: false },
+      { id: "d", done: false },
+    ];
+    expect(done.value).toHaveLength(0);
+    expect(pending.value).toHaveLength(2);
+  });
+
+  it("each signal participates in effect tracking independently", () => {
+    const todos = signal<Todo[]>([{ id: "a", done: false }]);
+    const [pending, done] = partition(() => todos.value, (t) => !t.done);
+    const pendingRuns: number[] = [];
+    const doneRuns: number[] = [];
+
+    effect(() => {
+      pendingRuns.push(pending.value.length);
+    });
+    effect(() => {
+      doneRuns.push(done.value.length);
+    });
+
+    expect(pendingRuns).toEqual([1]);
+    expect(doneRuns).toEqual([0]);
+
+    todos.value = [
+      { id: "a", done: true },
+      { id: "b", done: false },
+    ];
+    expect(pendingRuns.at(-1)).toBe(1);
+    expect(doneRuns.at(-1)).toBe(1);
+  });
+
+  it("preserves source order in both output arrays", () => {
+    const nums = signal<number[]>([1, 2, 3, 4, 5, 6]);
+    const [even, odd] = partition(() => nums.value, (n) => n % 2 === 0);
+    expect(even.value).toEqual([2, 4, 6]);
+    expect(odd.value).toEqual([1, 3, 5]);
   });
 });

--- a/packages/core/src/__tests__/component-types.test-d.ts
+++ b/packages/core/src/__tests__/component-types.test-d.ts
@@ -1,0 +1,41 @@
+// Type-level assertions for the component() signature.
+// Covers WHISQ-108: `component()` must accept a setup function that
+// returns `WhisqNode` (the actual hyperscript return type), and its call
+// result must satisfy `Child` so components compose inside elements.
+
+import { describe, it, expectTypeOf } from "vitest";
+import { div, span, h1, p } from "../elements.js";
+import { component } from "../component.js";
+// `component` is re-exported via the public index; the re-export path
+// must have the same signature as the internal one.
+import { component as componentPublic } from "../index.js";
+import type { WhisqNode } from "../elements.js";
+
+describe("component() signature accepts hyperscript return types", () => {
+  it("setup returning div() type-checks", () => {
+    const Comp = component(() => div("hello"));
+    // Calling the component gives back a WhisqNode — compatible with being
+    // used as a child to other elements.
+    expectTypeOf(Comp({})).toMatchTypeOf<WhisqNode>();
+  });
+
+  it("setup returning a nested element tree type-checks", () => {
+    const Card = component((props: { title: string }) =>
+      div({ class: "card" }, h1(props.title), p("body")),
+    );
+    expectTypeOf(Card({ title: "hi" })).toMatchTypeOf<WhisqNode>();
+  });
+
+  it("component's return value is a valid child of another element", () => {
+    const Inner = component(() => span("inner"));
+    // If this type-checks, we have the compose story closed: components
+    // nest inside elements the same way elements do.
+    const tree = div(Inner({}));
+    expectTypeOf(tree).toMatchTypeOf<WhisqNode>();
+  });
+
+  it("public re-export has the same shape", () => {
+    const Comp = componentPublic(() => div("public"));
+    expectTypeOf(Comp({})).toMatchTypeOf<WhisqNode>();
+  });
+});

--- a/packages/core/src/__tests__/each.test.ts
+++ b/packages/core/src/__tests__/each.test.ts
@@ -609,3 +609,146 @@ describe("each() with key — accessor callback", () => {
     expect(liAfter!.textContent).toBe("a-v2");
   });
 });
+
+// ── Hybrid accessor shape (WHISQ-96) ────────────────────────────────────────
+//
+// The keyed `each()` callback's `item` / `index` arguments are callable
+// (`item()`, `index()` — backwards-compatible) AND expose signal-like
+// `.value` / `.peek()` reads. The new `.value` shape joins the uniform
+// reactive-access pattern; the call form stays so helpers like `bindField`
+// (which expect `() => T`) keep working.
+
+describe("each() keyed — hybrid accessor shape (callable + .value + .peek)", () => {
+  type Item = { id: number; text: string };
+
+  it("item.value returns the current item (initial render)", () => {
+    const items = signal<Item[]>([{ id: 1, text: "a" }]);
+    let capturedValue: Item | undefined;
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item) => {
+          capturedValue = item.value;
+          return li(() => item.value.text);
+        },
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+
+    expect(capturedValue).toEqual({ id: 1, text: "a" });
+    expect(container.firstElementChild!.querySelector("li")!.textContent).toBe(
+      "a",
+    );
+  });
+
+  it("item.value stays live after reconciliation reuses an entry", () => {
+    const items = signal<Item[]>([{ id: 1, text: "a" }]);
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item) => li(() => item.value.text),
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+    const liBefore = container.firstElementChild!.querySelector("li");
+
+    items.value = [{ id: 1, text: "a-v2" }];
+    const liAfter = container.firstElementChild!.querySelector("li");
+
+    expect(liAfter).toBe(liBefore);
+    expect(liAfter!.textContent).toBe("a-v2");
+  });
+
+  it("item() and item.value return the same value at every read", () => {
+    const items = signal<Item[]>([{ id: 1, text: "a" }]);
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item) => li(() => `${item().text}|${item.value.text}`),
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+    const liEl = container.firstElementChild!.querySelector("li")!;
+    expect(liEl.textContent).toBe("a|a");
+
+    items.value = [{ id: 1, text: "updated" }];
+    expect(liEl.textContent).toBe("updated|updated");
+  });
+
+  it("item.peek() returns the current item", () => {
+    const items = signal<Item[]>([{ id: 1, text: "a" }]);
+    const peeks: string[] = [];
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item) =>
+          li(() => {
+            const tracked = item.value.text;
+            peeks.push(`peek=${item.peek().text}`);
+            return tracked;
+          }),
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+    expect(peeks[0]).toBe("peek=a");
+
+    items.value = [{ id: 1, text: "b" }];
+    expect(peeks[peeks.length - 1]).toBe("peek=b");
+  });
+
+  it("index.value returns the current index; updates on reorder", () => {
+    const items = signal<Item[]>([
+      { id: 1, text: "one" },
+      { id: 2, text: "two" },
+    ]);
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item, index) => li(() => `${index.value}:${item.value.text}`),
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+    const lisBefore = container.firstElementChild!.querySelectorAll("li");
+    expect(lisBefore[0].textContent).toBe("0:one");
+    expect(lisBefore[1].textContent).toBe("1:two");
+
+    items.value = [
+      { id: 2, text: "two" },
+      { id: 1, text: "one" },
+    ];
+    const lisAfter = container.firstElementChild!.querySelectorAll("li");
+    expect(lisAfter[0].textContent).toBe("0:two");
+    expect(lisAfter[1].textContent).toBe("1:one");
+  });
+
+  it("hybrid accessor satisfies the `() => T` shape for bindField-style helpers", () => {
+    // The hybrid accessor must be assignable to `() => T` so helpers like
+    // bindField (which expect that shape) continue to work unchanged.
+    const items = signal<Item[]>([{ id: 1, text: "a" }]);
+    const readText = (accessor: () => Item) => accessor().text;
+    let capturedViaCallShape: string | undefined;
+
+    const node = ul(
+      each(
+        () => items.value,
+        (item) => {
+          capturedViaCallShape = readText(item);
+          return li(item.value.text);
+        },
+        { key: (i) => i.id },
+      ),
+    );
+    dispose = mount(node, container);
+    expect(capturedViaCallShape).toBe("a");
+  });
+});

--- a/packages/core/src/__tests__/elements.test.ts
+++ b/packages/core/src/__tests__/elements.test.ts
@@ -59,6 +59,96 @@ describe("h()", () => {
     expect(container.firstElementChild!.className).toBe("on");
   });
 
+  // ── Array-form class prop (WHISQ-97, option B) ────────────────────────────
+
+  it("accepts a static class array and joins with spaces", () => {
+    const node = h("div", { class: ["btn", "primary"] });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("btn primary");
+  });
+
+  it("filters falsy values from a static class array", () => {
+    const node = h("div", {
+      class: ["btn", false, null, undefined, 0, "", "primary"],
+    });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("btn primary");
+  });
+
+  it("supports the `cond && 'active'` shorthand in class array", () => {
+    const isActive = true;
+    const isDisabled = false;
+    const node = h("div", {
+      class: ["btn", isActive && "active", isDisabled && "disabled"],
+    });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("btn active");
+  });
+
+  it("applies a class array reactively when any source is a function", () => {
+    const variant = signal<"primary" | "secondary">("primary");
+    const loading = signal(false);
+    const node = h("div", {
+      class: [
+        "btn",
+        () => `btn-${variant.value}`,
+        () => loading.value && "btn-loading",
+      ],
+    });
+    dispose = mount(node, container);
+
+    expect(container.firstElementChild!.className).toBe("btn btn-primary");
+
+    variant.value = "secondary";
+    expect(container.firstElementChild!.className).toBe("btn btn-secondary");
+
+    loading.value = true;
+    expect(container.firstElementChild!.className).toBe(
+      "btn btn-secondary btn-loading",
+    );
+  });
+
+  it("filters falsy returns from reactive sources in a class array", () => {
+    const show = signal(false);
+    const node = h("div", {
+      class: ["base", () => (show.value ? "on" : null)],
+    });
+    dispose = mount(node, container);
+
+    expect(container.firstElementChild!.className).toBe("base");
+
+    show.value = true;
+    expect(container.firstElementChild!.className).toBe("base on");
+
+    show.value = false;
+    expect(container.firstElementChild!.className).toBe("base");
+  });
+
+  it("treats an empty class array as an empty className", () => {
+    const node = h("div", { class: [] });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("");
+  });
+
+  it("treats an all-falsy class array as an empty className", () => {
+    const node = h("div", { class: [false, null, undefined, 0, ""] });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("");
+  });
+
+  it("does not create a reactive effect for a purely static class array", () => {
+    // Cover the common case — static array doesn't leak an effect that
+    // would fire on unrelated signal changes. We verify indirectly: the
+    // className matches expectation and mutating an unrelated signal in
+    // the same frame doesn't affect rendering.
+    const unrelated = signal("x");
+    const node = h("div", { class: ["btn", "primary"] });
+    dispose = mount(node, container);
+    expect(container.firstElementChild!.className).toBe("btn primary");
+    unrelated.value = "y"; // must not cause any re-read
+    expect(container.firstElementChild!.className).toBe("btn primary");
+  });
+
   it("applies reactive style prop", () => {
     const color = signal("red");
     const node = h("div", { style: () => `color: ${color.value}` });

--- a/packages/core/src/__tests__/ids.test.ts
+++ b/packages/core/src/__tests__/ids.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+// Internal import path. Public API is `@whisq/core/ids` (see
+// packages/core/package.json exports).
+import { randomId } from "../ids.js";
+
+const V4_UUID_SHAPE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe("randomId() — primary path (crypto.randomUUID)", () => {
+  it("returns a string", () => {
+    expect(typeof randomId()).toBe("string");
+  });
+
+  it("returns a UUID-v4-shaped string", () => {
+    const id = randomId();
+    expect(id).toMatch(V4_UUID_SHAPE);
+  });
+
+  it("returns different values on successive calls", () => {
+    const a = randomId();
+    const b = randomId();
+    expect(a).not.toBe(b);
+  });
+
+  it("uses crypto.randomUUID when available", () => {
+    const spy = vi
+      .spyOn(crypto, "randomUUID")
+      .mockReturnValue("00000000-0000-4000-8000-000000000000");
+    try {
+      const id = randomId();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(id).toBe("00000000-0000-4000-8000-000000000000");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("randomId() — fallback path (crypto.randomUUID unavailable)", () => {
+  function withoutRandomUUID<T>(fn: () => T): T {
+    const original = (crypto as { randomUUID?: () => string }).randomUUID;
+    (crypto as { randomUUID?: () => string }).randomUUID = undefined;
+    try {
+      return fn();
+    } finally {
+      (crypto as { randomUUID?: () => string }).randomUUID = original;
+    }
+  }
+
+  it("still returns a UUID-v4-shaped string", () => {
+    const id = withoutRandomUUID(() => randomId());
+    expect(id).toMatch(V4_UUID_SHAPE);
+  });
+
+  it("still returns different values on successive calls", () => {
+    const [a, b, c] = withoutRandomUUID(() => [
+      randomId(),
+      randomId(),
+      randomId(),
+    ]);
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+
+  it("does not throw when both crypto.randomUUID and global crypto are absent", () => {
+    const originalCrypto = globalThis.crypto;
+    // @ts-expect-error intentional delete — simulate pre-Web-Crypto env
+    delete (globalThis as { crypto?: Crypto }).crypto;
+    try {
+      expect(() => randomId()).not.toThrow();
+      const id = randomId();
+      expect(id).toMatch(V4_UUID_SHAPE);
+    } finally {
+      globalThis.crypto = originalCrypto;
+    }
+  });
+});

--- a/packages/core/src/__tests__/persistence.test.ts
+++ b/packages/core/src/__tests__/persistence.test.ts
@@ -169,3 +169,100 @@ describe("persistedSignal() — reactivity", () => {
     expect(seen).toEqual([0, 1, 2]);
   });
 });
+
+describe("persistedSignal() — onSchemaFailure callback", () => {
+  it("fires with the parse error and the raw string when JSON is malformed", () => {
+    window.localStorage.setItem("bad-json", "{not json}");
+    const onSchemaFailure = vi.fn();
+    const s = persistedSignal("bad-json", { ok: true }, { onSchemaFailure });
+    expect(s.value).toEqual({ ok: true });
+    expect(onSchemaFailure).toHaveBeenCalledTimes(1);
+    const [err, raw] = onSchemaFailure.mock.calls[0]!;
+    expect(err).toBeInstanceOf(SyntaxError);
+    expect(raw).toBe("{not json}");
+  });
+
+  it("fires with the schema error and the raw string when the validator throws", () => {
+    const rawStored = '{"name":"alice","age":"oops"}';
+    window.localStorage.setItem("bad-schema", rawStored);
+    const onSchemaFailure = vi.fn();
+    const s = persistedSignal<{ name: string; age: number }>(
+      "bad-schema",
+      { name: "anon", age: 0 },
+      {
+        schema: (raw) => {
+          const v = raw as { name: string; age: unknown };
+          if (typeof v.age !== "number") throw new TypeError("age");
+          return v as { name: string; age: number };
+        },
+        onSchemaFailure,
+      },
+    );
+    expect(s.value).toEqual({ name: "anon", age: 0 });
+    expect(onSchemaFailure).toHaveBeenCalledTimes(1);
+    const [err, raw] = onSchemaFailure.mock.calls[0]!;
+    expect(err).toBeInstanceOf(TypeError);
+    expect((err as Error).message).toBe("age");
+    expect(raw).toBe(rawStored);
+  });
+
+  it("is NOT invoked on first visit (no stored value)", () => {
+    const onSchemaFailure = vi.fn();
+    const s = persistedSignal("first-visit", "default", { onSchemaFailure });
+    expect(s.value).toBe("default");
+    expect(onSchemaFailure).not.toHaveBeenCalled();
+  });
+
+  it("is NOT invoked on the happy path (well-formed JSON + schema accepts)", () => {
+    window.localStorage.setItem("ok-json", '{"name":"alice","age":30}');
+    const onSchemaFailure = vi.fn();
+    const s = persistedSignal<{ name: string; age: number }>(
+      "ok-json",
+      { name: "anon", age: 0 },
+      {
+        schema: (raw) => raw as { name: string; age: number },
+        onSchemaFailure,
+      },
+    );
+    expect(s.value).toEqual({ name: "alice", age: 30 });
+    expect(onSchemaFailure).not.toHaveBeenCalled();
+  });
+
+  it("is NOT invoked on storage-access errors (getItem throws)", () => {
+    const onSchemaFailure = vi.fn();
+    const originalGet = Storage.prototype.getItem;
+    Storage.prototype.getItem = function throwingGet() {
+      throw new Error("access denied");
+    };
+    try {
+      const s = persistedSignal("storage-denied", "fallback", {
+        onSchemaFailure,
+      });
+      expect(s.value).toBe("fallback");
+      expect(onSchemaFailure).not.toHaveBeenCalled();
+    } finally {
+      Storage.prototype.getItem = originalGet;
+    }
+  });
+
+  it("still falls back to initial when the callback itself throws", () => {
+    window.localStorage.setItem("cb-throws", "{not json}");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onSchemaFailure = vi.fn(() => {
+      throw new Error("logger exploded");
+    });
+    try {
+      const s = persistedSignal("cb-throws", "initial", { onSchemaFailure });
+      expect(s.value).toBe("initial");
+      expect(onSchemaFailure).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'persistedSignal: onSchemaFailure callback for "cb-throws" threw',
+        ),
+        expect.any(Error),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/__tests__/styling-types.test-d.ts
+++ b/packages/core/src/__tests__/styling-types.test-d.ts
@@ -1,0 +1,79 @@
+// Type-level assertions for sheet() style object nesting.
+// Covers WHISQ-108: sheet definitions must accept both plain CSS
+// properties and nested rules under "&" / "@" selectors at the same key
+// level without type errors.
+
+import { describe, it, expectTypeOf } from "vitest";
+import { sheet } from "../styling.js";
+
+describe("sheet() accepts nested selectors", () => {
+  it("flat rules type-check", () => {
+    const s = sheet({
+      card: { color: "red", padding: "1rem" },
+    });
+    expectTypeOf(s.card).toEqualTypeOf<string>();
+  });
+
+  it("pseudo-class nested rules type-check", () => {
+    const s = sheet({
+      link: {
+        color: "var(--color-accent)",
+        textDecoration: "none",
+        "&:hover": { textDecoration: "underline" },
+      },
+    });
+    expectTypeOf(s.link).toEqualTypeOf<string>();
+  });
+
+  it("pseudo-element nested rules type-check", () => {
+    const s = sheet({
+      quote: {
+        fontStyle: "italic",
+        "&::before": { content: '"“"' },
+        "&::after": { content: '"”"' },
+      },
+    });
+    expectTypeOf(s.quote).toEqualTypeOf<string>();
+  });
+
+  it("descendant / child selectors type-check", () => {
+    const s = sheet({
+      nav: {
+        display: "flex",
+        "& a": { color: "blue" },
+        "& > span": { color: "red" },
+      },
+    });
+    expectTypeOf(s.nav).toEqualTypeOf<string>();
+  });
+
+  it("media queries type-check", () => {
+    const s = sheet({
+      row: {
+        display: "flex",
+        gap: "1rem",
+        "@media (max-width: 640px)": {
+          flexDirection: "column",
+          gap: "0.5rem",
+        },
+      },
+    });
+    expectTypeOf(s.row).toEqualTypeOf<string>();
+  });
+
+  it("mixed flat + pseudo + media in one rule type-checks", () => {
+    const s = sheet({
+      btn: {
+        padding: "0.5rem 1rem",
+        color: "white",
+        background: "var(--color-primary)",
+        "&:hover": { background: "var(--color-primary-hover)" },
+        "&:focus-visible": { outline: "2px solid white" },
+        "@media (prefers-reduced-motion: reduce)": {
+          transition: "none",
+        },
+      },
+    });
+    expectTypeOf(s.btn).toEqualTypeOf<string>();
+  });
+});

--- a/packages/core/src/__tests__/styling.test.ts
+++ b/packages/core/src/__tests__/styling.test.ts
@@ -273,3 +273,52 @@ describe("theme()", () => {
     expect(styleTags[0].textContent).not.toContain("--color-primary:red");
   });
 });
+
+// ── SSR safety ──────────────────────────────────────────────────────────────
+
+describe("styling SSR safety", () => {
+  // Simulate a server environment where `document` is undefined (the usual
+  // Node SSR shape). We do it via Object.defineProperty because jsdom exposes
+  // `document` as a non-configurable global in some setups.
+  function withoutDocument<T>(fn: () => T): T {
+    const originalDocument = globalThis.document;
+    // @ts-expect-error intentional delete for SSR simulation
+    delete (globalThis as { document?: Document }).document;
+    try {
+      return fn();
+    } finally {
+      (globalThis as { document?: Document }).document = originalDocument;
+    }
+  }
+
+  it("theme() no-ops when document is undefined (server)", () => {
+    expect(() =>
+      withoutDocument(() => {
+        theme({ color: { primary: "red" }, space: { md: "1rem" } });
+      }),
+    ).not.toThrow();
+  });
+
+  it("sheet() returns the classMap when document is undefined (server)", () => {
+    const result = withoutDocument(() =>
+      sheet({
+        card: { padding: "1rem" },
+        title: { fontSize: "1.5rem" },
+      }),
+    );
+
+    // Class names must be generated — they're referenced by server-rendered
+    // markup that the client will then hydrate against.
+    expect(typeof result.card).toBe("string");
+    expect(typeof result.title).toBe("string");
+    expect(result.card).not.toBe(result.title);
+  });
+
+  it("sheet() does not throw when document is undefined", () => {
+    expect(() =>
+      withoutDocument(() => {
+        sheet({ btn: { color: "red", "&:hover": { color: "blue" } } });
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/core/src/bindField.ts
+++ b/packages/core/src/bindField.ts
@@ -8,9 +8,20 @@
 
 import { type Signal, isSignal } from "./reactive.js";
 import type { TextBind, NumberBind, CheckboxBind, RadioBind } from "./bind.js";
+import { WhisqKeyByError } from "./dev-errors.js";
 
 interface Common<T> {
   keyBy?: (item: T) => unknown;
+  /**
+   * Error on no-match writes instead of warning. Defaults to `true` in dev
+   * (`process.env.NODE_ENV !== "production"`) and `false` in production, so
+   * a stale accessor or broken `keyBy` surfaces as a `WhisqKeyByError` in
+   * the dev loop but degrades to `console.warn` + discard in a shipped
+   * build. Pass `strict: false` in tests that deliberately exercise the
+   * no-match path, or `strict: true` in production if you want throws in
+   * both environments.
+   */
+  strict?: boolean;
 }
 
 export type BindFieldOptions<T> =
@@ -78,6 +89,8 @@ export function bindField<T, K extends keyof T>(
     (options as Common<T>)?.keyBy ??
     ((t: T) => (t as { id?: unknown }).id);
 
+  const strictOpt = (options as Common<T>)?.strict;
+
   const write = (next: T[K]): void => {
     const target = keyBy(item());
     let matched = false;
@@ -89,6 +102,15 @@ export function bindField<T, K extends keyof T>(
       return t;
     });
     if (!matched) {
+      const strict =
+        strictOpt ?? process.env.NODE_ENV !== "production";
+      if (strict) {
+        throw new WhisqKeyByError({
+          sourceKeys: source.value.map((t) => keyBy(t)),
+          targetKey: target,
+          field: String(key),
+        });
+      }
       // eslint-disable-next-line no-console
       console.warn(
         `bindField: no item in source matched ${String(target)}; write to "${String(key)}" discarded.`,

--- a/packages/core/src/collections.ts
+++ b/packages/core/src/collections.ts
@@ -7,7 +7,12 @@
 // as the rest of the reactive core.
 // ============================================================================
 
-import { signal, type Signal } from "./reactive.js";
+import {
+  signal,
+  computed,
+  type Signal,
+  type ReadonlySignal,
+} from "./reactive.js";
 
 const MISSING: unique symbol = Symbol("whisq.collections.missing");
 type Missing = typeof MISSING;
@@ -240,4 +245,36 @@ export function signalSet<T>(initial?: Iterable<T>): SignalSet<T> {
   };
 
   return set;
+}
+
+// ── partition ──────────────────────────────────────────────────────────────
+
+/**
+ * Split a signal-held array into two derived signals — one with items that
+ * match the predicate, one with items that don't. Both sides re-compute
+ * when the source changes; source order is preserved on both sides.
+ *
+ * ```ts
+ * const todos = signal<Todo[]>([...]);
+ * const [pending, done] = partition(() => todos.value, (t) => !t.done);
+ *
+ * p(() => `${pending.value.length} left`);
+ * p(() => `${done.value.length} done`);
+ * button({ onclick: () => todos.value = pending.value }, "Clear completed");
+ * ```
+ *
+ * Each side is an independent `ReadonlySignal<T[]>` — subscribing to one
+ * does not subscribe to the other, and each re-runs its own effects only
+ * when its portion of the result would change in content. (That's
+ * reference-equality on the produced arrays, matching `computed()`
+ * semantics — structural equality is the caller's job if they need it.)
+ */
+export function partition<T>(
+  source: () => T[],
+  predicate: (item: T) => boolean,
+): [ReadonlySignal<T[]>, ReadonlySignal<T[]>] {
+  return [
+    computed(() => source().filter(predicate)),
+    computed(() => source().filter((item) => !predicate(item))),
+  ];
 }

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -5,7 +5,7 @@
 // ============================================================================
 
 import { signal, effect } from "./reactive.js";
-import type { WhisqTemplate } from "./template.js";
+import type { WhisqNode } from "./elements.js";
 import { WhisqStructureError, describeValue } from "./dev-errors.js";
 
 type CleanupFn = () => void;
@@ -41,15 +41,16 @@ interface ComponentContext {
 }
 
 export interface ComponentDef<P = {}> {
-  (props: P): WhisqTemplate;
+  (props: P): WhisqNode;
   __whisq_component: true;
 }
 
 // ── Component ───────────────────────────────────────────────────────────────
 
 /**
- * Define a component. Components are setup functions that return a template.
- * Props are a plain typed object. Lifecycle via onMount/onCleanup.
+ * Define a component. Components are setup functions that return an element
+ * (a `WhisqNode` — the value you get from calling `div(...)`, `span(...)`,
+ * etc.). Props are a plain typed object. Lifecycle via onMount/onCleanup.
  *
  * ```ts
  * const Counter = component((props: { initial?: number }) => {
@@ -58,17 +59,15 @@ export interface ComponentDef<P = {}> {
  *   onMount(() => console.log("mounted!"));
  *   onCleanup(() => console.log("cleaned up!"));
  *
- *   return html`
- *     <div>
- *       <span>${() => count.value}</span>
- *       <button @click="${() => count.value++}">+</button>
- *     </div>
- *   `;
+ *   return div(
+ *     span(() => count.value),
+ *     button({ onclick: () => count.value++ }, "+"),
+ *   );
  * });
  * ```
  */
 export function component<P extends Record<string, any> = {}>(
-  setup: (props: P) => WhisqTemplate,
+  setup: (props: P) => WhisqNode,
 ): ComponentDef<P> {
   const def = ((props: P) => {
     const parentCtx = contextStack[contextStack.length - 1] ?? null;
@@ -81,24 +80,24 @@ export function component<P extends Record<string, any> = {}>(
     };
 
     contextStack.push(ctx);
-    let template: WhisqTemplate;
+    let node: WhisqNode;
     try {
-      template = setup(props);
+      node = setup(props);
     } finally {
       contextStack.pop();
     }
 
     if (process.env.NODE_ENV !== "production") {
       if (
-        template == null ||
-        typeof template !== "object" ||
-        !("el" in template) ||
-        !("dispose" in template)
+        node == null ||
+        typeof node !== "object" ||
+        !("el" in node) ||
+        !("dispose" in node)
       ) {
         throw new WhisqStructureError({
           element: "component",
           expected: "setup to return a WhisqNode (an element call like `div(...)`)",
-          received: describeValue(template),
+          received: describeValue(node),
           hint: "Return the root element from your setup function: `return div(...)`. Bare strings, numbers, arrays, and null aren't valid component roots — wrap them in an element.",
         });
       }
@@ -110,8 +109,8 @@ export function component<P extends Record<string, any> = {}>(
     });
 
     // Wrap dispose to run cleanups
-    const originalDispose = template.dispose;
-    template.dispose = () => {
+    const originalDispose = node.dispose;
+    node.dispose = () => {
       ctx.disposed = true;
       for (const fn of ctx.cleanups) fn();
       ctx.parent = null;
@@ -119,7 +118,7 @@ export function component<P extends Record<string, any> = {}>(
       originalDispose();
     };
 
-    return template;
+    return node;
   }) as ComponentDef<P>;
 
   def.__whisq_component = true;

--- a/packages/core/src/dev-errors.ts
+++ b/packages/core/src/dev-errors.ts
@@ -48,6 +48,41 @@ export class WhisqStructureError extends Error {
   }
 }
 
+export interface WhisqKeyByErrorFields {
+  /** All keys present in the source array at write time, in source order. */
+  sourceKeys: unknown[];
+  /** The key the write was trying to match against. */
+  targetKey: unknown;
+  /** The field name being written (from bindField's `key` argument). */
+  field: string;
+}
+
+/**
+ * Thrown by `bindField()` in dev mode (or with `strict: true`) when a write
+ * can't find an item in the source array whose `keyBy(...)` matches the
+ * current accessor's key. The typical cause is a stale accessor (the item
+ * was removed from the source after the accessor was created) or a broken
+ * `keyBy` function (returns a different key for read vs write).
+ *
+ * Production builds without `strict: true` log a warning and discard the
+ * write instead of throwing.
+ */
+export class WhisqKeyByError extends Error {
+  readonly sourceKeys: unknown[];
+  readonly targetKey: unknown;
+  readonly field: string;
+
+  constructor(fields: WhisqKeyByErrorFields) {
+    super(
+      `bindField: no item in source matched ${String(fields.targetKey)}; write to "${fields.field}" discarded. Source keys at write time: [${fields.sourceKeys.map(String).join(", ")}].`,
+    );
+    this.name = "WhisqKeyByError";
+    this.sourceKeys = fields.sourceKeys;
+    this.targetKey = fields.targetKey;
+    this.field = fields.field;
+  }
+}
+
 /**
  * Short human description of any value — used for the `received` field of a
  * structure error. Deliberately terse so the composed message stays short.

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -74,9 +74,26 @@ type ReactiveProp<T> = T | (() => T);
 type StyleValue = string | number | null | undefined;
 export type StyleObject = Record<string, StyleValue | (() => StyleValue)>;
 
+/**
+ * A single source inside a `class: [...]` array. Strings become class names;
+ * falsy values (`false | null | undefined | 0 | ""`) are filtered out,
+ * enabling the `cond && "active"` shorthand; functions are reactive — each
+ * function is called during the render effect, so reads inside it track.
+ */
+export type ClassArraySource =
+  | string
+  | false
+  | null
+  | undefined
+  | 0
+  | ""
+  | (() => string | false | null | undefined);
+
 interface BaseProps {
   ref?: Ref;
-  class?: ReactiveProp<string | undefined>;
+  class?:
+    | ReactiveProp<string | undefined>
+    | readonly ClassArraySource[];
   id?: ReactiveProp<string | undefined>;
   style?: ReactiveProp<string | undefined> | StyleObject;
   hidden?: ReactiveProp<boolean>;
@@ -224,6 +241,22 @@ export function h(
       if (key === "style" && isPlainStyleObject(value)) {
         // Style object — per-property reactive subscriptions
         applyStyleObject(el as HTMLElement, value, disposers);
+        continue;
+      }
+      if (key === "class" && Array.isArray(value)) {
+        // Array form (WHISQ-97): class: ["btn", () => ..., cond && "x"].
+        // Reactive if any source is a function; static otherwise. Falsy
+        // sources (false / null / undefined / 0 / "") are filtered out.
+        const sources = value as readonly ClassArraySource[];
+        const hasReactive = sources.some((s) => typeof s === "function");
+        if (hasReactive) {
+          const dispose = effect(() => {
+            applyProp(el, "class", joinClassArray(sources));
+          });
+          disposers.push(dispose);
+        } else {
+          applyProp(el, "class", joinClassArray(sources));
+        }
         continue;
       }
       if (key.startsWith("on") && typeof value === "function") {
@@ -1004,6 +1037,20 @@ function isPlainStyleObject(value: unknown): value is StyleObject {
   }
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
+}
+
+function joinClassArray(sources: readonly ClassArraySource[]): string {
+  const parts: string[] = [];
+  for (const src of sources) {
+    if (!src) continue; // filters false / null / undefined / 0 / ""
+    if (typeof src === "string") {
+      parts.push(src);
+    } else if (typeof src === "function") {
+      const result = src();
+      if (result) parts.push(result);
+    }
+  }
+  return parts.join(" ");
 }
 
 function camelToKebab(str: string): string {

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -75,6 +75,34 @@ type StyleValue = string | number | null | undefined;
 export type StyleObject = Record<string, StyleValue | (() => StyleValue)>;
 
 /**
+ * The accessor passed to a keyed `each()`'s render callback. It is both
+ * **callable** (`todo()` returns the current item — backwards-compatible
+ * with pre-alpha.8 code) **and** **signal-shaped** (`todo.value`,
+ * `todo.peek()`) — new code should prefer `todo.value.<field>` for the
+ * uniform reactive-access rule.
+ *
+ * ```ts
+ * // new canonical shape — joins the `() => sig.value` pattern
+ * each(() => todos.value, (todo) =>
+ *   li(() => todo.value.text),
+ *   { key: (t) => t.id },
+ * )
+ *
+ * // still works (call form) — bindField and other `() => T` consumers
+ * // continue to accept the accessor without modification
+ * each(() => todos.value, (todo) =>
+ *   input({ ...bindField(todos, todo, "done", { as: "checkbox" }) }),
+ *   { key: (t) => t.id },
+ * )
+ * ```
+ */
+export interface ItemAccessor<T> {
+  (): T;
+  readonly value: T;
+  peek(): T;
+}
+
+/**
  * A single source inside a `class: [...]` array. Strings become class names;
  * falsy values (`false | null | undefined | 0 | ""`) are filtered out,
  * enabling the `cond && "active"` shorthand; functions are reactive — each
@@ -709,14 +737,20 @@ export function each<T>(
 ): () => Child[];
 export function each<T>(
   items: () => T[],
-  render: (item: () => T, index: () => number) => WhisqNode,
+  render: (
+    item: ItemAccessor<T>,
+    index: ItemAccessor<number>,
+  ) => WhisqNode,
   options: { key: (item: T) => unknown },
 ): WhisqNode;
 export function each<T>(
   items: () => T[],
   render:
     | ((item: T, index: number) => WhisqNode)
-    | ((item: () => T, index: () => number) => WhisqNode),
+    | ((
+        item: ItemAccessor<T>,
+        index: ItemAccessor<number>,
+      ) => WhisqNode),
   options?: { key: (item: T) => unknown },
 ): (() => Child[]) | WhisqNode {
   if (process.env.NODE_ENV !== "production") {
@@ -766,8 +800,8 @@ export function each<T>(
   // array is replaced with new items at the same key (WHISQ-62).
   const keyFn = options.key;
   const renderAccessor = render as (
-    item: () => T,
-    index: () => number,
+    item: ItemAccessor<T>,
+    index: ItemAccessor<number>,
   ) => WhisqNode;
   const marker = document.createComment("whisq-each");
   const disposers: (() => void)[] = [];

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -1,0 +1,52 @@
+// ============================================================================
+// Whisq Core — IDs
+//
+// randomId() — UUID-v4-shaped string. Uses `crypto.randomUUID()` when
+// available (all modern browsers, Node 19+). Falls back to a Math.random
+// synthesis for older targets (old Safari, old Node) where the native API
+// isn't exposed. The fallback is NOT cryptographically strong — suitable
+// for client-side row ids / keys, not for security tokens.
+//
+// Import path: `@whisq/core/ids` — kept off the top-level bundle so apps
+// that don't use it pay no size cost.
+// ============================================================================
+
+/**
+ * Generate a UUID-v4-shaped random identifier.
+ *
+ * ```ts
+ * import { randomId } from "@whisq/core/ids";
+ *
+ * const todo = { id: randomId(), text, done: false };
+ * ```
+ *
+ * Prefers `crypto.randomUUID()` when the platform provides it (all modern
+ * browsers; Node 19+; Deno; Bun). Otherwise falls back to a `Math.random`
+ * synthesis — same v4 shape (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` where
+ * `y ∈ {8, 9, a, b}`), but with weaker entropy. Good enough for UI row
+ * ids and keyed-`each` keys; not for tokens, secrets, or deduplication
+ * across independent clients.
+ */
+export function randomId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return fallbackUuid();
+}
+
+function fallbackUuid(): string {
+  // Compose 32 hex digits, then splice in the v4 version (4) and variant
+  // (8/9/a/b) bits at positions 12 and 16. Output shape matches RFC 4122 v4.
+  const hex = (digits: number): string => {
+    let out = "";
+    for (let i = 0; i < digits; i++) {
+      out += Math.floor(Math.random() * 16).toString(16);
+    }
+    return out;
+  };
+  const variant = ((Math.random() * 4) | 0) + 8; // 8..11 → 8,9,a,b
+  return `${hex(8)}-${hex(4)}-4${hex(3)}-${variant.toString(16)}${hex(3)}-${hex(12)}`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,8 +118,11 @@ export { sheet, styles, cx, rcx, sx, theme } from "./styling.js";
 export type { StyleObject } from "./elements.js";
 
 // Dev-mode diagnostics
-export { WhisqStructureError } from "./dev-errors.js";
-export type { WhisqStructureErrorFields } from "./dev-errors.js";
+export { WhisqStructureError, WhisqKeyByError } from "./dev-errors.js";
+export type {
+  WhisqStructureErrorFields,
+  WhisqKeyByErrorFields,
+} from "./dev-errors.js";
 
 // Forms
 export { bind } from "./bind.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,7 @@ export type {
   EventHandler,
   WhisqEvent,
   ClassArraySource,
+  ItemAccessor,
 } from "./elements.js";
 
 // Component model

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,7 +83,12 @@ export {
   hr,
   iframe,
 } from "./elements.js";
-export type { WhisqNode, EventHandler, WhisqEvent } from "./elements.js";
+export type {
+  WhisqNode,
+  EventHandler,
+  WhisqEvent,
+  ClassArraySource,
+} from "./elements.js";
 
 // Component model
 export {

--- a/packages/core/src/persistence.ts
+++ b/packages/core/src/persistence.ts
@@ -24,6 +24,24 @@ export interface PersistedSignalOptions<T> {
    * and fall back to `initial`. Useful when the stored shape may have changed.
    */
   schema?: (raw: unknown) => T;
+  /**
+   * Called synchronously **before** falling back to `initial` when the stored
+   * payload can't be loaded. Fires on:
+   *
+   * - `deserialize(raw)` throwing (malformed stored JSON), or
+   * - `schema(parsed)` throwing (stored value rejected by the validator).
+   *
+   * Receives the thrown error and the exact `raw` string read from storage.
+   * Use for diagnostics (Sentry, analytics, migration prompts) — the fallback
+   * to `initial` still happens regardless of what the callback does.
+   *
+   * NOT invoked on first visit (no stored value — `raw` would be `null`, not
+   * a failure) or on storage-access errors (private mode, disabled storage
+   * — those are environment faults, not schema faults). If the callback
+   * itself throws, the exception is caught and logged via `console.warn` so
+   * a broken diagnostic pipeline can't prevent signal construction.
+   */
+  onSchemaFailure?: (err: unknown, raw: string) => void;
 }
 
 const getStorage = (which: "local" | "session"): Storage | null => {
@@ -68,17 +86,34 @@ export function persistedSignal<T>(
 
   let starting: T = initial;
   if (storage) {
+    let raw: string | null = null;
     try {
-      const raw = storage.getItem(key);
-      if (raw !== null) {
+      raw = storage.getItem(key);
+    } catch {
+      // Storage-access error (cross-origin iframe, privacy mode, etc.) —
+      // leave raw as null. This is an environment fault, not a schema
+      // fault, so `onSchemaFailure` does not fire.
+    }
+    if (raw !== null) {
+      try {
         const parsed = deserialize(raw) as unknown;
         starting = options?.schema
           ? options.schema(parsed)
           : (parsed as T);
+      } catch (err) {
+        starting = initial;
+        if (options?.onSchemaFailure) {
+          try {
+            options.onSchemaFailure(err, raw);
+          } catch (callbackError) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `persistedSignal: onSchemaFailure callback for "${key}" threw.`,
+              callbackError,
+            );
+          }
+        }
       }
-    } catch {
-      // Parse error, schema rejection, storage-access-error — fall through.
-      starting = initial;
     }
   }
 

--- a/packages/core/src/reconcile.ts
+++ b/packages/core/src/reconcile.ts
@@ -11,7 +11,7 @@
 // ============================================================================
 
 import { signal, type Signal } from "./reactive.js";
-import type { WhisqNode } from "./elements.js";
+import type { WhisqNode, ItemAccessor } from "./elements.js";
 
 export interface KeyedEntry<T = unknown> {
   key: unknown;
@@ -20,6 +20,22 @@ export interface KeyedEntry<T = unknown> {
   itemSig: Signal<T>;
   /** Updated on reorder so `() => indexSig.value` getters see the new position. */
   indexSig: Signal<number>;
+}
+
+/**
+ * Wrap a per-entry signal as the hybrid accessor that the render callback
+ * receives. Callable (`acc()` → current value, tracks) AND signal-shaped
+ * (`acc.value` → tracks; `acc.peek()` → untracked). Both call paths read
+ * the same underlying `Signal<T>` that the reconciler updates on reuse.
+ */
+function makeItemAccessor<T>(sig: Signal<T>): ItemAccessor<T> {
+  const fn = (() => sig.value) as ItemAccessor<T>;
+  Object.defineProperty(fn, "value", {
+    get: () => sig.value,
+    enumerable: true,
+  });
+  (fn as { peek: () => T }).peek = () => sig.peek();
+  return fn;
 }
 
 /**
@@ -40,7 +56,10 @@ export function reconcileKeyed<T>(
   oldEntries: KeyedEntry<T>[],
   newItems: T[],
   keyFn: (item: T) => unknown,
-  renderFn: (item: () => T, index: () => number) => WhisqNode,
+  renderFn: (
+    item: ItemAccessor<T>,
+    index: ItemAccessor<number>,
+  ) => WhisqNode,
 ): KeyedEntry<T>[] {
   const newLen = newItems.length;
   const oldLen = oldEntries.length;
@@ -53,8 +72,8 @@ export function reconcileKeyed<T>(
       const itemSig = signal(newItems[i]);
       const indexSig = signal(i);
       const node = renderFn(
-        () => itemSig.value,
-        () => indexSig.value,
+        makeItemAccessor(itemSig),
+        makeItemAccessor(indexSig),
       );
       fragment.appendChild(node.el);
       entries[i] = { key: keyFn(newItems[i]), node, itemSig, indexSig };
@@ -135,8 +154,8 @@ export function reconcileKeyed<T>(
       const itemSig = signal(newItems[i]);
       const indexSig = signal(i);
       const node = renderFn(
-        () => itemSig.value,
-        () => indexSig.value,
+        makeItemAccessor(itemSig),
+        makeItemAccessor(indexSig),
       );
       newEntries[i] = { key: newKeys[i], node, itemSig, indexSig };
     }

--- a/packages/core/src/styling.ts
+++ b/packages/core/src/styling.ts
@@ -338,6 +338,20 @@ type ThemeTokens = Record<
  *   }
  * })
  * ```
+ *
+ * ### Call-site conventions
+ *
+ * - **Call once, at module scope** of your `styles.ts` file. The tokens
+ *   become CSS custom properties on `:root` and are available everywhere.
+ * - **Duplicate calls = last-call-wins.** A second `theme()` call replaces
+ *   the first `<style id="whisq-style-whisq-theme">` block entirely; the
+ *   new tokens take effect immediately. This is intentional — it enables
+ *   theme-switching (e.g., `theme(lightTokens)` → `theme(darkTokens)` in a
+ *   toggle handler) without leaking old tokens.
+ * - **SSR-safe.** On the server (`typeof document === "undefined"`), the
+ *   call is a no-op. The CSS variables won't appear in server-rendered
+ *   HTML; attach theme tokens in a `<style>` block in your SSR template
+ *   until a dedicated server renderer ships.
  */
 export function theme(tokens: ThemeTokens): void {
   let cssText = ":root{";
@@ -389,6 +403,12 @@ function splitRules(rules: Record<string, any>): {
 }
 
 function injectCSS(id: string, cssText: string): void {
+  // SSR-safe: on the server there is no `document` to inject into. We still
+  // want `sheet()` to return its in-memory classMap (so server-rendered
+  // markup can reference the correct class names that the client will then
+  // hydrate against), but the actual DOM injection is skipped.
+  if (typeof document === "undefined") return;
+
   // Remove existing style with same id
   const existing = document.getElementById(`whisq-style-${id}`);
   if (existing) existing.remove();

--- a/packages/core/src/styling.ts
+++ b/packages/core/src/styling.ts
@@ -13,13 +13,20 @@
 // ── sheet() — Scoped CSS-in-JS ──────────────────────────────────────────────
 
 type StyleValue = string | number;
-type StyleRule = Record<string, StyleValue>;
-type NestedRule = StyleRule & {
-  [key: `&${string}`]: StyleRule; // &:hover, &:focus, &::before, &.active
-  [key: `@${string}`]: StyleRule; // @media queries
-};
 
-type SheetDef = Record<string, NestedRule | StyleRule>;
+// A rule is a bag of CSS properties that may also contain nested rules.
+// The runtime applies the prefix convention — keys starting with "&"
+// (pseudo-classes / pseudo-elements / combinators) or "@" (media queries,
+// @supports, …) are treated as nested scopes; everything else is a direct
+// CSS property. The type is recursive so arbitrary-depth nesting (e.g.
+// `"& a": { "&:hover": { ... } }`) type-checks — TypeScript index
+// signatures can't discriminate on template-literal key shape, so runtime
+// validation is the source of truth for which keys are nested vs base.
+interface StyleRule {
+  [key: string]: StyleValue | StyleRule;
+}
+
+type SheetDef = Record<string, StyleRule>;
 type SheetResult<T extends SheetDef> = {
   [K in keyof T]: string; // class name per key
 } & {

--- a/packages/create-whisq/CHANGELOG.md
+++ b/packages/create-whisq/CHANGELOG.md
@@ -1,5 +1,19 @@
 # create-whisq
 
+## 0.1.0-alpha.8
+
+### Minor Changes
+
+- e3134ac: `full-app` template now scaffolds the canonical multi-file shape that the project-structure docs describe:
+  - **`src/components/`** — `CounterRow.ts` demonstrates the pattern for reusable UI pulled out of a page.
+  - **`src/lib/`** — `format.ts` demonstrates a pure utility module (no `@whisq/*` imports), including `formatCount()` and `clamp()` used by the scaffolded `CounterRow`.
+  - **`src/App.ts`** — now wraps `RouterView` in `errorBoundary`, so a thrown error in any page degrades to a retry UI instead of tearing down the whole app. Demonstrates the canonical error-boundary shape `App.ts` should own.
+  - **`src/pages/Home.ts`** — rewritten to consume `CounterRow` + `clamp`, connecting all four directories (`pages/` → `components/` → `lib/`) in one working example.
+
+  Closes the framework-side half of WHISQ-102. A whisq.dev companion page (`/examples/canonical-app-structure/`) is tracked for a follow-up PR.
+
+  Existing `full-app` behavior (router, stores/, styles.ts, pages/About.ts) is unchanged.
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/create-whisq/CHANGELOG.md
+++ b/packages/create-whisq/CHANGELOG.md
@@ -1,5 +1,119 @@
 # create-whisq
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- 35c30c1: Document the three reactive **access shapes** — signal `.value`, keyed-`each` item accessor `()`, `resource()` field `()` — honestly, without papering over the fact that the uniform-`() => value` claim describes the _wrapper_ but not what goes inside it. New canonical framework doc at [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+
+  Each scaffolded project's `CLAUDE.md` now carries a three-row table and a link to the canonical doc so AI coding assistants don't have to re-derive the rule from scratch on every prompt.
+
+  Collateral updates:
+  - `packages/core/docs/reactive-shapes.md` now cross-links to `access-shapes.md`, drops the "uniform framing undersells" opener (access-shapes.md owns that framing now), and updates shape #4 from "manual event pair" to `bindField()` (shipped in WHISQ-78) with the manual pair demoted to escape-hatch status.
+  - Repo README bullet tightened from "uniform `() => value` reactive pattern" to "one reactive wrapper" with a link to the three read shapes.
+
+  Closes #79. `@whisq/core` runtime unchanged — pure docs/positioning work.
+
+- b278f60: Document **accessors across component boundaries** — the silent-staleness bug that alpha.6 feedback called the single most uncertain moment in building a todo app.
+
+  [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md) gains a full "Accessors across component boundaries" section with:
+  - A worked parent + child example where the child takes `{ todo: () => Todo }` and reads `props.todo()` inside getters.
+  - A counter-example showing the exact snapshot-at-setup pattern that silently breaks (row renders, never updates, stale `.id` after reorder).
+  - A variant table mapping parent source type (`Signal<T>`, keyed-`each` accessor, `resource()` field) to prop shapes and child read patterns.
+  - A mistakes table naming the four most common footguns (calling the accessor at the parent, snapshotting inside child setup, destructuring props, passing `.value[0]`).
+
+  All four scaffolded `CLAUDE.md` files gain the short version inline — parent + child skeleton + the "don't snapshot" rule — with a link to the canonical doc for depth.
+
+  Closes #80. Runtime-warning AC deferred to a P3 follow-up — static analysis (eslint / tsc) is a better fit than runtime instrumentation once real usage demands detection.
+
+- 757049d: Add `bindField(source, item, key, opts?)` — two-way binding for a field on an item inside a signal-held array. Closes the ergonomic gap `bind()` didn't reach: the most common UI shape in real applications (todos, carts, forms-with-rows, CRUD grids).
+
+  ```ts
+  each(
+    () => todos.value,
+    (todo) =>
+      input({
+        type: "checkbox",
+        ...bindField(todos, todo, "done", { as: "checkbox" }),
+      }),
+    { key: (t) => t.id },
+  );
+  ```
+
+  Mirrors `bind()`'s discriminator shapes (text / number / checkbox / radio). `keyBy` identifies which item to rewrite — defaults to `t => t.id`; override for items keyed on something else. Writes produce an immutable array update so downstream `computed` / `effect` re-run correctly.
+
+  All four scaffolded templates' `CLAUDE.md` reactive-shapes tables now lead with `bindField()` for this case instead of the manual event pair. The decision flow also updates to _"single signal you own → `bind()`; field inside an item inside a signal-held array → `bindField()`."_
+
+  `@whisq/core` size budget raised from 5 KB to 5.5 KB gzipped (current: 5.08 KB). The README updates "Under 5 KB gzipped" → "~5 KB gzipped" to match. `bindField` is exported from the top-level `@whisq/core` so LLMs and autocompletion discover it alongside `bind()`.
+
+  Closes #78.
+
+- 34a2c7a: Add `bindPath(source, path, opts?)` — two-way binding for a field at an arbitrary **object path** in a signal-held record. Use when `bind()` doesn't apply because the field lives two or more levels deep (e.g. `user.profile.email`, `settings.billing.plan`). Follow-up to WHISQ-78 (`bindField`) for the nested-object case the feedback docs flagged as friction against the flat-binding primitives.
+
+  Exported from a new sub-path, `@whisq/core/forms`, so apps that only need `bind()` + `bindField()` (the 80% case) pay no bundle cost. Top-level `@whisq/core` stays at 5.25 KB gzipped.
+
+  ```ts
+  import { bindPath } from "@whisq/core/forms";
+
+  form(
+    input({ ...bindPath(user, ["profile", "name"]) }),
+    input({ type: "email", ...bindPath(user, ["profile", "email"]) }),
+    input({
+      type: "number",
+      ...bindPath(user, ["profile", "age"], { as: "number" }),
+    }),
+    input({
+      type: "checkbox",
+      ...bindPath(user, ["prefs", "dark"], { as: "checkbox" }),
+    }),
+  );
+  ```
+
+  ### Behaviors worth leading with
+  - **Structural sharing on writes.** Writes produce a new root and new objects at every level on the path; sibling branches keep their reference identity so downstream `computed` / `effect` re-runs stay narrow.
+  - **Missing-intermediate creation.** Reading through a missing intermediate returns `undefined`; writing creates the object structure as needed.
+  - **Object keys only.** Array traversal is not supported in the path — use `bindField()` at the array level and compose. This keeps `bindPath` predictable and its implementation small.
+  - **Typed overloads** for depths 1–4; deeper paths work via the loose signature (same runtime, just less TS inference).
+
+  Mirrors `bind()` and `bindField()`'s discriminator shapes — text / number / checkbox / radio.
+
+  Scaffolded `CLAUDE.md` files gain a "Binding into nested records (opt-in, sub-path import)" block under Forms so AI-generated code for new projects discovers the pattern without reinventing it.
+
+  Closes #86.
+
+- 3a31d18: Clarify `match()` as a **predicate chain, not pattern matching**.
+
+  Audit finding: `match()` has always had exactly one shape — variadic tuple branches `[predicate, render]` with an optional trailing bare render fn as fallback. The GPT-side alpha.6 feedback flagged "object vs tuple form" confusion, but no object form exists in the code; GPT was pattern-matching against Rust/Scala/Vue conventions where `match(value, { case1, case2 })` is common.
+
+  Changes:
+  - **JSDoc** now leads with _"Predicate-chain conditional renderer — not pattern matching"_ and calls out the canonical shape, first-true-wins ordering, and fallback-position rules explicitly.
+  - **Dev-mode validation** (stripped in production builds) throws a `WhisqStructureError` when `match()` receives a plain object (the exact GPT-style confusion), a malformed tuple, or a fallback that isn't in the last position. Production bundle unchanged at 5.25 KB gzipped.
+  - **Scaffolded templates** — all four `CLAUDE.md` files now include `match` in the canonical imports line and expand the "Conditional Rendering" section to document `when()` vs `match()` with a ready example. AI-generated code for new projects will reach for `match` instead of nesting `when()`.
+
+  Closes #83.
+
+- c84e495: Add `persistedSignal(key, initial, opts?)` — a `Signal<T>` backed by `localStorage` / `sessionStorage`, exported from the new sub-path `@whisq/core/persistence` so apps that don't need it pay zero bundle cost.
+
+  ```ts
+  import { persistedSignal } from "@whisq/core/persistence";
+
+  export const todos = persistedSignal<Todo[]>("todos", []);
+  ```
+
+  Closes the "every Whisq app reinvents the guarded-localStorage-read-with-effect-writer pattern" problem identified by the alpha.6 feedback. Blessed shape, one import, no hand-rolling.
+
+  ### Behaviors worth leading with
+  - **SSR-safe.** On the server (`typeof window === "undefined"`) returns a plain signal initialized to `initial` with no storage subscription.
+  - **Schema-validated.** If the stored JSON is malformed, or an optional `schema(raw)` validator throws, the signal falls back to `initial` rather than crashing at mount.
+  - **Quota-safe.** If a write throws (`QuotaExceededError`, private mode), logs a warning and keeps the in-memory value — the app keeps working.
+  - **Module-scope intent.** Call `persistedSignal` at module scope in your `stores/` file, not inside components — the write effect lives for the module lifetime by design.
+
+  Options: `storage: "local" | "session"`, `serialize` / `deserialize` (default JSON), `schema` (validation on load).
+
+  Scaffolded templates' `CLAUDE.md` files gain a "Persisted stores (opt-in, sub-path import)" block under Shared State so AI-generated code for new projects can discover the pattern without reinventing it.
+
+  Closes #82.
+
 ## 0.1.0-alpha.6
 
 ### Minor Changes

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/src/__tests__/cli.test.ts
+++ b/packages/create-whisq/src/__tests__/cli.test.ts
@@ -175,6 +175,50 @@ describe("createProject — full-app", () => {
     expect(fs.existsSync(path.join(projectDir, "CLAUDE.md"))).toBe(true);
     expect(fs.existsSync(path.join(projectDir, ".cursorrules"))).toBe(true);
   });
+
+  it("scaffolds components/ with at least one reusable component", () => {
+    const projectDir = path.join(tmpDir, "full-app-components");
+
+    createProject({ projectName: projectDir, template: "full-app" });
+
+    const componentsDir = path.join(projectDir, "src", "components");
+    expect(fs.existsSync(componentsDir)).toBe(true);
+    const componentFiles = fs
+      .readdirSync(componentsDir)
+      .filter((f) => f.endsWith(".ts"));
+    expect(componentFiles.length).toBeGreaterThan(0);
+  });
+
+  it("scaffolds lib/ with at least one utility (no Whisq imports)", () => {
+    const projectDir = path.join(tmpDir, "full-app-lib");
+
+    createProject({ projectName: projectDir, template: "full-app" });
+
+    const libDir = path.join(projectDir, "src", "lib");
+    expect(fs.existsSync(libDir)).toBe(true);
+    const libFiles = fs
+      .readdirSync(libDir)
+      .filter((f) => f.endsWith(".ts"));
+    expect(libFiles.length).toBeGreaterThan(0);
+
+    // lib/ is Whisq-free: utilities should be testable in isolation.
+    for (const file of libFiles) {
+      const contents = fs.readFileSync(path.join(libDir, file), "utf-8");
+      expect(contents).not.toMatch(/from\s+["']@whisq\//);
+    }
+  });
+
+  it("App.ts wraps route content in errorBoundary", () => {
+    const projectDir = path.join(tmpDir, "full-app-error-boundary");
+
+    createProject({ projectName: projectDir, template: "full-app" });
+
+    const app = fs.readFileSync(
+      path.join(projectDir, "src", "App.ts"),
+      "utf-8",
+    );
+    expect(app).toContain("errorBoundary");
+  });
 });
 
 // ── createProject — ssr ───────────────────────────────────────────────────

--- a/packages/create-whisq/src/templates/full-app/CLAUDE.md
+++ b/packages/create-whisq/src/templates/full-app/CLAUDE.md
@@ -81,38 +81,44 @@ Four shapes cover every reactive position. The one-line decision flow: *"single 
 | `bind()` spread  | `input({ ...bind(email) })`                                        | Two-way binding one signal into one form input       |
 | `bindField()` spread | `input({ type: "checkbox", ...bindField(todos, todo, "done", { as: "checkbox" }) })` | Field inside an item inside a keyed `each`           |
 
-Inside a keyed `each(..., { key })`, the callback’s `item` is an **accessor function** — call it (`todo()`) to read the current item. Getters that close over `todo` directly go stale when the array is replaced.
+Inside a keyed `each(..., { key })`, the callback's `item` is a **hybrid accessor** — read it as `todo.value.<field>` inside getters (canonical, matches the `() => sig.value` rule for signals) or as `todo()` when handing it to `() => T` consumers like `bindField`. Both return the current item; getters that close over `todo` without unwrapping via `.value` or `()` go stale when the array is replaced.
 
 #### Three ways to read inside a getter
 
 The `() => …` wrapper is uniform; what goes **inside** it depends on the source.
 
-| Source              | Read inside getter       |
-| ------------------- | ------------------------ |
-| Plain signal        | `() => sig.value`      |
-| Keyed `each` item | `() => todo().text`    |
-| `resource()` field | `() => users.loading()` |
+| Source              | Read inside getter              |
+| ------------------- | ------------------------------- |
+| Plain signal        | `() => sig.value`               |
+| Keyed `each` item   | `() => todo.value.text` (canonical — matches signals) |
+| `resource()` field  | `() => users.loading()`         |
 
-Signals use `.value`; accessors (keyed-each items, resource fields) are already callable — wrap them in `() =>` for reactivity. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
+Signals and keyed-`each` items both read via `.value`; `resource()` fields are callable (`users.loading()`, `users.data()`) because loading / error / data are semantic states. Full canonical reference: [`packages/core/docs/access-shapes.md`](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md).
 
 #### Accessors across component boundaries
 
 When you split a child component that needs a reactive item, **pass the accessor — don't call it at the parent**:
 
 ```ts
+import type { ItemAccessor } from "@whisq/core";
+
 // parent
 each(() => todos.value, (todo) => TodoItem({ todo }), { key: t => t.id })
 
 // child — read inside each getter, never destructure props or snapshot at setup
-const TodoItem = component((props: { todo: () => Todo }) => {
+const TodoItem = component((props: { todo: ItemAccessor<Todo> }) => {
   return li(
-    span(() => props.todo().text),                  // re-reads on every source change
-    button({ onclick: () => remove(props.todo().id) }, "✕"),
+    span(() => props.todo.value.text),                 // canonical — matches Shape 1
+    button({ onclick: () => remove(props.todo.value.id) }, "✕"),
   );
 });
+
+// Legacy shape — type the prop as `() => Todo` if the child should accept
+// any `() => T` source (keyed-each accessors, pre-wrapped signal readers,
+// resource fields). Read with `props.todo()`.
 ```
 
-Snapshotting (`const todo = props.todo()` at setup) makes the row freeze at mount — no error, just silent staleness after the next array change. The [access-shapes.md](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md) doc covers the full mistake table and the prop-shape variants (pass a signal when the child needs to write; pass a getter when it only reads).
+Snapshotting (`const todo = props.todo.value` or `const todo = props.todo()` at setup) makes the row freeze at mount — no error, just silent staleness after the next array change. The [access-shapes.md](https://github.com/whisqjs/whisq/blob/develop/packages/core/docs/access-shapes.md) doc covers the full mistake table and the prop-shape variants (pass a signal when the child needs to write; pass a getter when it only reads).
 
 ### Events
 
@@ -171,23 +177,24 @@ ul(
 )
 
 // 2. Keyed — DOM nodes are reused for matching keys. The render callback
-//    receives ACCESSORS, not snapshots, so field reads inside reactive
-//    getters see fresh values when the source array is replaced:
+//    receives HYBRID ACCESSORS that are both signal-shaped (.value/.peek())
+//    and callable, so field reads inside reactive getters see fresh values
+//    when the source array is replaced:
 ul(
   each(
     () => todos.value,
     (todo) =>
       li(
-        { class: () => todo().done ? "done" : "" },  // getter reads accessor
-        span(() => todo().text),                      // getter reads accessor
-        button({ onclick: () => remove(todo().id) }, "✕"),
+        { class: () => todo.value.done ? "done" : "" },    // signal-shape — canonical
+        span(() => todo.value.text),                        // signal-shape
+        button({ onclick: () => remove(todo.value.id) }, "✕"),
       ),
     { key: (t) => t.id },
   ),
 )
 ```
 
-When you pass `{ key }`, the callback’s `item` / `index` are **accessor functions** — call them (`todo()`, `index()`) to read the current value. Wrap them in `() =>` for reactive children/props so they re-read when the source array changes.
+When you pass `{ key }`, the callback's `item` / `index` are **hybrid accessors**. Prefer `todo.value.<field>` inside reactive getters — it joins the uniform `() => sig.value` rule. The call form `todo()` (and `index()`) still works for legacy code and for helpers like `bindField` that type their argument as `() => T`.
 
 Inline `.map()` also works for simple cases:
 

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.7",
-    "@whisq/router": "^0.1.0-alpha.7"
+    "@whisq/core": "^0.1.0-alpha.8",
+    "@whisq/router": "^0.1.0-alpha.8"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.6",
-    "@whisq/router": "^0.1.0-alpha.6"
+    "@whisq/core": "^0.1.0-alpha.7",
+    "@whisq/router": "^0.1.0-alpha.7"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/full-app/src/App.ts
+++ b/packages/create-whisq/src/templates/full-app/src/App.ts
@@ -1,4 +1,8 @@
-import { component, div } from "@whisq/core";
+// App.ts owns the top-level shell: routing, layout, error boundary, head
+// setup. Business logic goes in `stores/`; route targets in `pages/`;
+// reusable UI in `components/`; pure utilities in `lib/`.
+
+import { component, div, p, button, errorBoundary } from "@whisq/core";
 import { createRouter, RouterView, Link } from "@whisq/router";
 import { Home } from "./pages/Home";
 import { About } from "./pages/About";
@@ -19,6 +23,24 @@ const Nav = component(() =>
   ),
 );
 
+// The boundary wraps the route content so a thrown error in any page (or
+// its child components / effects) degrades gracefully to a retry UI instead
+// of tearing down the whole app.
 export const App = component(() =>
-  div({ class: s.app }, Nav({}), div({ class: s.content }, RouterView(router))),
+  div(
+    { class: s.app },
+    Nav({}),
+    div(
+      { class: s.content },
+      errorBoundary(
+        (error, retry) =>
+          div(
+            p({ class: s.heading }, "Something broke"),
+            p({ class: s.text }, error.message),
+            button({ class: s.btn, onclick: retry }, "Retry"),
+          ),
+        () => RouterView(router),
+      ),
+    ),
+  ),
 );

--- a/packages/create-whisq/src/templates/full-app/src/components/CounterRow.ts
+++ b/packages/create-whisq/src/templates/full-app/src/components/CounterRow.ts
@@ -1,0 +1,25 @@
+// Reusable UI component. One component per file, PascalCase — the filename
+// matches the named export. Pulled out of pages/Home.ts so it can be reused
+// on other pages without copy/paste.
+
+import { component, div, button, span } from "@whisq/core";
+import { s } from "../styles";
+import { formatCount } from "../lib/format";
+
+interface CounterRowProps {
+  /** Reactive getter for the current count. */
+  count: () => number;
+  /** Increment handler. */
+  onIncrement: () => void;
+  /** Decrement handler. */
+  onDecrement: () => void;
+}
+
+export const CounterRow = component((props: CounterRowProps) =>
+  div(
+    { class: s.row },
+    button({ class: s.btn, onclick: props.onDecrement }, "-"),
+    span({ class: s.count }, () => formatCount(props.count())),
+    button({ class: s.btn, onclick: props.onIncrement }, "+"),
+  ),
+);

--- a/packages/create-whisq/src/templates/full-app/src/lib/format.ts
+++ b/packages/create-whisq/src/templates/full-app/src/lib/format.ts
@@ -1,0 +1,18 @@
+// Pure utilities. NO Whisq imports — `lib/` modules stay testable in
+// isolation. If a helper needs a signal, it belongs in `stores/` instead.
+
+/**
+ * Format a count as a human-readable string. Uses locale-aware grouping so
+ * 1234 renders as "1,234" in en-US, "1.234" in de-DE, etc.
+ */
+export function formatCount(n: number): string {
+  return n.toLocaleString();
+}
+
+/**
+ * Clamp a number between a min and a max. Useful for bounding user input
+ * before handing it to a signal write.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/packages/create-whisq/src/templates/full-app/src/pages/Home.ts
+++ b/packages/create-whisq/src/templates/full-app/src/pages/Home.ts
@@ -1,14 +1,7 @@
-import {
-  signal,
-  computed,
-  component,
-  div,
-  h1,
-  button,
-  span,
-  p,
-} from "@whisq/core";
+import { signal, computed, component, div, h1, p } from "@whisq/core";
 import { s } from "../styles";
+import { CounterRow } from "../components/CounterRow";
+import { clamp } from "../lib/format";
 
 export const Home = component(() => {
   const count = signal(0);
@@ -16,14 +9,21 @@ export const Home = component(() => {
     count.value === 0 ? "Click to start" : `Count: ${count.value}`,
   );
 
+  // Keep count bounded — clamp is a pure utility from lib/, Whisq-free.
+  const increment = () => {
+    count.value = clamp(count.value + 1, -99, 99);
+  };
+  const decrement = () => {
+    count.value = clamp(count.value - 1, -99, 99);
+  };
+
   return div(
     h1({ class: s.heading }, "Home"),
     p({ class: s.text }, () => label.value),
-    div(
-      { class: s.row },
-      button({ class: s.btn, onclick: () => count.value-- }, "-"),
-      span({ class: s.count }, () => `${count.value}`),
-      button({ class: s.btn, onclick: () => count.value++ }, "+"),
-    ),
+    CounterRow({
+      count: () => count.value,
+      onIncrement: increment,
+      onDecrement: decrement,
+    }),
   );
 });

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.7"
+    "@whisq/core": "^0.1.0-alpha.8"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.6"
+    "@whisq/core": "^0.1.0-alpha.7"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.6",
-    "@whisq/ssr": "^0.1.0-alpha.6"
+    "@whisq/core": "^0.1.0-alpha.7",
+    "@whisq/ssr": "^0.1.0-alpha.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.7",
-    "@whisq/ssr": "^0.1.0-alpha.7"
+    "@whisq/core": "^0.1.0-alpha.8",
+    "@whisq/ssr": "^0.1.0-alpha.8"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.6",
-    "@whisq/router": "^0.1.0-alpha.6"
+    "@whisq/core": "^0.1.0-alpha.7",
+    "@whisq/router": "^0.1.0-alpha.7"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.6",
+    "@whisq/vite-plugin": "^0.1.0-alpha.7",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.7",
-    "@whisq/router": "^0.1.0-alpha.7"
+    "@whisq/core": "^0.1.0-alpha.8",
+    "@whisq/router": "^0.1.0-alpha.8"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.7",
+    "@whisq/vite-plugin": "^0.1.0-alpha.8",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @whisq/devtools
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- Updated dependencies [8f645a8]
+- Updated dependencies [401bfca]
+- Updated dependencies [0c1dccf]
+- Updated dependencies [91740a2]
+- Updated dependencies [2809555]
+- Updated dependencies [1b669b4]
+- Updated dependencies [0afc98b]
+  - @whisq/core@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @whisq/devtools
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- Updated dependencies [757049d]
+- Updated dependencies [34a2c7a]
+- Updated dependencies [97203c8]
+- Updated dependencies [3a31d18]
+- Updated dependencies [c84e495]
+  - @whisq/core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ### Patch Changes

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/mcp-server
 
+## 0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ## 0.1.0-alpha.6

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/mcp-server
 
+## 0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ## 0.1.0-alpha.5

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @whisq/router
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- Updated dependencies [757049d]
+- Updated dependencies [34a2c7a]
+- Updated dependencies [97203c8]
+- Updated dependencies [3a31d18]
+- Updated dependencies [c84e495]
+  - @whisq/core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ### Patch Changes

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @whisq/router
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- Updated dependencies [8f645a8]
+- Updated dependencies [401bfca]
+- Updated dependencies [0c1dccf]
+- Updated dependencies [91740a2]
+- Updated dependencies [2809555]
+- Updated dependencies [1b669b4]
+- Updated dependencies [0afc98b]
+  - @whisq/core@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/sandbox
 
+## 0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ## 0.1.0-alpha.5

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/sandbox
 
+## 0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ## 0.1.0-alpha.6

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @whisq/ssr
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- Updated dependencies [757049d]
+- Updated dependencies [34a2c7a]
+- Updated dependencies [97203c8]
+- Updated dependencies [3a31d18]
+- Updated dependencies [c84e495]
+  - @whisq/core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ### Patch Changes

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @whisq/ssr
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- Updated dependencies [8f645a8]
+- Updated dependencies [401bfca]
+- Updated dependencies [0c1dccf]
+- Updated dependencies [91740a2]
+- Updated dependencies [2809555]
+- Updated dependencies [1b669b4]
+- Updated dependencies [0afc98b]
+  - @whisq/core@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @whisq/testing
 
+## 0.1.0-alpha.7
+
+### Patch Changes
+
+- Updated dependencies [757049d]
+- Updated dependencies [34a2c7a]
+- Updated dependencies [97203c8]
+- Updated dependencies [3a31d18]
+- Updated dependencies [c84e495]
+  - @whisq/core@0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ### Patch Changes

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @whisq/testing
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- Updated dependencies [8f645a8]
+- Updated dependencies [401bfca]
+- Updated dependencies [0c1dccf]
+- Updated dependencies [91740a2]
+- Updated dependencies [2809555]
+- Updated dependencies [1b669b4]
+- Updated dependencies [0afc98b]
+  - @whisq/core@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/vite-plugin
 
+## 0.1.0-alpha.7
+
 ## 0.1.0-alpha.6
 
 ## 0.1.0-alpha.5

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/vite-plugin
 
+## 0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ## 0.1.0-alpha.6

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release `v0.1.0-alpha.8` — the alpha.7 feedback-response cycle. Every P1 and P2 concern the alpha.7 reviewer pair (Claude + GPT) flagged as live pain is closed; one P1 bug discovered mid-cycle (`component()` type mismatch that broke every scaffolded app under `tsc --strict`) is fixed; two P3s shipped opportunistically. 9 PRs total, all merged with green CI.

## Changes in this release

### Core API — new / enhanced

- **[#104](https://github.com/whisqjs/whisq/pull/104) (WHISQ-98)** — `persistedSignal.onSchemaFailure` callback: surface why a stored payload was rejected (parse vs. schema vs. first-visit) instead of silently falling back.
- **[#106](https://github.com/whisqjs/whisq/pull/106) (WHISQ-97)** — `class:` prop accepts array-of-sources: `class: ["btn", () => variant.value, cond && "active"]` works with per-source reactivity, removing the `cx` → `rcx` migration footgun.
- **[#110](https://github.com/whisqjs/whisq/pull/110) (WHISQ-100)** — `bindField` dev-strict mode: throws `WhisqKeyByError` on no-match writes in dev (env-defaulted; `strict: boolean` opt-out/in). Stale accessors and broken `keyBy` functions surface at first click instead of burying in the console.
- **[#111](https://github.com/whisqjs/whisq/pull/111) (WHISQ-96)** — Hybrid item accessor in keyed `each()`: callable (`todo()`) AND signal-shaped (`todo.value`, `todo.peek()`). New `ItemAccessor<T>` type exported. Non-breaking — every existing `() => T` consumer (including `bindField`) still type-checks.
- **[#114](https://github.com/whisqjs/whisq/pull/114) (WHISQ-101)** — `partition(source, predicate)` in `@whisq/core/collections` and `randomId()` in `@whisq/core/ids` (new sub-path). Both behind sub-path imports — top-level bundle unchanged at 5.5 KB gzipped.

### Fixes

- **[#105](https://github.com/whisqjs/whisq/pull/105) (WHISQ-99)** — `theme()` and `sheet()` are now SSR-safe. Previously unconditionally threw `ReferenceError: document is not defined` under SSR render. Clarified JSDoc on `theme()` call-site conventions + duplicate-call semantics.
- **[#109](https://github.com/whisqjs/whisq/pull/109) (WHISQ-108)** — `component()` typed to return `WhisqNode` (matches the runtime check + hyperscript API) instead of legacy `WhisqTemplate`. `sheet()` `StyleRule` widened to recursive type so nested `"& a": { "&:hover": {…} }` type-checks. **Before this fix, every alpha.7 scaffold failed `tsc --strict`.**

### Tooling + Templates

- **[#107](https://github.com/whisqjs/whisq/pull/107) (WHISQ-102)** — `create-whisq` `full-app` template scaffolds the canonical multi-file shape: `components/`, `lib/`, and `errorBoundary` wrapping `RouterView` in `App.ts`.
- **[#113](https://github.com/whisqjs/whisq/pull/113) (WHISQ-112)** — Internal docs (`access-shapes.md`, `reactive-shapes.md`) and the scaffolded-app `CLAUDE.md` now demonstrate `todo.value.<field>` as the canonical keyed-`each` read shape.

## Test plan

- [x] `pnpm -w build` clean across all 9 packages.
- [x] `pnpm -w test` — **404 core tests pass**; 18/18 workspace tasks green.
- [x] `pnpm check:versions` — 9 packages + 4 templates all aligned at `0.1.0-alpha.8`.
- [x] **Smoke test**: `create-whisq` scaffold produces a tree that `tsc --noEmit` exits 0 on (before alpha.8 → alpha.7 scaffolds failed with the `WhisqNode`/`WhisqTemplate` mismatch, now fixed via #109).
- [x] `pnpm size` — top-level `@whisq/core` at 5.5 KB gzipped (unchanged from alpha.7; new `partition`/`randomId` helpers live behind sub-path imports).
- [ ] CI green on this PR.
- [ ] Post-merge: tag `v0.1.0-alpha.8`, GitHub Release created, `main → develop` back-merge clean.

## Remaining open (deferred, not blockers for this release)

- #84 (P2) — alpha.6 docs papercuts, mostly whisq.dev work.
- #90 (P3) — dev-mode warning for snapshotted accessors; waiting for user reports.
- #103 (P3) — enrich `public-api.json`; waiting for a concrete consumer (likely `@whisq/mcp-server` once it grows a use).

## Next cycle

The 15 open whisq.dev docs issues consume exactly the APIs shipped here — the natural next focus is the docs site (cookbook pages, `/api/persistedSignal/`, golden-patterns page). No framework-runtime work is blocking them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)