### PR TITLE
WHISQ-122: dev warning on duplicate theme() calls

### DIFF
--- a/.changeset/theme-duplicate-call-warning.md
+++ b/.changeset/theme-duplicate-call-warning.md
@@ -1,0 +1,29 @@
+---
+"@whisq/core": minor
+---
+
+Dev-mode warning on duplicate `theme()` calls. Completes the alpha.7 `theme()` saga started by #99 / #105 (docs + SSR guard). Catches the failure mode Claude's alpha.8 feedback flagged: a multi-file project that imports two styles files and silently wipes the first theme's variables.
+
+```ts
+// styles.ts — app's primary theme
+import { theme } from "@whisq/core";
+theme({ color: { primary: "#4386FB" } });
+
+// another styles.ts elsewhere in the graph — accidentally imported
+import { theme } from "@whisq/core";
+theme({ color: { primary: "#ffffff" } });
+// Dev: console.warn names the conflict; production is silent.
+```
+
+New optional `silent?: boolean` on the `theme()` signature suppresses the warning for legitimate second calls (theme-switching toggles):
+
+```ts
+// Runtime theme switch — intentional; silent: true says "don't warn"
+theme(darkTokens, { silent: true });
+```
+
+Detection is DOM-based — a `getElementById("whisq-style-whisq-theme")` check. Production builds strip the entire guard via the existing `NODE_ENV !== "production"` pattern, so there's no runtime cost in shipped code. Each `theme()` is still last-call-wins: the warning doesn't change injection semantics, only surfaces when a second call would replace an existing block.
+
+Exported `ThemeOptions` type for callers who type their wrapper helpers.
+
+Closes WHISQ-122.

--- a/packages/core/src/__tests__/styling.test.ts
+++ b/packages/core/src/__tests__/styling.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { sheet, styles, cx, rcx, theme } from "../styling";
 import { signal } from "../reactive";
 
