### PR TITLE
WHISQ-124: StackBlitz-runnable template at examples/template-todo/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,10 @@ CLAUDE.md
 
 # internal drafts
 draft/
-examples/
+# examples/ is gitignored by default to keep local experiments out of the
+# tree; committed example projects need an explicit un-ignore below.
+examples/*
+!examples/template-todo/
 
 # website (moved to whisqjs/whisq.dev)
 website/

--- a/examples/template-todo/.gitignore
+++ b/examples/template-todo/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.vite

--- a/examples/template-todo/README.md
+++ b/examples/template-todo/README.md
@@ -1,0 +1,36 @@
+# whisq-template-todo
+
+A minimal, StackBlitz-runnable [Whisq](https://whisq.dev) todo app. Used by the whisq.dev docs as the target of the "Open in StackBlitz" button on `/examples/todo-app/`.
+
+## Run in StackBlitz
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/whisqjs/whisq/tree/main/examples/template-todo)
+
+## Run locally
+
+```bash
+git clone https://github.com/whisqjs/whisq.git
+cd whisq/examples/template-todo
+npm install
+npm run dev
+```
+
+## What the template demonstrates
+
+The canonical alpha.8 Whisq patterns, one per file:
+
+- **`src/main.ts`** — mount entrypoint.
+- **`src/App.ts`** — `errorBoundary` wrapping the mutable UI (so a thrown error in any child degrades gracefully).
+- **`src/stores/todos.ts`** — `persistedSignal<Todo[]>` with `onSchemaFailure` diagnostic, `randomId()` for keys, mutations exported as named actions.
+- **`src/components/TodoInput.ts`** — `bind()` for two-way input binding.
+- **`src/components/TodoList.ts`** — `match()` directly as a component root (no wrapper div), keyed `each()` with an `ItemAccessor<Todo>` render.
+- **`src/components/TodoItem.ts`** — `bindField()` for the checkbox toggle, `class:` array form with a reactive strikethrough getter.
+- **`src/styles.ts`** — `sheet()` with nested selectors (`&:hover`, `&:focus`) + `theme()` tokens.
+
+## Dependency contract
+
+The `@whisq/core` version in `package.json` is kept in lockstep with the monorepo via `scripts/sync-template-versions.mjs` on release. Every `pnpm run version` bump rewrites this file so `npm install @whisq/core` on StackBlitz resolves to a matching release.
+
+## License
+
+MIT (same as the framework).

--- a/examples/template-todo/index.html
+++ b/examples/template-todo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Whisq todo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/template-todo/package.json
+++ b/examples/template-todo/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "whisq-template-todo",
+  "version": "0.1.0",
+  "private": true,
+  "description": "StackBlitz-runnable Whisq todo-app template. Kept in sync with @whisq/core via scripts/sync-template-versions.mjs.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@whisq/core": "^0.1.0-alpha.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/examples/template-todo/src/App.ts
+++ b/examples/template-todo/src/App.ts
@@ -1,0 +1,33 @@
+import {
+  component,
+  div,
+  h1,
+  p,
+  button,
+  errorBoundary,
+} from "@whisq/core";
+import { TodoInput } from "./components/TodoInput";
+import { TodoList } from "./components/TodoList";
+import { s } from "./styles";
+
+export const App = component(() =>
+  div(
+    { class: s.app },
+    h1({ class: s.heading }, "Whisq todos"),
+    // errorBoundary wraps the mutable UI so a thrown error in any child
+    // degrades to a retry button instead of tearing down the whole app.
+    errorBoundary(
+      (err, retry) =>
+        div(
+          { class: s.error },
+          p("Something broke: " + err.message),
+          button({ class: s.btn, onclick: retry }, "Retry"),
+        ),
+      () =>
+        div(
+          TodoInput({}),
+          TodoList({}),
+        ),
+    ),
+  ),
+);

--- a/examples/template-todo/src/components/TodoInput.ts
+++ b/examples/template-todo/src/components/TodoInput.ts
@@ -1,0 +1,34 @@
+import {
+  component,
+  signal,
+  form,
+  input,
+  button,
+  bind,
+} from "@whisq/core";
+import { addTodo } from "../stores/todos";
+import { s } from "../styles";
+
+export const TodoInput = component(() => {
+  const draft = signal("");
+
+  const submit = (e: Event): void => {
+    e.preventDefault();
+    addTodo(draft.value);
+    draft.value = "";
+  };
+
+  return form(
+    { class: s.inputRow, onsubmit: submit },
+    input({
+      class: s.input,
+      type: "text",
+      placeholder: "What needs doing?",
+      // bind spread LAST — per the WHISQ-120 convention, spreading bind
+      // last makes it obvious if another handler gets wiped (since bind's
+      // handler would be the one that "wins" and overwrites yours).
+      ...bind(draft),
+    }),
+    button({ class: s.btn, type: "submit" }, "Add"),
+  );
+});

--- a/examples/template-todo/src/components/TodoItem.ts
+++ b/examples/template-todo/src/components/TodoItem.ts
@@ -1,0 +1,44 @@
+import {
+  component,
+  li,
+  input,
+  span,
+  button,
+  bindField,
+} from "@whisq/core";
+import type { ItemAccessor } from "@whisq/core";
+import { todos, removeTodo } from "../stores/todos";
+import type { Todo } from "../stores/todos";
+import { s } from "../styles";
+
+interface TodoItemProps {
+  todo: ItemAccessor<Todo>;
+}
+
+export const TodoItem = component((props: TodoItemProps) =>
+  li(
+    { class: s.item },
+    input({
+      type: "checkbox",
+      ...bindField(todos, props.todo, "done", { as: "checkbox" }),
+    }),
+    span(
+      // class: array form — strings + reactive getter, falsy-filtered.
+      {
+        class: [
+          s.itemText,
+          () => props.todo.value.done && s.doneText,
+        ],
+      },
+      () => props.todo.value.text,
+    ),
+    button(
+      {
+        class: s.removeBtn,
+        title: "Remove",
+        onclick: () => removeTodo(props.todo.value.id),
+      },
+      "×",
+    ),
+  ),
+);

--- a/examples/template-todo/src/components/TodoList.ts
+++ b/examples/template-todo/src/components/TodoList.ts
@@ -1,0 +1,43 @@
+import {
+  component,
+  div,
+  ul,
+  span,
+  button,
+  p,
+  each,
+  match,
+} from "@whisq/core";
+import { todos, clearDone, pendingCount } from "../stores/todos";
+import { TodoItem } from "./TodoItem";
+import { s } from "../styles";
+
+// `match()` works directly as a component root (WHISQ-121) — no sacrificial
+// wrapper div needed just to host the returned function.
+export const TodoList = component(() =>
+  match(
+    [
+      () => todos.value.length === 0,
+      () => p({ class: s.empty }, "Nothing yet. Add a todo above."),
+    ],
+    () =>
+      div(
+        ul(
+          { class: s.list },
+          each(
+            () => todos.value,
+            (todo) => TodoItem({ todo }),
+            { key: (t) => t.id },
+          ),
+        ),
+        div(
+          { class: s.footer },
+          span(() => `${pendingCount.value} pending`),
+          button(
+            { class: s.btn, onclick: clearDone },
+            "Clear done",
+          ),
+        ),
+      ),
+  ),
+);

--- a/examples/template-todo/src/main.ts
+++ b/examples/template-todo/src/main.ts
@@ -1,0 +1,4 @@
+import { mount } from "@whisq/core";
+import { App } from "./App";
+
+mount(App({}), document.getElementById("app")!);

--- a/examples/template-todo/src/stores/todos.ts
+++ b/examples/template-todo/src/stores/todos.ts
@@ -1,0 +1,41 @@
+import { computed } from "@whisq/core";
+import { persistedSignal } from "@whisq/core/persistence";
+import { randomId } from "@whisq/core/ids";
+
+export interface Todo {
+  id: string;
+  text: string;
+  done: boolean;
+}
+
+// Persisted signal: survives reloads, tabs share state. Schema versioned via
+// the key suffix — bump to `:v2` on shape change and the old value falls
+// back to the initial `[]`.
+export const todos = persistedSignal<Todo[]>("whisq-template-todo:v1", [], {
+  onSchemaFailure: (err) => {
+    console.warn("todos: failed to hydrate stored state, resetting", err);
+  },
+});
+
+export const pendingCount = computed(
+  () => todos.value.filter((t) => !t.done).length,
+);
+
+// Mutations as named actions — every write goes through one of these so
+// the "set of ways state can change" stays auditable.
+export const addTodo = (text: string): void => {
+  const trimmed = text.trim();
+  if (!trimmed) return;
+  todos.value = [
+    ...todos.value,
+    { id: randomId(), text: trimmed, done: false },
+  ];
+};
+
+export const removeTodo = (id: string): void => {
+  todos.value = todos.value.filter((t) => t.id !== id);
+};
+
+export const clearDone = (): void => {
+  todos.value = todos.value.filter((t) => !t.done);
+};

--- a/examples/template-todo/src/styles.ts
+++ b/examples/template-todo/src/styles.ts
@@ -1,0 +1,142 @@
+import { sheet, theme } from "@whisq/core";
+
+theme({
+  color: {
+    bg: "#0a0a12",
+    surface: "#111122",
+    card: "#1a1a2e",
+    primary: "#4F46E5",
+    accent: "#5CE0F2",
+    text: "#E2E8F0",
+    muted: "#94A3B8",
+    border: "#1E293B",
+    danger: "#dc2626",
+  },
+  radius: { sm: "6px", md: "8px", lg: "12px" },
+});
+
+export const s = sheet({
+  app: {
+    maxWidth: "560px",
+    margin: "0 auto",
+    padding: "2rem 1.5rem",
+    fontFamily: "system-ui, -apple-system, sans-serif",
+    color: "var(--color-text)",
+  },
+
+  heading: {
+    fontSize: "1.75rem",
+    fontWeight: "700",
+    marginBottom: "1.5rem",
+    background: "linear-gradient(90deg, #A78BFA, #5CE0F2)",
+    WebkitBackgroundClip: "text",
+    WebkitTextFillColor: "transparent",
+    backgroundClip: "text",
+  },
+
+  inputRow: {
+    display: "flex",
+    gap: "0.5rem",
+    marginBottom: "1.5rem",
+  },
+
+  input: {
+    flex: "1",
+    padding: "0.625rem 0.875rem",
+    borderRadius: "var(--radius-md)",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-card)",
+    color: "var(--color-text)",
+    fontSize: "1rem",
+    "&:focus": {
+      outline: "none",
+      borderColor: "var(--color-primary)",
+    },
+  },
+
+  btn: {
+    padding: "0.625rem 1rem",
+    borderRadius: "var(--radius-md)",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-card)",
+    color: "var(--color-text)",
+    fontSize: "0.95rem",
+    fontWeight: "600",
+    cursor: "pointer",
+    "&:hover": {
+      borderColor: "var(--color-primary)",
+      background: "var(--color-primary)",
+      color: "#ffffff",
+    },
+  },
+
+  list: {
+    listStyle: "none",
+    padding: "0",
+    margin: "0",
+  },
+
+  item: {
+    display: "flex",
+    alignItems: "center",
+    gap: "0.75rem",
+    padding: "0.75rem",
+    borderRadius: "var(--radius-md)",
+    background: "var(--color-card)",
+    marginBottom: "0.5rem",
+  },
+
+  itemText: {
+    flex: "1",
+    fontSize: "0.95rem",
+  },
+
+  doneText: {
+    textDecoration: "line-through",
+    color: "var(--color-muted)",
+  },
+
+  removeBtn: {
+    width: "32px",
+    height: "32px",
+    padding: "0",
+    borderRadius: "var(--radius-sm)",
+    border: "1px solid var(--color-border)",
+    background: "transparent",
+    color: "var(--color-muted)",
+    fontSize: "1.25rem",
+    lineHeight: "1",
+    cursor: "pointer",
+    "&:hover": {
+      borderColor: "var(--color-danger)",
+      color: "var(--color-danger)",
+    },
+  },
+
+  empty: {
+    color: "var(--color-muted)",
+    fontSize: "0.95rem",
+    fontStyle: "italic",
+    padding: "2rem 0",
+    textAlign: "center",
+  },
+
+  footer: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: "1rem",
+    padding: "0.75rem 0",
+    borderTop: "1px solid var(--color-border)",
+    fontSize: "0.875rem",
+    color: "var(--color-muted)",
+  },
+
+  error: {
+    padding: "1rem",
+    borderRadius: "var(--radius-md)",
+    background: "var(--color-card)",
+    border: "1px solid var(--color-danger)",
+    color: "var(--color-danger)",
+  },
+});

--- a/examples/template-todo/tsconfig.json
+++ b/examples/template-todo/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/examples/template-todo/vite.config.ts
+++ b/examples/template-todo/vite.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({});

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 // Verifies version consistency across the monorepo:
 //   1. Every `@whisq/*` package AND `create-whisq` in `packages/*` share the same version.
-//   2. Every `@whisq/*` reference inside `packages/create-whisq/src/templates/**/package.json.tmpl`
-//      resolves to that same version. Allowed forms: "X.Y.Z", "^X.Y.Z", "~X.Y.Z", "workspace:*".
+//   2. Every `@whisq/*` reference inside
+//      `packages/create-whisq/src/templates/**/package.json.tmpl` resolves to
+//      that same version. Allowed forms: "X.Y.Z", "^X.Y.Z", "~X.Y.Z", "workspace:*".
+//   3. Every `@whisq/*` reference inside `examples/*/package.json` (real
+//      runnable StackBlitz templates) follows the same rule.
 //
 // `create-whisq` is included so the scaffolder and the runtime packages
 // always release together. Enforced by the `fixed` group in
@@ -10,7 +13,7 @@
 //
 // Exits non-zero on any drift. Run in CI and as a gate inside /release.
 
-import { readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -46,12 +49,16 @@ for (const pkg of releasedPackages) {
   }
 }
 
-function walk(dir, out = []) {
+function walk(dir, matcher, out = []) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     const s = statSync(full);
-    if (s.isDirectory()) walk(full, out);
-    else if (entry === "package.json.tmpl") out.push(full);
+    if (s.isDirectory()) {
+      if (entry === "node_modules" || entry === "dist") continue;
+      walk(full, matcher, out);
+    } else if (matcher(entry, full)) {
+      out.push(full);
+    }
   }
   return out;
 }
@@ -59,9 +66,20 @@ function walk(dir, out = []) {
 const templatesDir = join(root, "packages", "create-whisq", "src", "templates");
 let templateFiles = [];
 try {
-  templateFiles = walk(templatesDir);
+  templateFiles = walk(templatesDir, (name) => name === "package.json.tmpl");
 } catch {
   errors.push(`Templates directory not found at ${relative(root, templatesDir)}`);
+}
+
+// Examples dir is optional — not every repo snapshot has runnable examples.
+const examplesDir = join(root, "examples");
+let exampleFiles = [];
+if (existsSync(examplesDir)) {
+  try {
+    exampleFiles = walk(examplesDir, (name) => name === "package.json");
+  } catch {
+    errors.push(`Examples directory walk failed at ${relative(root, examplesDir)}`);
+  }
 }
 
 const validSpec = (spec) => {
@@ -70,13 +88,13 @@ const validSpec = (spec) => {
   return stripped === referenceVersion;
 };
 
-for (const file of templateFiles) {
+function checkFile(file) {
   let pkg;
   try {
     pkg = JSON.parse(readFileSync(file, "utf8"));
   } catch (e) {
     errors.push(`${relative(root, file)} is not valid JSON: ${e.message}`);
-    continue;
+    return;
   }
   for (const section of ["dependencies", "devDependencies", "peerDependencies"]) {
     const deps = pkg[section] ?? {};
@@ -91,6 +109,9 @@ for (const file of templateFiles) {
   }
 }
 
+for (const file of templateFiles) checkFile(file);
+for (const file of exampleFiles) checkFile(file);
+
 if (errors.length > 0) {
   console.error("Version consistency check failed:");
   for (const err of errors) console.error(`  - ${err}`);
@@ -98,5 +119,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `Version consistency OK — ${releasedPackages.length} released packages at ${referenceVersion}, ${templateFiles.length} template(s) aligned.`,
+  `Version consistency OK — ${releasedPackages.length} released packages at ${referenceVersion}, ${templateFiles.length} template(s) + ${exampleFiles.length} example(s) aligned.`,
 );

--- a/scripts/sync-template-versions.mjs
+++ b/scripts/sync-template-versions.mjs
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
-// Rewrites every `@whisq/*` dep inside
-// `packages/create-whisq/src/templates/**/package.json.tmpl`
-// to match the current workspace version (the one in `packages/core/package.json`).
+// Rewrites every `@whisq/*` dep in two places to match the current workspace
+// version (the one in `packages/core/package.json`):
+//
+//   1. `packages/create-whisq/src/templates/**/package.json.tmpl` — the
+//      templates the CLI scaffolds from.
+//   2. `examples/*/package.json` — StackBlitz-runnable example apps that
+//      must pin to the latest release so `npm install` on StackBlitz
+//      resolves to something that works.
 //
 // Caret range is preserved. `workspace:*` specs are left alone.
-// Run after version bumps so scaffolded apps pick up the new release.
+// Run after version bumps so scaffolded apps + examples pick up the new
+// release.
 
-import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -21,18 +27,31 @@ if (!targetVersion) {
   process.exit(1);
 }
 
-function walk(dir, out = []) {
+function walk(dir, matcher, out = []) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     const s = statSync(full);
-    if (s.isDirectory()) walk(full, out);
-    else if (entry === "package.json.tmpl") out.push(full);
+    if (s.isDirectory()) {
+      // Skip node_modules inside examples — they can exist after a local
+      // `npm install` and we don't want to rewrite vendored files.
+      if (entry === "node_modules" || entry === "dist") continue;
+      walk(full, matcher, out);
+    } else if (matcher(entry, full)) {
+      out.push(full);
+    }
   }
   return out;
 }
 
 const templatesDir = join(root, "packages", "create-whisq", "src", "templates");
-const files = walk(templatesDir);
+const examplesDir = join(root, "examples");
+
+const files = [
+  ...walk(templatesDir, (name) => name === "package.json.tmpl"),
+  ...(existsSync(examplesDir)
+    ? walk(examplesDir, (name) => name === "package.json")
+    : []),
+];
 let changed = 0;
 
 for (const file of files) {
@@ -63,4 +82,6 @@ for (const file of files) {
   }
 }
 
-console.log(`Synced ${changed}/${files.length} template(s) to @whisq/*@${targetVersion}.`);
+console.log(
+  `Synced ${changed}/${files.length} template/example file(s) to @whisq/*@${targetVersion}.`,
+);


### PR DESCRIPTION
Closes #124. Unblocks whisqjs/whisq.dev#158 (the docs-side "Open in StackBlitz" button).

## Summary

whisq.dev#158 added an "Open in StackBlitz" button next to `/examples/todo-app/` on the docs site, but the existing `create-whisq` templates use `package.json.tmpl` files with placeholders the CLI fills in — StackBlitz can't consume those directly. This PR lands the prerequisite: a static, runnable Whisq todo app at `examples/template-todo/` that StackBlitz's GitHub-tree URL resolves to.

Once this merges to `main`:

```
https://stackblitz.com/github/whisqjs/whisq/tree/main/examples/template-todo
```

Decision vs the issue's options — **Option B tweaked**: placed the example at the **repo-root `examples/`** directory rather than `packages/template-todo/`. Putting it under `packages/` would register it as a pnpm workspace member and symlink `@whisq/core` from the monorepo, which would conflict with StackBlitz's `npm install` fetching the published `@whisq/core@0.1.0-alpha.8`. `pnpm-workspace.yaml` only claims `packages/*` + `tools/*`, so the example stays invisible to workspace tooling while still being a real git tree StackBlitz can walk.

## What the template demonstrates

Canonical alpha.8 patterns, one per file:

- **`stores/todos.ts`** — `persistedSignal<Todo[]>` with `onSchemaFailure`, `randomId()` for ids, mutations exported as named actions.
- **`components/TodoInput.ts`** — `bind()` (spread last, following the WHISQ-120 convention).
- **`components/TodoList.ts`** — `match()` directly as component root (no wrapper div — WHISQ-121), keyed `each()` with `ItemAccessor<Todo>` render.
- **`components/TodoItem.ts`** — `bindField()` checkbox, `class:` array form with reactive getter for strikethrough.
- **`App.ts`** — `errorBoundary` wrapping the mutable UI.
- **`styles.ts`** — `sheet()` nested selectors + `theme()` tokens.

## Infrastructure touches

- **`.gitignore`**: pattern changed from `examples/` (blanket ignore) to `examples/*` + `!examples/template-todo/` so the template is tracked but local experiments under `examples/` still are not.
- **`scripts/sync-template-versions.mjs`**: extended to also walk `examples/*/package.json` on release. Now covers both the CLI template tmpls and the runnable examples. Console output: `Synced X/Y template/example file(s) to @whisq/*@VERSION.`
- **`scripts/check-versions.mjs`**: same walk-extension for validation. CI check output now reads `X template(s) + Y example(s) aligned.`

## Test plan

- [x] `pnpm check:versions` → passes with "9 released packages at 0.1.0-alpha.8, 4 template(s) + 1 example(s) aligned."
- [x] Smoke-test: link `@whisq/core` into `examples/template-todo/node_modules/@whisq/core`, run `tsc --noEmit` against the example's tsconfig. Exits 0.
- [x] `pnpm -w build` clean across 9 packages.
- [x] `pnpm -w test` green: all 18 tasks; 428 core tests pass (unchanged — this PR doesn't touch `@whisq/core` source).
- [x] `aria-label` tripped Whisq's typed props on first cut (`aria-*` index signature isn't in `BaseProps`). Worked around by using `title="Remove"` — typed, accessible in tooltips, keeps the example within the sanctioned typed API surface.

## No changeset

Example addition is infrastructure — no published-package API changes. The `scripts/*` edits keep existing behaviour + add the `examples/` walker. Skip-changeset label applies.

## Out of scope

- Adding the StackBlitz button on whisq.dev — that's whisq.dev#158's remaining task; this PR is the prerequisite.
- Adding `aria-*` index signature to Whisq's element types — separate concern, file if it comes up again.
- Multi-example scaffolding infrastructure (option C from #124 — a post-process step in the CLI). Defer until we have >1 example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)