### PR TITLE
WHISQ-128: type aria-* attrs on BaseProps + fix aria-true serialisation

### DIFF
--- a/.changeset/aria-attribute-typing.md
+++ b/.changeset/aria-attribute-typing.md
@@ -1,0 +1,23 @@
+---
+"@whisq/core": minor
+---
+
+Typed `aria-*` attributes on every element. `BaseProps` now accepts `[key: \`aria-${string}\`]: ReactiveProp<string | boolean | undefined>` — mirrors the existing `data-*` pattern but with a wider value type because ARIA uses both enum-string attrs (`aria-live: "polite"`) and predicate-boolean attrs (`aria-expanded`, `aria-hidden`, `aria-pressed`).
+
+```ts
+// Before: typed props rejected aria-label; workaround was `title="Remove"`
+// (correct for tooltips, compromised for screen readers).
+button({ "aria-label": "Remove" }, "×");
+
+// Reactive ARIA also works:
+button({ "aria-expanded": () => menuOpen.value }, "menu");
+div({ "aria-live": "polite", "aria-atomic": true }, () => status.value);
+```
+
+Also fixes the **boolean serialisation bug** this exposed: the generic boolean-attribute branch in `applyProp` wrote `aria-expanded=""` for `true`, which is **invalid** per the ARIA spec — `aria-expanded=""` is not equivalent to `aria-expanded="true"`. A dedicated `aria-*` branch now serialises `true`/`false` to the strings `"true"` / `"false"`, and `undefined`/`null` still removes the attribute. String values pass through unchanged.
+
+Runtime cost: one `startsWith("aria-")` check per prop. Bundle size: 5.67 KB of 6 KB budget (+ ~20 B).
+
+Discovered during WHISQ-124 smoke-test; the `examples/template-todo/` remove button now uses `aria-label="Remove"` instead of the previous `title="Remove"` workaround.
+
+Closes WHISQ-128.

--- a/examples/template-todo/src/components/TodoItem.ts
+++ b/examples/template-todo/src/components/TodoItem.ts
@@ -35,7 +35,7 @@ export const TodoItem = component((props: TodoItemProps) =>
     button(
       {
         class: s.removeBtn,
-        title: "Remove",
+        "aria-label": "Remove",
         onclick: () => removeTodo(props.todo.value.id),
       },
       "×",

--- a/packages/core/src/__tests__/elements.test.ts
+++ b/packages/core/src/__tests__/elements.test.ts
@@ -459,3 +459,91 @@ describe("mount()", () => {
     expect(container.textContent).toBe("");
   });
 });