@@ -264,13 +264,93 @@ describe("theme()", () => {
   });
 
   it("replaces existing theme on second call", () => {
+    // Second call triggers the dup-warning (WHISQ-122) by default; use
+    // silent:true here since we're testing replacement semantics, not the
+    // warning itself.
     theme({ color: { primary: "red" } });
-    theme({ color: { primary: "blue" } });
+    theme({ color: { primary: "blue" } }, { silent: true });
 
     const styleTags = document.querySelectorAll("#whisq-style-whisq-theme");
     expect(styleTags.length).toBe(1);
     expect(styleTags[0].textContent).toContain("--color-primary:blue");
     expect(styleTags[0].textContent).not.toContain("--color-primary:red");
+  });
+});
+
+// ── Duplicate-call warning (WHISQ-122) ──────────────────────────────────────
+//
+// Dev-mode warning on second+ theme() calls catches the accidental-
+// overwrite failure mode Claude flagged in alpha.8 feedback (import one
+// styles.ts file, later import another that also calls theme(), last call
+// silently wipes the first). Detection is DOM-based (existing whisq-
+// style-whisq-theme element), so the beforeEach that clears that element
+// naturally resets state between tests — no counter to maintain.
+
+describe("theme() — duplicate-call warning", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("does NOT warn on first theme() call", () => {
+    theme({ color: { primary: "red" } });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns on second theme() call in dev (default)", () => {
+    theme({ color: { primary: "red" } });
+    theme({ color: { primary: "blue" } });
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0]![0] as string;
+    expect(msg).toContain("theme()");
+    expect(msg).toMatch(/replaces?|last-call-wins|duplicate/i);
+  });
+
+  it("warns again on third call (persistent, not just once)", () => {
+    theme({ color: { primary: "a" } });
+    theme({ color: { primary: "b" } });
+    theme({ color: { primary: "c" } });
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses the warning when silent: true is passed", () => {
+    theme({ color: { primary: "red" } });
+    theme({ color: { primary: "blue" } }, { silent: true });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns in dev even if the first call used silent: true", () => {
+    // silent applies only to THIS call. A subsequent call still warns
+    // against whatever style tag exists — silent doesn't disable detection
+    // globally.
+    theme({ color: { primary: "red" } }, { silent: true });
+    theme({ color: { primary: "blue" } });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT warn in production", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      theme({ color: { primary: "red" } });
+      theme({ color: { primary: "blue" } });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it("does NOT warn in SSR (no document)", () => {
+    const originalDocument = globalThis.document;
+    // @ts-expect-error intentional delete to simulate SSR
+    delete (globalThis as { document?: Document }).document;
+    try {
+      theme({ color: { primary: "red" } });
+      theme({ color: { primary: "blue" } });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      (globalThis as { document?: Document }).document = originalDocument;
+    }
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -116,6 +116,7 @@ export type { Ref, ElementRef } from "./ref.js";
 
 // Styling
 export { sheet, styles, cx, rcx, sx, theme } from "./styling.js";
+export type { ThemeOptions } from "./styling.js";
 export type { StyleObject } from "./elements.js";
 
 // Dev-mode diagnostics

--- a/packages/core/src/styling.ts
+++ b/packages/core/src/styling.ts
@@ -300,6 +300,19 @@ type ThemeTokens = Record<
 >;
 
 /**
+ * Options for `theme()`.
+ */
+export interface ThemeOptions {
+  /**
+   * Suppress the dev-mode "theme() called twice" warning for this call.
+   * Set when a second call is intentional — for example, a theme-switching
+   * toggle `theme(darkTokens, { silent: true })`. Production doesn't emit
+   * the warning regardless of this option.
+   */
+  silent?: boolean;
+}
+
+/**
  * Define CSS custom properties (design tokens) at :root level.
  *
  * ```ts
@@ -359,8 +372,32 @@ type ThemeTokens = Record<
  *   call is a no-op. The CSS variables won't appear in server-rendered
  *   HTML; attach theme tokens in a `<style>` block in your SSR template
  *   until a dedicated server renderer ships.
+ * - **Dev warning on accidental duplicates.** In dev, a second `theme()`
+ *   call with an existing whisq-theme block in the DOM emits a
+ *   `console.warn` — the bug this catches is the multi-file project that
+ *   imports two styles files and silently wipes the first theme. Pass
+ *   `{ silent: true }` when the second call is intentional (e.g. a
+ *   theme-switching toggle).
  */
-export function theme(tokens: ThemeTokens): void {
+export function theme(tokens: ThemeTokens, options?: ThemeOptions): void {
+  // Dev-only: detect accidental duplicate calls by checking whether a
+  // whisq-theme style block is already in the DOM. The check is cheap
+  // (one getElementById) and runs before injection, so production builds
+  // strip it via the NODE_ENV guard without changing behavior.
+  if (
+    process.env.NODE_ENV !== "production" &&
+    !options?.silent &&
+    typeof document !== "undefined" &&
+    document.getElementById("whisq-style-whisq-theme") !== null
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[whisq] theme() called a second time — the existing <style id=\"whisq-style-whisq-theme\"> block will be replaced (last-call-wins). " +
+        "If this is intentional (e.g. a theme-switching toggle), pass { silent: true } to suppress this warning. " +
+        "If unexpected, check whether two modules on your import graph both call theme() at module scope.",
+    );
+  }
+
   let cssText = ":root{";
 
   for (const [group, value] of Object.entries(tokens)) {


### PR DESCRIPTION
Closes #122. Completes the alpha.7 `theme()` saga — #99 shipped docs + SSR semantics via #105; #122 adds the runtime-visibility gap that doc-only coverage couldn't close.

## Summary

Dev-only warning when `theme()` is called a second time and an existing `<style id="whisq-style-whisq-theme">` block is already in the DOM. Catches the multi-file-project failure mode Claude's alpha.8 feedback flagged:

```ts
// styles.ts — app's primary theme
import { theme } from "@whisq/core";
theme({ color: { primary: "#4386FB" } });

// another styles.ts elsewhere on the import graph — accidentally pulled in
import { theme } from "@whisq/core";
theme({ color: { primary: "#ffffff" } });
// Dev: console.warn names the conflict + suggests { silent: true } for intentional theme-switches.
// Production: silent.
```

New optional `silent?: boolean` suppresses the warning for deliberate second calls:

```ts
theme(darkTokens, { silent: true });
```

`ThemeOptions` type exported for callers who wrap `theme()`.

## Mechanism

Detection is DOM-based — `getElementById("whisq-style-whisq-theme") !== null` before injection. This reuses the exact element the existing `injectCSS` helper already replaces in place, so there's no new state. State "resets" naturally on page reload or when tests clear the DOM between cases (which the existing styling test `beforeEach` already does).

Production builds strip the entire guard via the existing `NODE_ENV !== "production"` pattern — zero runtime cost on shipped code.

## Test plan

- [x] First `theme()` call — no warn.
- [x] Second `theme()` call in dev — exactly one warn.
- [x] Third call — another warn (persistent, not just once).
- [x] `silent: true` on the second call — no warn.
- [x] `silent: true` on the *first* call doesn't disable detection globally (second call still warns).
- [x] Production env — no warn regardless.
- [x] SSR env (no `document`) — no warn, no throw.
- [x] All 31 pre-existing styling tests still pass (one test updated to pass `silent: true` on a deliberate second call; now exercises the new option alongside replacement semantics).
- [x] Full suite: 428 core tests pass (was 421 → +7 new); all 18 workspace tasks green.
- [x] Bundle size: 5.66 KB gzipped (within the 6.0 KB budget bumped in #125).

## Out of scope

- Merging tokens across calls (option B on #122) — stays with the documented last-call-wins contract.
- whisq.dev companion — the `/api/theme/` page needs a one-line note about `silent: true`; trivial follow-up, no separate issue warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)