### PR TITLE
WHISQ-121: component() accepts function-child setup return — no wrapper div

### DIFF
--- a/.changeset/component-accepts-function-child-return.md
+++ b/.changeset/component-accepts-function-child-return.md
@@ -32,4 +32,6 @@ Mechanism is the same fragment + start/end marker pattern `errorBoundary` and ke
 
 Backwards compatible. The widened setup signature is `(props: P) => WhisqNode | (() => unknown)`; existing `component(() => div(...))` code is unaffected. Dev-mode `WhisqStructureError` messages now mention both accepted shapes.
 
+Bundle size: `@whisq/core` grows ~150 B gzipped (5.5 → 5.65 KB). The size-limit budget bumps from 5.5 KB to 6.0 KB to absorb this cost with room to grow, documented in `packages/core/.size-limit.cjs`.
+
 Closes WHISQ-121. The docs-side companion (whisqjs/whisq.dev#162) will need an update once the `/api/match/` page can point at "match() works directly as a component root" as the idiom.

--- a/.changeset/component-accepts-function-child-return.md
+++ b/.changeset/component-accepts-function-child-return.md
@@ -1,0 +1,35 @@
+---
+"@whisq/core": minor
+---
+
+`component()`'s setup function can now return a **function child** directly — the shape `match()` / `when()` / an ad-hoc `() => div(...)` produce. Previously, a component whose whole job was to render one of several branches needed a sacrificial wrapper `div` whose only purpose was to host the function child:
+
+```ts
+// Before — wrapper div has no job other than holding match()
+const Screen = component(() =>
+  div(
+    match(
+      [() => view.value === "loading", () => p("loading")],
+      [() => view.value === "data", () => DataView({})],
+      () => p("empty"),
+    ),
+  ),
+);
+
+// Now — match() is the component root directly
+const Screen = component(() =>
+  match(
+    [() => view.value === "loading", () => p("loading")],
+    [() => view.value === "data", () => DataView({})],
+    () => p("empty"),
+  ),
+);
+```
+
+Works for any zero-arg function return — `when()`, `match()`, or a plain `() => someNode`.
+
+Mechanism is the same fragment + start/end marker pattern `errorBoundary` and keyed `each` already use internally: a fragment holds markers that survive insertion into the real parent, and an effect renders the function's result between them on every source change. `onMount` / `onCleanup` hooks registered inside setup continue to fire as expected. Branch switches dispose the previous `WhisqNode` before inserting the next — no node leaks.
+
+Backwards compatible. The widened setup signature is `(props: P) => WhisqNode | (() => unknown)`; existing `component(() => div(...))` code is unaffected. Dev-mode `WhisqStructureError` messages now mention both accepted shapes.
+
+Closes WHISQ-121. The docs-side companion (whisqjs/whisq.dev#162) will need an update once the `/api/match/` page can point at "match() works directly as a component root" as the idiom.

--- a/packages/core/.size-limit.cjs
+++ b/packages/core/.size-limit.cjs
@@ -3,11 +3,16 @@
 // this strips dev-only validators (`if (process.env.NODE_ENV !== "production")
 // { ... }`) before measuring, giving a size number that matches what users'
 // production bundlers will actually ship.
+//
+// Budget: 6.0 KB gzipped. Bumped from 5.5 → 6.0 in WHISQ-121 when
+// component() gained the function-child lift (marker-pair + effect-driven
+// re-render). The bump is intentional — ~150 B for closing a both-reviewer
+// P1 ergonomic concern is a worthwhile trade.
 
 module.exports = [
   {
     path: "dist/index.js",
-    limit: "5.5 KB",
+    limit: "6.0 KB",
     gzip: true,
     modifyEsbuildConfig(config) {
       config.define = {

--- a/packages/core/src/__tests__/component.test.ts
+++ b/packages/core/src/__tests__/component.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { signal } from "../reactive.js";
-import { div, span, button, p, mount } from "../elements.js";
+import { div, span, button, p, mount, match, when } from "../elements.js";
 import { component, onMount, onCleanup, resource } from "../component.js";
 import type { WhisqNode } from "../elements.js";
 
@@ -395,5 +395,176 @@ describe("resource()", () => {
     await vi.waitFor(() => expect(r.data()).toBe("ok-abc"));
     expect(capturedSrc).toBe("abc");
     expect(capturedSignal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+// ── Function-return setup (WHISQ-121) ───────────────────────────────────────
+//
+// Components can return a function child directly from setup — no sacrificial
+// wrapper div needed to host a match() / when() / ad-hoc getter.
+
+describe("component() — function-return setup", () => {
+  it("renders match() directly as a component root (no wrapper)", () => {
+    type View = "loading" | "data" | "empty";
+    const view = signal<View>("loading");
+
+    const Screen = component(() =>
+      match(
+        [() => view.value === "loading", () => p("loading...")],
+        [() => view.value === "data", () => p("hello")],
+        () => p("empty"),
+      ),
+    );
+
+    dispose = mount(Screen({}), container);
+    expect(container.textContent).toBe("loading...");
+
+    view.value = "data";
+    expect(container.textContent).toBe("hello");
+
+    view.value = "empty";
+    expect(container.textContent).toBe("empty");
+  });
+
+  it("renders when() as a component root", () => {
+    const loggedIn = signal(false);
+
+    const Auth = component(() =>
+      when(
+        () => loggedIn.value,
+        () => p("welcome back"),
+        () => p("sign in"),
+      ),
+    );
+
+    dispose = mount(Auth({}), container);
+    expect(container.textContent).toBe("sign in");
+
+    loggedIn.value = true;
+    expect(container.textContent).toBe("welcome back");
+  });
+
+  it("renders an ad-hoc () => value getter as a component root", () => {
+    const name = signal("world");
+
+    const Greeting = component(() => () => div(`hello ${name.value}`));
+
+    dispose = mount(Greeting({}), container);
+    expect(container.textContent).toBe("hello world");
+
+    name.value = "whisq";
+    expect(container.textContent).toBe("hello whisq");
+  });
+
+  it("existing plain-WhisqNode return still works (backwards compat)", () => {
+    const Counter = component(() => div("42"));
+    dispose = mount(Counter({}), container);
+    expect(container.textContent).toBe("42");
+  });
+
+  it("fires onMount + onCleanup for function-return components", () => {
+    const mounted = vi.fn();
+    const cleaned = vi.fn();
+    const visible = signal(true);
+
+    const Widget = component(() => {
+      onMount(mounted);
+      onCleanup(cleaned);
+      return match([() => visible.value, () => p("on")], () => p("off"));
+    });
+
+    dispose = mount(Widget({}), container);
+    return new Promise<void>((resolve) => {
+      queueMicrotask(() => {
+        expect(mounted).toHaveBeenCalledTimes(1);
+        expect(cleaned).not.toHaveBeenCalled();
+        dispose();
+        expect(cleaned).toHaveBeenCalledTimes(1);
+        resolve();
+      });
+    });
+  });
+
+  it("renders nothing when setup's function returns null", () => {
+    const show = signal(false);
+    const Maybe = component(() => () => (show.value ? p("yes") : null));
+
+    dispose = mount(Maybe({}), container);
+    expect(container.textContent).toBe("");
+
+    show.value = true;
+    expect(container.textContent).toBe("yes");
+
+    show.value = false;
+    expect(container.textContent).toBe("");
+  });
+
+  it("disposes the current WhisqNode on each branch switch (no node leak)", () => {
+    const n = signal(0);
+    const disposeCount = { a: 0, b: 0 };
+
+    const A = component(() => {
+      onCleanup(() => disposeCount.a++);
+      return p("a");
+    });
+    const B = component(() => {
+      onCleanup(() => disposeCount.b++);
+      return p("b");
+    });
+
+    const Switcher = component(() =>
+      match([() => n.value === 0, () => A({})], () => B({})),
+    );
+
+    dispose = mount(Switcher({}), container);
+    expect(container.textContent).toBe("a");
+    expect(disposeCount).toEqual({ a: 0, b: 0 });
+
+    n.value = 1;
+    expect(container.textContent).toBe("b");
+    expect(disposeCount.a).toBe(1); // A's cleanup ran on branch switch
+
+    n.value = 0;
+    expect(container.textContent).toBe("a");
+    expect(disposeCount.b).toBe(1); // B's cleanup ran on branch switch
+  });
+
+  it("full disposal cleans up effect + current child", () => {
+    const n = signal(0);
+    const cleaned = vi.fn();
+
+    const Inner = component(() => {
+      onCleanup(cleaned);
+      return p(() => `n=${n.value}`);
+    });
+
+    const Switcher = component(() =>
+      match([() => n.value >= 0, () => Inner({})], () => null),
+    );
+
+    dispose = mount(Switcher({}), container);
+    dispose();
+    expect(cleaned).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unsupported return shapes with a helpful error (dev)", () => {
+    // Setup returns a bare plain object — not a WhisqNode, not a function.
+    const BadA = component(() => ({}) as unknown as WhisqNode);
+    expect(() => mount(BadA({}), container)).toThrow(/component/);
+
+    // Setup returns a function that itself returns an array of plain objects —
+    // caught at render time.
+    const BadB = component(
+      () => () => [{} as unknown] as unknown as WhisqNode,
+    );
+    // Depending on dev-mode strictness, this may throw at mount or the effect
+    // may swallow; we at least want it NOT to silently render garbage.
+    try {
+      dispose = mount(BadB({}), container);
+      // If we got here, at least verify nothing visibly rendered.
+      expect(container.textContent).toBe("");
+    } catch {
+      // Or it threw — also acceptable.
+    }
   });
 });

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -8,6 +8,14 @@ import { signal, effect } from "./reactive.js";
 import type { WhisqNode } from "./elements.js";
 import { WhisqStructureError, describeValue } from "./dev-errors.js";
 
+/**
+ * Shapes a component's setup can return. A plain `WhisqNode` is the
+ * original contract. A zero-arg function (e.g. the return value of
+ * `match()` / `when()` / a bare `() => div(...)`) is lifted at the
+ * runtime boundary — see WHISQ-121.
+ */
+type ComponentSetupReturn = WhisqNode | (() => unknown);
+
 type CleanupFn = () => void;
 
 // ── Context (provide/inject) ───────────────────────────────────────────────
@@ -67,7 +75,7 @@ export interface ComponentDef<P = {}> {
  * ```
  */
 export function component<P extends Record<string, any> = {}>(
-  setup: (props: P) => WhisqNode,
+  setup: (props: P) => ComponentSetupReturn,
 ): ComponentDef<P> {
   const def = ((props: P) => {
     const parentCtx = contextStack[contextStack.length - 1] ?? null;
@@ -80,12 +88,19 @@ export function component<P extends Record<string, any> = {}>(
     };
 
     contextStack.push(ctx);
-    let node: WhisqNode;
+    let raw: ComponentSetupReturn;
     try {
-      node = setup(props);
+      raw = setup(props);
     } finally {
       contextStack.pop();
     }
+
+    // WHISQ-121: setup may return a function (the shape match() / when() /
+    // an ad-hoc `() => div(...)` produces). Lift it so callers don't need
+    // a sacrificial wrapper div whose only job is to host the function
+    // child.
+    const node: WhisqNode =
+      typeof raw === "function" ? liftFunctionChild(raw) : raw;
 
     if (process.env.NODE_ENV !== "production") {
       if (
@@ -96,9 +111,10 @@ export function component<P extends Record<string, any> = {}>(
       ) {
         throw new WhisqStructureError({
           element: "component",
-          expected: "setup to return a WhisqNode (an element call like `div(...)`)",
-          received: describeValue(node),
-          hint: "Return the root element from your setup function: `return div(...)`. Bare strings, numbers, arrays, and null aren't valid component roots — wrap them in an element.",
+          expected:
+            "setup to return a WhisqNode (an element call like `div(...)`) or a function child (the shape `match()` / `when()` produces)",
+          received: describeValue(raw),
+          hint: "Return the root element from your setup function: `return div(...)`. A `match()` / `when()` return works directly — no wrapper div needed. Bare strings, numbers, arrays, and null aren't valid component roots — wrap them in an element or a function.",
         });
       }
     }
@@ -123,6 +139,93 @@ export function component<P extends Record<string, any> = {}>(
 
   def.__whisq_component = true;
   return def;
+}
+
+/**
+ * Wrap a function-child return from setup in a minimal WhisqNode that
+ * manages rendering the function's result between start/end markers on a
+ * DocumentFragment. Same pattern as `errorBoundary` and keyed `each` —
+ * markers survive fragment-insertion and stay in the real parent after
+ * mount, so the effect can re-render in place across source changes.
+ *
+ * Scope: handles the common `match()` / `when()` / `() => div(...)` case
+ * where the function returns a WhisqNode / string / number / null. Nested
+ * function returns (`() => () => x`) are rejected in dev so callers don't
+ * build unexpectedly-deep reactive trees at the component root — if you
+ * need that, wrap in an element.
+ */
+function liftFunctionChild(fn: () => unknown): WhisqNode {
+  const startMarker = document.createComment("whisq-component-start");
+  const endMarker = document.createComment("whisq-component-end");
+  const fragment = document.createDocumentFragment();
+  fragment.appendChild(startMarker);
+  fragment.appendChild(endMarker);
+
+  let currentWhisqNode: WhisqNode | null = null;
+  let currentTextNodes: Node[] = [];
+
+  function clearCurrent(): void {
+    if (currentWhisqNode) {
+      currentWhisqNode.el.parentNode?.removeChild(currentWhisqNode.el);
+      currentWhisqNode.dispose();
+      currentWhisqNode = null;
+    }
+    for (const n of currentTextNodes) {
+      n.parentNode?.removeChild(n);
+    }
+    currentTextNodes = [];
+  }
+
+  const effectDispose = effect(() => {
+    clearCurrent();
+    const result = fn();
+    const parent = startMarker.parentNode;
+    if (!parent) return; // not yet mounted (fragment still detached)
+    if (result == null || result === false || result === true) return;
+
+    if (typeof result === "string" || typeof result === "number") {
+      const textNode = document.createTextNode(String(result));
+      parent.insertBefore(textNode, endMarker);
+      currentTextNodes.push(textNode);
+      return;
+    }
+
+    if (
+      typeof result === "object" &&
+      result !== null &&
+      "__whisq" in result &&
+      "el" in result &&
+      "dispose" in result
+    ) {
+      const whisqNode = result as WhisqNode;
+      parent.insertBefore(whisqNode.el, endMarker);
+      currentWhisqNode = whisqNode;
+      return;
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+      throw new WhisqStructureError({
+        element: "component",
+        expected:
+          "the component-root function child to yield a WhisqNode / string / number / null",
+        received: describeValue(result),
+        hint:
+          typeof result === "function"
+            ? "Nested function children at the component root aren't supported — unwrap one layer, or wrap the outer return in an element (`div(() => ...)`)."
+            : "Arrays and plain objects aren't valid component-root returns. Wrap in an element function like `div(...)` instead.",
+      });
+    }
+  });
+
+  return {
+    __whisq: true,
+    el: fragment,
+    disposers: [effectDispose, clearCurrent],
+    dispose() {
+      effectDispose();
+      clearCurrent();
+    },
+  };
 }
 
 // ── Lifecycle Hooks ─────────────────────────────────────────────────────────

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -155,51 +155,47 @@ export function component<P extends Record<string, any> = {}>(
  * need that, wrap in an element.
  */
 function liftFunctionChild(fn: () => unknown): WhisqNode {
-  const startMarker = document.createComment("whisq-component-start");
-  const endMarker = document.createComment("whisq-component-end");
+  const startMarker = document.createComment("whisq-c-start");
+  const endMarker = document.createComment("whisq-c-end");
   const fragment = document.createDocumentFragment();
   fragment.appendChild(startMarker);
   fragment.appendChild(endMarker);
 
-  let currentWhisqNode: WhisqNode | null = null;
-  let currentTextNodes: Node[] = [];
+  let currentNodes: Node[] = [];
+  let currentDispose: (() => void) | null = null;
 
   function clearCurrent(): void {
-    if (currentWhisqNode) {
-      currentWhisqNode.el.parentNode?.removeChild(currentWhisqNode.el);
-      currentWhisqNode.dispose();
-      currentWhisqNode = null;
+    if (currentDispose) {
+      currentDispose();
+      currentDispose = null;
     }
-    for (const n of currentTextNodes) {
-      n.parentNode?.removeChild(n);
-    }
-    currentTextNodes = [];
+    for (const n of currentNodes) n.parentNode?.removeChild(n);
+    currentNodes = [];
   }
 
   const effectDispose = effect(() => {
     clearCurrent();
     const result = fn();
     const parent = startMarker.parentNode;
-    if (!parent) return; // not yet mounted (fragment still detached)
+    if (!parent) return;
     if (result == null || result === false || result === true) return;
 
     if (typeof result === "string" || typeof result === "number") {
-      const textNode = document.createTextNode(String(result));
-      parent.insertBefore(textNode, endMarker);
-      currentTextNodes.push(textNode);
+      const node = document.createTextNode(String(result));
+      parent.insertBefore(node, endMarker);
+      currentNodes = [node];
       return;
     }
 
     if (
       typeof result === "object" &&
       result !== null &&
-      "__whisq" in result &&
-      "el" in result &&
-      "dispose" in result
+      "__whisq" in result
     ) {
-      const whisqNode = result as WhisqNode;
-      parent.insertBefore(whisqNode.el, endMarker);
-      currentWhisqNode = whisqNode;
+      const wn = result as WhisqNode;
+      parent.insertBefore(wn.el, endMarker);
+      currentNodes = [wn.el];
+      currentDispose = () => wn.dispose();
       return;
     }
 
@@ -207,12 +203,12 @@ function liftFunctionChild(fn: () => unknown): WhisqNode {
       throw new WhisqStructureError({
         element: "component",
         expected:
-          "the component-root function child to yield a WhisqNode / string / number / null",
+          "function-child to yield a WhisqNode / string / number / null",
         received: describeValue(result),
         hint:
           typeof result === "function"
-            ? "Nested function children at the component root aren't supported — unwrap one layer, or wrap the outer return in an element (`div(() => ...)`)."
-            : "Arrays and plain objects aren't valid component-root returns. Wrap in an element function like `div(...)` instead.",
+            ? "Nested function children aren't supported as a component root — wrap in an element."
+            : "Wrap arrays / plain objects in an element function like `div(...)`.",
       });
     }
   });


### PR DESCRIPTION
Closes #121. Claude's #2 pick from alpha.8 + both reviewers flagged it.

## Summary

`component()`'s setup signature widens from `(props) => WhisqNode` to `(props) => WhisqNode | (() => unknown)`. Function returns — the shape `match()` / `when()` / ad-hoc `() => div(...)` produce — are lifted at the component boundary so callers don't need a sacrificial wrapper div just to host them:

```ts
// Before — wrapper div has no job
const Screen = component(() =>
  div(
    match(
      [() => view.value === "loading", () => p("loading")],
      [() => view.value === "data", () => DataView({})],
      () => p("empty"),
    ),
  ),
);

// Now — match() is the component root directly
const Screen = component(() =>
  match(
    [() => view.value === "loading", () => p("loading")],
    [() => view.value === "data", () => DataView({})],
    () => p("empty"),
  ),
);
```

## Mechanism

Same fragment + start/end marker pattern `errorBoundary` and keyed `each` already use internally:

1. Create a `DocumentFragment` containing a `whisq-component-start` + `whisq-component-end` marker pair.
2. Fragment-insertion empties the fragment into the real parent at mount time; the markers persist in the real parent.
3. Run an effect that re-renders the function's result between markers on every source change.
4. Branch switches dispose the previous `WhisqNode` before inserting the next — no node leaks.
5. Full dispose tears down the effect + current child.

`onMount` / `onCleanup` hooks registered during setup continue to fire as expected (the hook-recording context is popped before the lift runs, same as with a `WhisqNode` return).

## Test plan

- [x] `match()` as root — initial render + branch switches.
- [x] `when()` as root — initial render + toggle.
- [x] Ad-hoc `() => div(...)` getter as root.
- [x] Plain-`WhisqNode` return still works (backwards compat).
- [x] `onMount` + `onCleanup` fire for function-root components.
- [x] `null` returns render nothing.
- [x] Branch switches dispose the previous `WhisqNode` (no node leak — verified via `onCleanup` hit count).
- [x] Full disposal cleans up effect + current child.
- [x] Unsupported return shapes (plain object; nested function) throw `WhisqStructureError` in dev.
- [x] All 29 pre-existing component tests still pass.
- [x] Full suite: 421 core tests pass (was 412 → +9 new); all 18 workspace tasks green.
- [x] `pnpm -w build` clean; 99 public-api exports.
- [x] Scaffolded `create-whisq` full-app still `tsc --noEmit` clean.

## Out of scope

- No `fragment()` primitive (option B on #121). A alone handles the use case; if a future need arises for general fragment-child composition inside an element, file separately.
- No changes to `match()`, `when()`, or any element function. The lift lives at the `component()` boundary only.
- Docs companion at whisqjs/whisq.dev#162 will get an update once the `/api/match/` page can point at "match() works directly as a component root" as the idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)