+
+// ── aria-* attribute typing + correct boolean serialisation (WHISQ-128) ─────
+
+describe("aria-* attributes", () => {
+  it("applies a static string aria-label", () => {
+    const node = button({ "aria-label": "Close" }, "×");
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.getAttribute("aria-label")).toBe("Close");
+  });
+
+  it("serialises boolean aria-* values as the strings 'true' / 'false'", () => {
+    // ARIA spec: `aria-expanded="true"` is the correct shape. The generic
+    // boolean-attribute branch in applyProp sets `key=""` for `value === true`,
+    // which is invalid for aria — empty string is NOT equivalent to "true" per
+    // the ARIA spec.
+    const expanded = button({ "aria-expanded": true }, "open");
+    dispose = mount(expanded, container);
+    expect(
+      (container.firstElementChild as HTMLElement).getAttribute("aria-expanded"),
+    ).toBe("true");
+  });
+
+  it("serialises boolean aria-expanded: false as the string 'false' (not removal)", () => {
+    const collapsed = button({ "aria-expanded": false }, "closed");
+    dispose = mount(collapsed, container);
+    expect(
+      (container.firstElementChild as HTMLElement).getAttribute("aria-expanded"),
+    ).toBe("false");
+  });
+
+  it("applies a reactive aria-hidden that toggles across renders", () => {
+    const hidden = signal(true);
+    const node = div({ "aria-hidden": () => hidden.value }, "region");
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.getAttribute("aria-hidden")).toBe("true");
+
+    hidden.value = false;
+    expect(el.getAttribute("aria-hidden")).toBe("false");
+  });
+
+  it("removes aria-* when the value is undefined", () => {
+    const current = signal<string | undefined>("Loading…");
+    const node = div({ "aria-live": () => current.value }, "status");
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.getAttribute("aria-live")).toBe("Loading…");
+
+    current.value = undefined;
+    expect(el.hasAttribute("aria-live")).toBe(false);
+
+    current.value = "polite";
+    expect(el.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("works with a reactive getter that returns a boolean (aria-pressed)", () => {
+    const pressed = signal(false);
+    const node = button(
+      { "aria-pressed": () => pressed.value },
+      "toggle",
+    );
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.getAttribute("aria-pressed")).toBe("false");
+    pressed.value = true;
+    expect(el.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("multiple aria-* attrs on one element all apply", () => {
+    const node = div(
+      {
+        "aria-label": "status",
+        "aria-live": "polite",
+        "aria-atomic": true,
+      },
+      "ready",
+    );
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.getAttribute("aria-label")).toBe("status");
+    expect(el.getAttribute("aria-live")).toBe("polite");
+    expect(el.getAttribute("aria-atomic")).toBe("true");
+  });
+});

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -128,6 +128,17 @@ interface BaseProps {
   hidden?: ReactiveProp<boolean>;
   title?: ReactiveProp<string | undefined>;
   [key: `data-${string}`]: ReactiveProp<string | undefined>;
+  /**
+   * ARIA attributes. Value types match how aria reads in HTML — strings
+   * for enum-valued attrs (`aria-live: "polite"`), booleans for
+   * predicate-shaped attrs (`aria-expanded`, `aria-hidden`,
+   * `aria-pressed`). Booleans serialise to the strings `"true"` and
+   * `"false"`, matching the ARIA spec — `aria-expanded=""` is NOT
+   * equivalent to `aria-expanded="true"`, and this typed path routes
+   * through a dedicated branch in `applyProp` that handles that.
+   * `undefined` / `null` removes the attribute.
+   */
+  [key: `aria-${string}`]: ReactiveProp<string | boolean | undefined>;
 }
 
 // Shared form-control event bundle, generic over the control's element type
@@ -1168,6 +1179,17 @@ function applyProp(el: Element, key: string, value: unknown): void {
     (el as HTMLInputElement).disabled = Boolean(value);
   } else if (key === "hidden") {
     (el as HTMLElement).hidden = Boolean(value);
+  } else if (key.startsWith("aria-")) {
+    // ARIA attributes need string "true"/"false", not empty string — per
+    // the ARIA spec, `aria-expanded=""` is NOT equivalent to
+    // `aria-expanded="true"`. Route boolean and string values through
+    // String() which produces the correct serialisation; null / undefined
+    // still remove the attribute.
+    if (value == null) {
+      el.removeAttribute(key);
+    } else {
+      el.setAttribute(key, String(value));
+    }
   } else if (value === false || value == null) {
     el.removeAttribute(key);
   } else if (value === true) {


### PR DESCRIPTION
Closes #128. Discovered during WHISQ-124 smoke-test.

## Summary

`BaseProps` gains `[key: \`aria-${string}\`]: ReactiveProp<string | boolean | undefined>`. Mirrors the existing `data-*` pattern; widens the value type because ARIA uses both **enum-string** attrs (`aria-live: "polite"`, `aria-orientation: "horizontal"`) and **predicate-boolean** attrs (`aria-expanded`, `aria-hidden`, `aria-pressed`, `aria-atomic`, …).

Discovered mid-session during WHISQ-124 smoke-test: the scaffolded template's `×` remove button wanted `aria-label="Remove"` and had to compromise on `title="Remove"`. That's now typed:

```ts
button({ "aria-label": "Remove", onclick: remove }, "×")
button({ "aria-expanded": () => menuOpen.value }, "menu")   // reactive boolean
div({ "aria-live": "polite", "aria-atomic": true }, status)
```

## Also fixed: silent ARIA-spec bug

The generic boolean-attribute branch in `applyProp` writes `key=""` for `value === true` — that works for `disabled`/`checked`/`required`/etc. (HTML boolean attrs) but is **invalid for ARIA**: `aria-expanded=""` is not equivalent to `aria-expanded="true"` per the ARIA spec. A dedicated `aria-*` branch now routes boolean values through `String()` so they serialise to the literal `"true"` / `"false"` strings. `undefined` / `null` still remove the attribute; string values pass through unchanged.

## Test plan

- [x] Static string: `button({ "aria-label": "Close" })` → attr set.
- [x] Static boolean `true`: `button({ "aria-expanded": true })` → `aria-expanded="true"` (not empty string).
- [x] Static boolean `false`: `button({ "aria-expanded": false })` → `aria-expanded="false"` (not removed — per the ARIA spec `false` is a meaningful state).
- [x] Reactive string getter: `div({ "aria-live": () => state.value })` tracks.
- [x] Reactive `undefined` return: attribute is removed; reassigning to a string restores it.
- [x] Reactive boolean getter: `button({ "aria-pressed": () => pressed.value })` tracks, serialises `"true"` / `"false"`.
- [x] Multiple aria-* attrs on one element: all apply correctly.
- [x] All 38 pre-existing element tests still pass.
- [x] Full suite: 435 core tests pass (was 428 → +7 new); 18 tasks green.
- [x] Bundle size: 5.67 KB of 6.0 KB budget (+ ~20 B for the new `applyProp` branch).
- [x] `examples/template-todo/src/components/TodoItem.ts` replaces its `title="Remove"` workaround with `aria-label="Remove"`; template smoke-test (`tsc --noEmit`) passes.

## Out of scope

- Promoting `role`, `tabindex`, `draggable` on `CommonProps` to `ReactiveProp<…>` (currently non-reactive `string` / `number` / `boolean`). Same family of gap but separate concern — will file if it comes up on a real use.
- Enumerating specific aria attrs with narrow string-literal unions (e.g. `aria-live: "polite" | "assertive" | "off"`). Defer until someone writes enough ARIA to feel the narrowing gap; the index signature gives them "it compiles" which is the minimum bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)