### PR TITLE
WHISQ-120: dev warning when spreading bind() clobbers an event handler

### DIFF
--- a/.changeset/bind-duplicate-handler-warning.md
+++ b/.changeset/bind-duplicate-handler-warning.md
@@ -1,0 +1,21 @@
+---
+"@whisq/core": minor
+---
+
+Dev-only warning when spreading `bind()` / `bindField()` / `bindPath()` then overwriting one of its event handlers. Closes the production-bug window Claude's alpha.8 feedback called out as the top concern:
+
+```ts
+// Before: silently dropped bind's oninput, no warning.
+input({
+  ...bind(draft),
+  oninput: (e) => track(e),   // overwrites bind's oninput
+});
+
+// Now (in dev): console.warn with the tag, event name, and a fix hint.
+```
+
+Mechanism — the three bind helpers attach a symbol-keyed manifest of the handlers they declared to their return objects. Object spread copies symbol-keyed own properties, so the manifest survives into the final props. The element builder checks "for each declared handler, is the current prop handler still the one I declared?" On mismatch, `console.warn` (dev only; zero cost in production).
+
+**Known limitation.** Only catches _direction 1_ — spread-first, user-handler-second. _Direction 2_ (user handler first, `...bind(sig)` spread on top) cannot be detected from final props alone: by the time the element builder sees `props`, the user's original handler is gone without a trace. The warning message steers users toward the safer convention: spread bind LAST so it's your own handler that visibly "wins", making the collision obvious.
+
+Closes WHISQ-120.

--- a/packages/core/src/__tests__/bind.test.ts
+++ b/packages/core/src/__tests__/bind.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { signal } from "../reactive.js";
 import { input, textarea, select, option, mount } from "../elements.js";
 import { bind } from "../bind.js";
+import { bindField } from "../bindField.js";
+import { bindPath } from "../bindPath.js";
 
 let container: HTMLElement;
 let dispose: () => void;
@@ -177,5 +179,151 @@ describe("bind() — input validation", () => {
     expect(() => bind({} as never)).toThrow(TypeError);
     expect(() => bind(null as never)).toThrow(TypeError);
     expect(() => bind("not a signal" as never)).toThrow(TypeError);
+  });
+});
+
+// ── Duplicate-handler dev warning (WHISQ-120) ───────────────────────────────
+//
+// Dev-only detection of the "spread bind() then overwrite the same event
+// handler" footgun. The sentinel mechanism lives in bind-sentinel.ts and
+// catches direction 1 (spread first, user handler second). Direction 2
+// (user handler first, bind spread second) isn't detectable from final
+// props — documented limitation.
+
+describe("bind() duplicate-handler warning (direction 1)", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("warns when ...bind(sig) is followed by an overriding oninput", () => {
+    const name = signal("");
+    dispose = mount(
+      input({ ...bind(name), oninput: () => {} }),
+      container,
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0]![0] as string;
+    expect(msg).toContain("duplicate handler");
+    expect(msg).toContain('"oninput"');
+    expect(msg).toContain("<input>");
+  });
+
+  it("warns when ...bind(sig, checkbox) is followed by an overriding onchange", () => {
+    const agreed = signal(false);
+    dispose = mount(
+      input({
+        type: "checkbox",
+        ...bind(agreed, { as: "checkbox" }),
+        onchange: () => {},
+      }),
+      container,
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0]![0] as string;
+    expect(msg).toContain('"onchange"');
+  });
+
+  it("does NOT warn on the clean use — ...bind(sig) alone", () => {
+    const name = signal("");
+    dispose = mount(input({ ...bind(name) }), container);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns once per overwritten handler (not per key in the sentinel)", () => {
+    // bind() text returns { value, oninput }. value is not an on* handler,
+    // so only oninput is tracked. Overwriting oninput → one warning.
+    // Overwriting value (a non-handler) → no warning.
+    const name = signal("");
+    dispose = mount(
+      input({ ...bind(name), value: "override", oninput: () => {} }),
+      container,
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT warn in production", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const name = signal("");
+      dispose = mount(
+        input({ ...bind(name), oninput: () => {} }),
+        container,
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it("known limitation: does NOT warn when user handler is written first, then bind is spread on top (direction 2)", () => {
+    // This is an honest acknowledgement of the runtime limitation — by the
+    // time the element builder sees props, direction-2 overwrites have
+    // already lost their trace. The user's handler is gone, but the sentinel
+    // matches the current oninput so no warning fires. Documented in the
+    // warning message's hint: "spread bind LAST so your handler is the one
+    // that gets wiped (usually the bug you want)."
+    const name = signal("");
+    dispose = mount(
+      input({ oninput: () => {}, ...bind(name) }),
+      container,
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("bindField() duplicate-handler warning (direction 1)", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("warns when bindField's onchange is overwritten by a later handler", () => {
+    type Todo = { id: string; done: boolean };
+    const todos = signal<Todo[]>([{ id: "a", done: false }]);
+    const todo = () => todos.value[0]!;
+    dispose = mount(
+      input({
+        type: "checkbox",
+        ...bindField(todos, todo, "done", { as: "checkbox" }),
+        onchange: () => {},
+      }),
+      container,
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('"onchange"'),
+    );
+  });
+});
+
+describe("bindPath() duplicate-handler warning (direction 1)", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("warns when bindPath's oninput is overwritten by a later handler", () => {
+    type User = { profile: { email: string } };
+    const user = signal<User>({ profile: { email: "" } });
+    dispose = mount(
+      input({
+        ...bindPath(user, ["profile", "email"]),
+        oninput: () => {},
+      }),
+      container,
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('"oninput"'),
+    );
   });
 });

--- a/packages/core/src/bind-sentinel.ts
+++ b/packages/core/src/bind-sentinel.ts
@@ -1,0 +1,72 @@
+// ============================================================================
+// Whisq Core — Bind sentinel (WHISQ-120)
+//
+// Dev-mode detection for the "spread then overwrite" footgun:
+//
+//   input({
+//     ...bind(draft),        // returns { value, oninput }
+//     oninput: (e) => track(e),   // silently drops bind's oninput
+//   });
+//
+// JS object spread is last-key-wins. By the time the element builder sees
+// `props`, bind's oninput is already gone. We can't detect that from the
+// final props alone — there's only one handler per key.
+//
+// Mechanism: bind() / bindField() / bindPath() attach a symbol-keyed
+// metadata record to their return objects. Object spread copies symbol-
+// keyed own properties (including non-enumerables by design in `{ ... }`
+// spread for enumerable symbols), so the record survives into the final
+// props. The element builder checks: "for each handler I declared, is
+// the current prop handler === what I declared?" If differs → warn.
+//
+// Caveat (documented): this only catches direction-1 (user overwrites
+// after spread). It cannot catch direction-2 (user handler first, then
+// spread bind on top) — the user's original handler is gone without a
+// trace by the time props reach the element builder. The recommended
+// convention is to spread bind/bindField/bindPath LAST; a future
+// `compose(bind(sig), { oninput: fn })` helper could cover both shapes
+// but isn't part of this change.
+// ============================================================================
+
+/**
+ * Well-known symbol carrying the handler map from bind() / bindField() /
+ * bindPath() through object spread. Not exported publicly — used only as
+ * a dev-mode diagnostic channel between the bind family and the element
+ * builder. Symbol.for() so the same token is shared across bundled and
+ * source builds (tests, externals) without drift.
+ */
+export const WHISQ_BIND_SOURCES = Symbol.for("whisq.bindSources");
+
+/**
+ * Shape of the metadata the bind family attaches under WHISQ_BIND_SOURCES.
+ * Keys are event-handler prop names (oninput, onchange, …); values are the
+ * exact handler functions that bind returned. The element builder checks
+ * `props[key] === sources[key]` — strict identity — to detect overwrites.
+ */
+export type BindSources = Readonly<Record<string, unknown>>;
+
+/**
+ * Attach the sentinel to a bind result. In production the marker is
+ * omitted (the checker in the element builder is also dev-gated, so
+ * shipping the symbol would only add dead weight). Mutates and returns
+ * `result` so call sites stay concise.
+ */
+export function tagBindResult<T extends object>(result: T): T {
+  if (process.env.NODE_ENV === "production") return result;
+
+  const sources: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(result)) {
+    if (key.startsWith("on") && typeof value === "function") {
+      sources[key] = value;
+    }
+  }
+  // Silent attach — symbol keys don't appear in Object.entries or
+  // JSON.stringify so the sentinel never leaks into user-visible output.
+  Object.defineProperty(result, WHISQ_BIND_SOURCES, {
+    value: sources,
+    enumerable: true, // enumerable so `{ ...result }` copies the sentinel
+    writable: false,
+    configurable: false,
+  });
+  return result;
+}

--- a/packages/core/src/bind.ts
+++ b/packages/core/src/bind.ts
@@ -4,6 +4,7 @@
 // ============================================================================
 
 import { type Signal, isSignal } from "./reactive.js";
+import { tagBindResult } from "./bind-sentinel.js";
 
 export interface TextBind {
   value: () => string;
@@ -64,18 +65,18 @@ export function bind(
 
   if (options?.as === "checkbox") {
     const sig = signal as Signal<boolean>;
-    return {
+    return tagBindResult({
       checked: () => sig.value,
       onchange: (e: Event) => {
         sig.value = (e.target as HTMLInputElement).checked;
       },
-    };
+    });
   }
 
   if (options?.as === "radio") {
     const sig = signal as Signal<string>;
     const target = options.value;
-    return {
+    return tagBindResult({
       value: target,
       checked: () => sig.value === target,
       onchange: (e: Event) => {
@@ -83,27 +84,27 @@ export function bind(
           sig.value = target;
         }
       },
-    };
+    });
   }
 
   if (options?.as === "number") {
     const sig = signal as Signal<number>;
-    return {
+    return tagBindResult({
       value: () => String(sig.value),
       oninput: (e: Event) => {
         const n = (e.target as HTMLInputElement).valueAsNumber;
         if (!Number.isNaN(n)) sig.value = n;
       },
-    };
+    });
   }
 
   const sig = signal as Signal<string>;
-  return {
+  return tagBindResult({
     value: () => sig.value,
     oninput: (e: Event) => {
       sig.value = (
         e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
       ).value;
     },
-  };
+  });
 }

--- a/packages/core/src/bindField.ts
+++ b/packages/core/src/bindField.ts
@@ -9,6 +9,7 @@
 import { type Signal, isSignal } from "./reactive.js";
 import type { TextBind, NumberBind, CheckboxBind, RadioBind } from "./bind.js";
 import { WhisqKeyByError } from "./dev-errors.js";
+import { tagBindResult } from "./bind-sentinel.js";
 
 interface Common<T> {
   keyBy?: (item: T) => unknown;
@@ -123,42 +124,42 @@ export function bindField<T, K extends keyof T>(
   const as = (options as { as?: string } | undefined)?.as;
 
   if (as === "checkbox") {
-    return {
+    return tagBindResult({
       checked: () => item()[key] as unknown as boolean,
       onchange: (e) => write(
         (e.target as HTMLInputElement).checked as unknown as T[K],
       ),
-    };
+    });
   }
 
   if (as === "radio") {
     const target = (options as { value: string }).value;
-    return {
+    return tagBindResult({
       value: target,
       checked: () => (item()[key] as unknown) === target,
       onchange: (e) => {
         if ((e.target as HTMLInputElement).checked)
           write(target as unknown as T[K]);
       },
-    };
+    });
   }
 
   if (as === "number") {
-    return {
+    return tagBindResult({
       value: () => String(item()[key] as unknown),
       oninput: (e) => {
         const n = (e.target as HTMLInputElement).valueAsNumber;
         if (!Number.isNaN(n)) write(n as unknown as T[K]);
       },
-    };
+    });
   }
 
-  return {
+  return tagBindResult({
     value: () => String(item()[key] as unknown),
     oninput: (e) =>
       write(
         (e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)
           .value as unknown as T[K],
       ),
-  };
+  });
 }

--- a/packages/core/src/bindPath.ts
+++ b/packages/core/src/bindPath.ts
@@ -8,6 +8,7 @@
 
 import { type Signal, isSignal } from "./reactive.js";
 import type { TextBind, NumberBind, CheckboxBind, RadioBind } from "./bind.js";
+import { tagBindResult } from "./bind-sentinel.js";
 
 type PathOptions =
   | Record<string, never>
@@ -156,40 +157,40 @@ export function bindPath<T>(
   const as = (options as { as?: string } | undefined)?.as;
 
   if (as === "checkbox") {
-    return {
+    return tagBindResult({
       checked: () => readPath(source.value, path) as boolean,
       onchange: (e) =>
         write((e.target as HTMLInputElement).checked),
-    };
+    });
   }
 
   if (as === "radio") {
     const target = (options as { value: string }).value;
-    return {
+    return tagBindResult({
       value: target,
       checked: () => readPath(source.value, path) === target,
       onchange: (e) => {
         if ((e.target as HTMLInputElement).checked) write(target);
       },
-    };
+    });
   }
 
   if (as === "number") {
-    return {
+    return tagBindResult({
       value: () => String(readPath(source.value, path) ?? ""),
       oninput: (e) => {
         const n = (e.target as HTMLInputElement).valueAsNumber;
         if (!Number.isNaN(n)) write(n);
       },
-    };
+    });
   }
 
-  return {
+  return tagBindResult({
     value: () => String(readPath(source.value, path) ?? ""),
     oninput: (e) =>
       write(
         (e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)
           .value,
       ),
-  };
+  });
 }

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -15,6 +15,7 @@ import { effect, isSignal, setEffectErrorHandler } from "./reactive.js";
 import { reconcileKeyed, type KeyedEntry } from "./reconcile.js";
 import type { Ref } from "./ref.js";
 import { WhisqStructureError, describeValue } from "./dev-errors.js";
+import { WHISQ_BIND_SOURCES, type BindSources } from "./bind-sentinel.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -245,6 +246,14 @@ export function h(
 ): WhisqNode {
   const el = document.createElement(tag);
   const disposers: (() => void)[] = [];
+
+  // Dev-only: detect when a spread of bind()/bindField()/bindPath() was
+  // followed by an explicit overwrite of one of its event handlers.
+  // See WHISQ-120 + packages/core/src/bind-sentinel.ts for the mechanism
+  // (a symbol-keyed manifest carried through object spread).
+  if (process.env.NODE_ENV !== "production" && props) {
+    checkOverwrittenBindHandlers(tag, props);
+  }
 
   // Apply props
   if (props) {
@@ -1071,6 +1080,33 @@ function isPlainStyleObject(value: unknown): value is StyleObject {
   }
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
+}
+
+function checkOverwrittenBindHandlers(
+  tag: string,
+  props: Record<string, unknown>,
+): void {
+  // The sentinel is a non-enumerable property under a symbol key; a plain
+  // `in` check hits it without polluting any Object.entries iteration.
+  const sources = (props as { [k: symbol]: unknown })[WHISQ_BIND_SOURCES] as
+    | BindSources
+    | undefined;
+  if (!sources) return;
+  for (const key of Object.keys(sources)) {
+    const declared = sources[key];
+    const current = (props as Record<string, unknown>)[key];
+    if (current !== declared) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[whisq] duplicate handler for "${key}" on <${tag}>: ` +
+          `the handler returned by bind()/bindField()/bindPath() was overwritten. ` +
+          `JS object spread is last-key-wins — your explicit "${key}" silently dropped the bind handler. ` +
+          `To keep both, chain them manually: ` +
+          `{ ...bind(sig), ${key}: (e) => { /* your code */ /* then call bind's handler yourself */ } }, ` +
+          `or spread bind LAST so your handler is the one that gets wiped (usually the bug you want).`,
+      );
+    }
+  }
 }
 
 function joinClassArray(sources: readonly ClassArraySource[]): string {


### PR DESCRIPTION
Closes #120.

## Summary

`bind()` / `bindField()` / `bindPath()` now carry a dev-mode sentinel that lets the element builder detect when a spread-then-overwrite silently dropped one of their event handlers. Claude's alpha.8 feedback ranked this as **the** production-bug concern for alpha.9 — the one paper cut that will "produce a bug someone ships to production and then spends an afternoon debugging."

```ts
// Before: silently dropped bind's oninput. Zero diagnostic.
input({
  ...bind(draft),
  oninput: (e) => track(e),
});

// Now (in dev): console.warn naming the tag, the event, and a fix hint.
```

## Mechanism

**Key realisation that shaped the design:** JS object spread is last-key-wins and collapses `{ ...bind(x), oninput: fn }` into a single object before any framework code sees it. The original handler is already gone at element-build time — detection needs a sentinel that **survives the spread**.

1. `bind()` / `bindField()` / `bindPath()` attach a `Symbol.for("whisq.bindSources")`-keyed manifest to their return objects: `{ oninput: handlerRef, onchange: handlerRef, … }`.
2. Object spread copies symbol-keyed enumerable own properties, so the manifest lands in the final `props`.
3. The element builder's dev path (`NODE_ENV !== "production"`) runs a pre-loop check: for each key the sentinel claims, is `props[key] === sentinel[key]`? On mismatch, `console.warn` with the tag, event name, and a hint pointing at spread-then-overwrite as the likely cause.
4. In production, `tagBindResult` is a no-op and `checkOverwrittenBindHandlers` is never called. Zero cost in prod.

## Honest limitation (documented in the warning text + changeset)

Only **direction 1** is detectable:

| Shape | Detected? | Why |
|---|---|---|
| `input({ ...bind(sig), oninput: fn })` | ✅ | Sentinel manifest lists bind's handler; current `oninput` differs → WARN |
| `input({ oninput: fn, ...bind(sig) })` | ❌ | User's handler is gone by element-build time with no trace; sentinel matches current `oninput`; no mismatch to detect |

Direction 2 would require a different API contract — e.g. a `compose(bind(sig), { oninput: fn })` helper that sees both sides. Out of scope here. The warning text steers users toward the safer convention: **spread bind LAST** so if there's a collision, your own handler is the one that visibly disappears, which makes the problem obvious.

## Test plan

- [x] `{ ...bind(name), oninput: () => {} }` triggers one warning naming `"oninput"` and `<input>`.
- [x] `{ ...bind(agreed, { as: "checkbox" }), onchange: () => {} }` triggers one warning naming `"onchange"`.
- [x] `{ ...bind(name) }` alone — no warning (clean use).
- [x] `{ ...bind(name), value: "override", oninput: () => {} }` — one warning (`value` isn't an `on*` handler so isn't tracked).
- [x] Production env (`NODE_ENV = "production"`) — no warning regardless.
- [x] Direction 2 (`{ oninput: () => {}, ...bind(name) }`) — documented as non-detectable; test asserts no warning fires (codifies the known limitation).
- [x] `bindField` variant: `{ ...bindField(todos, todo, "done", { as: "checkbox" }), onchange: () => {} }` → warning.
- [x] `bindPath` variant: `{ ...bindPath(user, ["profile", "email"]), oninput: () => {} }` → warning.
- [x] All 52 bind-family tests pass (21 bind + 19 bindField + 12 bindPath).
- [x] Full suite: 412 core tests pass (was 404 → +8 new).
- [x] `pnpm -w build` clean across all 9 packages.

## Files

- New `packages/core/src/bind-sentinel.ts` — symbol + `tagBindResult()` helper (prod no-op).
- `packages/core/src/bind.ts`, `bindField.ts`, `bindPath.ts` — each of the four return paths wraps in `tagBindResult()`.
- `packages/core/src/elements.ts` — `h()` gains a dev-gated `checkOverwrittenBindHandlers()` call before the main props loop; helper appended to the internal-helpers block.
- 8 new tests across `bind.test.ts`.

## Out of scope

- Direction-2 detection — see "Honest limitation" above. Would need a new `compose()` API.
- Handler-chaining auto-composition (option B on #120). Kept the existing contract: spread then the later key wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)