### PR TITLE
Release v0.1.0-alpha.9

### DIFF
--- a/.changeset/aria-attribute-typing.md
+++ b/.changeset/aria-attribute-typing.md
@@ -1,0 +1,23 @@
+---
+"@whisq/core": minor
+---
+
+Typed `aria-*` attributes on every element. `BaseProps` now accepts `[key: \`aria-${string}\`]: ReactiveProp<string | boolean | undefined>` — mirrors the existing `data-*` pattern but with a wider value type because ARIA uses both enum-string attrs (`aria-live: "polite"`) and predicate-boolean attrs (`aria-expanded`, `aria-hidden`, `aria-pressed`).
+
+```ts
+// Before: typed props rejected aria-label; workaround was `title="Remove"`
+// (correct for tooltips, compromised for screen readers).
+button({ "aria-label": "Remove" }, "×");
+
+// Reactive ARIA also works:
+button({ "aria-expanded": () => menuOpen.value }, "menu");
+div({ "aria-live": "polite", "aria-atomic": true }, () => status.value);
+```
+
+Also fixes the **boolean serialisation bug** this exposed: the generic boolean-attribute branch in `applyProp` wrote `aria-expanded=""` for `true`, which is **invalid** per the ARIA spec — `aria-expanded=""` is not equivalent to `aria-expanded="true"`. A dedicated `aria-*` branch now serialises `true`/`false` to the strings `"true"` / `"false"`, and `undefined`/`null` still removes the attribute. String values pass through unchanged.
+
+Runtime cost: one `startsWith("aria-")` check per prop. Bundle size: 5.67 KB of 6 KB budget (+ ~20 B).
+
+Discovered during WHISQ-124 smoke-test; the `examples/template-todo/` remove button now uses `aria-label="Remove"` instead of the previous `title="Remove"` workaround.
+
+Closes WHISQ-128.

--- a/.changeset/bind-duplicate-handler-warning.md
+++ b/.changeset/bind-duplicate-handler-warning.md
@@ -1,0 +1,21 @@
+---
+"@whisq/core": minor
+---
+
+Dev-only warning when spreading `bind()` / `bindField()` / `bindPath()` then overwriting one of its event handlers. Closes the production-bug window Claude's alpha.8 feedback called out as the top concern:
+
+```ts
+// Before: silently dropped bind's oninput, no warning.
+input({
+  ...bind(draft),
+  oninput: (e) => track(e),   // overwrites bind's oninput
+});
+
+// Now (in dev): console.warn with the tag, event name, and a fix hint.
+```
+
+Mechanism — the three bind helpers attach a symbol-keyed manifest of the handlers they declared to their return objects. Object spread copies symbol-keyed own properties, so the manifest survives into the final props. The element builder checks "for each declared handler, is the current prop handler still the one I declared?" On mismatch, `console.warn` (dev only; zero cost in production).
+
+**Known limitation.** Only catches _direction 1_ — spread-first, user-handler-second. _Direction 2_ (user handler first, `...bind(sig)` spread on top) cannot be detected from final props alone: by the time the element builder sees `props`, the user's original handler is gone without a trace. The warning message steers users toward the safer convention: spread bind LAST so it's your own handler that visibly "wins", making the collision obvious.
+
+Closes WHISQ-120.

--- a/.changeset/component-accepts-function-child-return.md
+++ b/.changeset/component-accepts-function-child-return.md
@@ -1,0 +1,37 @@
+---
+"@whisq/core": minor
+---
+
+`component()`'s setup function can now return a **function child** directly — the shape `match()` / `when()` / an ad-hoc `() => div(...)` produce. Previously, a component whose whole job was to render one of several branches needed a sacrificial wrapper `div` whose only purpose was to host the function child:
+
+```ts
+// Before — wrapper div has no job other than holding match()
+const Screen = component(() =>
+  div(
+    match(
+      [() => view.value === "loading", () => p("loading")],
+      [() => view.value === "data", () => DataView({})],
+      () => p("empty"),
+    ),
+  ),
+);
+
+// Now — match() is the component root directly
+const Screen = component(() =>
+  match(
+    [() => view.value === "loading", () => p("loading")],
+    [() => view.value === "data", () => DataView({})],
+    () => p("empty"),
+  ),
+);
+```
+
+Works for any zero-arg function return — `when()`, `match()`, or a plain `() => someNode`.
+
+Mechanism is the same fragment + start/end marker pattern `errorBoundary` and keyed `each` already use internally: a fragment holds markers that survive insertion into the real parent, and an effect renders the function's result between them on every source change. `onMount` / `onCleanup` hooks registered inside setup continue to fire as expected. Branch switches dispose the previous `WhisqNode` before inserting the next — no node leaks.
+
+Backwards compatible. The widened setup signature is `(props: P) => WhisqNode | (() => unknown)`; existing `component(() => div(...))` code is unaffected. Dev-mode `WhisqStructureError` messages now mention both accepted shapes.
+
+Bundle size: `@whisq/core` grows ~150 B gzipped (5.5 → 5.65 KB). The size-limit budget bumps from 5.5 KB to 6.0 KB to absorb this cost with room to grow, documented in `packages/core/.size-limit.cjs`.
+
+Closes WHISQ-121. The docs-side companion (whisqjs/whisq.dev#162) will need an update once the `/api/match/` page can point at "match() works directly as a component root" as the idiom.

--- a/.changeset/mount-sandboxed.md
+++ b/.changeset/mount-sandboxed.md
@@ -1,0 +1,37 @@
+---
+"@whisq/sandbox": minor
+---
+
+Add `mountSandboxed()` — render AI-generated (or otherwise untrusted) Whisq source into an isolated iframe on the current page. Complements the existing `createSandbox()` primitive (which evaluates code and returns a value) by covering the rendering-isolation use case that ArrowJS's WASM sandbox is known for — without the WASM cost.
+
+```ts
+import { mountSandboxed } from "@whisq/sandbox";
+
+const handle = mountSandboxed({
+  source: `
+    import { div, signal } from "@whisq/core";
+    const n = signal(0);
+    setInterval(() => (n.value += 1), 1000);
+    document.body.append(div(() => String(n.value)).el);
+    window.__whisqPost({ type: "ready" });
+  `,
+  container: document.getElementById("agent-output")!,
+  importMap: { "@whisq/core": "https://esm.sh/@whisq/core@latest" },
+  onMessage: (msg) => console.log("from sandbox:", msg),
+});
+
+handle.postMessage({ type: "shutdown" });
+handle.dispose();
+```
+
+Isolation is standards-only:
+
+- `<iframe sandbox="allow-scripts">` — unique origin; no same-origin access, no forms, no popups, no top-navigation.
+- `<meta http-equiv="Content-Security-Policy">` in the iframe's srcdoc — default policy is `default-src 'none'` with `script-src` allowing inline + origins from your `importMap`; override via `cspDirectives`.
+- `srcdoc` rather than `src=` — no network navigation; the iframe is a blank document we write into.
+- `__whisq`-tagged postMessage bridge — other frames can't spoof messages into the parent's `onMessage` callback. Parent-to-iframe messages arrive as a `whisq:parent` `CustomEvent` on the iframe-side `window`.
+- `</script>` and HTML comment closers inside the user source are escaped to prevent srcdoc injection.
+
+API shape is deliberately scaffolded so future `isolation: "worker"` / `isolation: "wasm"` backends can land without a breaking change.
+
+Closes WHISQ-118.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -16,11 +16,14 @@
     "access-shapes-canonical-doc",
     "accessor-boundaries-docs",
     "alpha-5-batch",
+    "aria-attribute-typing",
     "array-accepting-class-prop",
+    "bind-duplicate-handler-warning",
     "bindfield-dev-strict-mode",
     "bindfield-for-array-items",
     "bindpath-for-nested-records",
     "clarify-ref-accessor",
+    "component-accepts-function-child-return",
     "component-types-and-sheet-nested-selectors",
     "each-keyed-accessor-callback",
     "export-event-types",
@@ -28,11 +31,13 @@
     "full-app-template-canonical-shape",
     "hybrid-item-accessor-keyed-each",
     "match-api-clarity",
+    "mount-sandboxed",
     "partition-and-random-id-helpers",
     "persisted-signal",
     "persistedsignal-onschemafailure",
     "project-structure-conventions",
     "reactive-shapes-taxonomy",
+    "theme-duplicate-call-warning",
     "theme-sheet-ssr-guard"
   ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -16,15 +16,23 @@
     "access-shapes-canonical-doc",
     "accessor-boundaries-docs",
     "alpha-5-batch",
+    "array-accepting-class-prop",
+    "bindfield-dev-strict-mode",
     "bindfield-for-array-items",
     "bindpath-for-nested-records",
     "clarify-ref-accessor",
+    "component-types-and-sheet-nested-selectors",
     "each-keyed-accessor-callback",
     "export-event-types",
     "friendlier-runtime-errors",
+    "full-app-template-canonical-shape",
+    "hybrid-item-accessor-keyed-each",
     "match-api-clarity",
+    "partition-and-random-id-helpers",
     "persisted-signal",
+    "persistedsignal-onschemafailure",
     "project-structure-conventions",
-    "reactive-shapes-taxonomy"
+    "reactive-shapes-taxonomy",
+    "theme-sheet-ssr-guard"
   ]
 }

--- a/.changeset/theme-duplicate-call-warning.md
+++ b/.changeset/theme-duplicate-call-warning.md
@@ -1,0 +1,29 @@
+---
+"@whisq/core": minor
+---
+
+Dev-mode warning on duplicate `theme()` calls. Completes the alpha.7 `theme()` saga started by #99 / #105 (docs + SSR guard). Catches the failure mode Claude's alpha.8 feedback flagged: a multi-file project that imports two styles files and silently wipes the first theme's variables.
+
+```ts
+// styles.ts — app's primary theme
+import { theme } from "@whisq/core";
+theme({ color: { primary: "#4386FB" } });
+
+// another styles.ts elsewhere in the graph — accidentally imported
+import { theme } from "@whisq/core";
+theme({ color: { primary: "#ffffff" } });
+// Dev: console.warn names the conflict; production is silent.
+```
+
+New optional `silent?: boolean` on the `theme()` signature suppresses the warning for legitimate second calls (theme-switching toggles):
+
+```ts
+// Runtime theme switch — intentional; silent: true says "don't warn"
+theme(darkTokens, { silent: true });
+```
+
+Detection is DOM-based — a `getElementById("whisq-style-whisq-theme")` check. Production builds strip the entire guard via the existing `NODE_ENV !== "production"` pattern, so there's no runtime cost in shipped code. Each `theme()` is still last-call-wins: the warning doesn't change injection semantics, only surfaces when a second call would replace an existing block.
+
+Exported `ThemeOptions` type for callers who type their wrapper helpers.
+
+Closes WHISQ-122.

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,10 @@ CLAUDE.md
 
 # internal drafts
 draft/
-examples/
+# examples/ is gitignored by default to keep local experiments out of the
+# tree; committed example projects need an explicit un-ignore below.
+examples/*
+!examples/template-todo/
 
 # website (moved to whisqjs/whisq.dev)
 website/

--- a/examples/template-todo/.gitignore
+++ b/examples/template-todo/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.vite

--- a/examples/template-todo/README.md
+++ b/examples/template-todo/README.md
@@ -1,0 +1,36 @@
+# whisq-template-todo
+
+A minimal, StackBlitz-runnable [Whisq](https://whisq.dev) todo app. Used by the whisq.dev docs as the target of the "Open in StackBlitz" button on `/examples/todo-app/`.
+
+## Run in StackBlitz
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/whisqjs/whisq/tree/main/examples/template-todo)
+
+## Run locally
+
+```bash
+git clone https://github.com/whisqjs/whisq.git
+cd whisq/examples/template-todo
+npm install
+npm run dev
+```
+
+## What the template demonstrates
+
+The canonical alpha.8 Whisq patterns, one per file:
+
+- **`src/main.ts`** — mount entrypoint.
+- **`src/App.ts`** — `errorBoundary` wrapping the mutable UI (so a thrown error in any child degrades gracefully).
+- **`src/stores/todos.ts`** — `persistedSignal<Todo[]>` with `onSchemaFailure` diagnostic, `randomId()` for keys, mutations exported as named actions.
+- **`src/components/TodoInput.ts`** — `bind()` for two-way input binding.
+- **`src/components/TodoList.ts`** — `match()` directly as a component root (no wrapper div), keyed `each()` with an `ItemAccessor<Todo>` render.
+- **`src/components/TodoItem.ts`** — `bindField()` for the checkbox toggle, `class:` array form with a reactive strikethrough getter.
+- **`src/styles.ts`** — `sheet()` with nested selectors (`&:hover`, `&:focus`) + `theme()` tokens.
+
+## Dependency contract
+
+The `@whisq/core` version in `package.json` is kept in lockstep with the monorepo via `scripts/sync-template-versions.mjs` on release. Every `pnpm run version` bump rewrites this file so `npm install @whisq/core` on StackBlitz resolves to a matching release.
+
+## License
+
+MIT (same as the framework).

--- a/examples/template-todo/index.html
+++ b/examples/template-todo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Whisq todo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/template-todo/package.json
+++ b/examples/template-todo/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.8"
+    "@whisq/core": "^0.1.0-alpha.9"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/examples/template-todo/package.json
+++ b/examples/template-todo/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "whisq-template-todo",
+  "version": "0.1.0",
+  "private": true,
+  "description": "StackBlitz-runnable Whisq todo-app template. Kept in sync with @whisq/core via scripts/sync-template-versions.mjs.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@whisq/core": "^0.1.0-alpha.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/examples/template-todo/src/App.ts
+++ b/examples/template-todo/src/App.ts
@@ -1,0 +1,33 @@
+import {
+  component,
+  div,
+  h1,
+  p,
+  button,
+  errorBoundary,
+} from "@whisq/core";
+import { TodoInput } from "./components/TodoInput";
+import { TodoList } from "./components/TodoList";
+import { s } from "./styles";
+
+export const App = component(() =>
+  div(
+    { class: s.app },
+    h1({ class: s.heading }, "Whisq todos"),
+    // errorBoundary wraps the mutable UI so a thrown error in any child
+    // degrades to a retry button instead of tearing down the whole app.
+    errorBoundary(
+      (err, retry) =>
+        div(
+          { class: s.error },
+          p("Something broke: " + err.message),
+          button({ class: s.btn, onclick: retry }, "Retry"),
+        ),
+      () =>
+        div(
+          TodoInput({}),
+          TodoList({}),
+        ),
+    ),
+  ),
+);

--- a/examples/template-todo/src/components/TodoInput.ts
+++ b/examples/template-todo/src/components/TodoInput.ts
@@ -1,0 +1,34 @@
+import {
+  component,
+  signal,
+  form,
+  input,
+  button,
+  bind,
+} from "@whisq/core";
+import { addTodo } from "../stores/todos";
+import { s } from "../styles";
+
+export const TodoInput = component(() => {
+  const draft = signal("");
+
+  const submit = (e: Event): void => {
+    e.preventDefault();
+    addTodo(draft.value);
+    draft.value = "";
+  };
+
+  return form(
+    { class: s.inputRow, onsubmit: submit },
+    input({
+      class: s.input,
+      type: "text",
+      placeholder: "What needs doing?",
+      // bind spread LAST — per the WHISQ-120 convention, spreading bind
+      // last makes it obvious if another handler gets wiped (since bind's
+      // handler would be the one that "wins" and overwrites yours).
+      ...bind(draft),
+    }),
+    button({ class: s.btn, type: "submit" }, "Add"),
+  );
+});

--- a/examples/template-todo/src/components/TodoItem.ts
+++ b/examples/template-todo/src/components/TodoItem.ts
@@ -1,0 +1,44 @@
+import {
+  component,
+  li,
+  input,
+  span,
+  button,
+  bindField,
+} from "@whisq/core";
+import type { ItemAccessor } from "@whisq/core";
+import { todos, removeTodo } from "../stores/todos";
+import type { Todo } from "../stores/todos";
+import { s } from "../styles";
+
+interface TodoItemProps {
+  todo: ItemAccessor<Todo>;
+}
+
+export const TodoItem = component((props: TodoItemProps) =>
+  li(
+    { class: s.item },
+    input({
+      type: "checkbox",
+      ...bindField(todos, props.todo, "done", { as: "checkbox" }),
+    }),
+    span(
+      // class: array form — strings + reactive getter, falsy-filtered.
+      {
+        class: [
+          s.itemText,
+          () => props.todo.value.done && s.doneText,
+        ],
+      },
+      () => props.todo.value.text,
+    ),
+    button(
+      {
+        class: s.removeBtn,
+        title: "Remove",
+        onclick: () => removeTodo(props.todo.value.id),
+      },
+      "×",
+    ),
+  ),
+);

--- a/examples/template-todo/src/components/TodoItem.ts
+++ b/examples/template-todo/src/components/TodoItem.ts
@@ -35,7 +35,7 @@ export const TodoItem = component((props: TodoItemProps) =>
     button(
       {
         class: s.removeBtn,
-        title: "Remove",
+        "aria-label": "Remove",
         onclick: () => removeTodo(props.todo.value.id),
       },
       "×",

--- a/examples/template-todo/src/components/TodoList.ts
+++ b/examples/template-todo/src/components/TodoList.ts
@@ -1,0 +1,43 @@
+import {
+  component,
+  div,
+  ul,
+  span,
+  button,
+  p,
+  each,
+  match,
+} from "@whisq/core";
+import { todos, clearDone, pendingCount } from "../stores/todos";
+import { TodoItem } from "./TodoItem";
+import { s } from "../styles";
+
+// `match()` works directly as a component root (WHISQ-121) — no sacrificial
+// wrapper div needed just to host the returned function.
+export const TodoList = component(() =>
+  match(
+    [
+      () => todos.value.length === 0,
+      () => p({ class: s.empty }, "Nothing yet. Add a todo above."),
+    ],
+    () =>
+      div(
+        ul(
+          { class: s.list },
+          each(
+            () => todos.value,
+            (todo) => TodoItem({ todo }),
+            { key: (t) => t.id },
+          ),
+        ),
+        div(
+          { class: s.footer },
+          span(() => `${pendingCount.value} pending`),
+          button(
+            { class: s.btn, onclick: clearDone },
+            "Clear done",
+          ),
+        ),
+      ),
+  ),
+);

--- a/examples/template-todo/src/main.ts
+++ b/examples/template-todo/src/main.ts
@@ -1,0 +1,4 @@
+import { mount } from "@whisq/core";
+import { App } from "./App";
+
+mount(App({}), document.getElementById("app")!);

--- a/examples/template-todo/src/stores/todos.ts
+++ b/examples/template-todo/src/stores/todos.ts
@@ -1,0 +1,41 @@
+import { computed } from "@whisq/core";
+import { persistedSignal } from "@whisq/core/persistence";
+import { randomId } from "@whisq/core/ids";
+
+export interface Todo {
+  id: string;
+  text: string;
+  done: boolean;
+}
+
+// Persisted signal: survives reloads, tabs share state. Schema versioned via
+// the key suffix — bump to `:v2` on shape change and the old value falls
+// back to the initial `[]`.
+export const todos = persistedSignal<Todo[]>("whisq-template-todo:v1", [], {
+  onSchemaFailure: (err) => {
+    console.warn("todos: failed to hydrate stored state, resetting", err);
+  },
+});
+
+export const pendingCount = computed(
+  () => todos.value.filter((t) => !t.done).length,
+);
+
+// Mutations as named actions — every write goes through one of these so
+// the "set of ways state can change" stays auditable.
+export const addTodo = (text: string): void => {
+  const trimmed = text.trim();
+  if (!trimmed) return;
+  todos.value = [
+    ...todos.value,
+    { id: randomId(), text: trimmed, done: false },
+  ];
+};
+
+export const removeTodo = (id: string): void => {
+  todos.value = todos.value.filter((t) => t.id !== id);
+};
+
+export const clearDone = (): void => {
+  todos.value = todos.value.filter((t) => !t.done);
+};

--- a/examples/template-todo/src/styles.ts
+++ b/examples/template-todo/src/styles.ts
@@ -1,0 +1,142 @@
+import { sheet, theme } from "@whisq/core";
+
+theme({
+  color: {
+    bg: "#0a0a12",
+    surface: "#111122",
+    card: "#1a1a2e",
+    primary: "#4F46E5",
+    accent: "#5CE0F2",
+    text: "#E2E8F0",
+    muted: "#94A3B8",
+    border: "#1E293B",
+    danger: "#dc2626",
+  },
+  radius: { sm: "6px", md: "8px", lg: "12px" },
+});
+
+export const s = sheet({
+  app: {
+    maxWidth: "560px",
+    margin: "0 auto",
+    padding: "2rem 1.5rem",
+    fontFamily: "system-ui, -apple-system, sans-serif",
+    color: "var(--color-text)",
+  },
+
+  heading: {
+    fontSize: "1.75rem",
+    fontWeight: "700",
+    marginBottom: "1.5rem",
+    background: "linear-gradient(90deg, #A78BFA, #5CE0F2)",
+    WebkitBackgroundClip: "text",
+    WebkitTextFillColor: "transparent",
+    backgroundClip: "text",
+  },
+
+  inputRow: {
+    display: "flex",
+    gap: "0.5rem",
+    marginBottom: "1.5rem",
+  },
+
+  input: {
+    flex: "1",
+    padding: "0.625rem 0.875rem",
+    borderRadius: "var(--radius-md)",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-card)",
+    color: "var(--color-text)",
+    fontSize: "1rem",
+    "&:focus": {
+      outline: "none",
+      borderColor: "var(--color-primary)",
+    },
+  },
+
+  btn: {
+    padding: "0.625rem 1rem",
+    borderRadius: "var(--radius-md)",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-card)",
+    color: "var(--color-text)",
+    fontSize: "0.95rem",
+    fontWeight: "600",
+    cursor: "pointer",
+    "&:hover": {
+      borderColor: "var(--color-primary)",
+      background: "var(--color-primary)",
+      color: "#ffffff",
+    },
+  },
+
+  list: {
+    listStyle: "none",
+    padding: "0",
+    margin: "0",
+  },
+
+  item: {
+    display: "flex",
+    alignItems: "center",
+    gap: "0.75rem",
+    padding: "0.75rem",
+    borderRadius: "var(--radius-md)",
+    background: "var(--color-card)",
+    marginBottom: "0.5rem",
+  },
+
+  itemText: {
+    flex: "1",
+    fontSize: "0.95rem",
+  },
+
+  doneText: {
+    textDecoration: "line-through",
+    color: "var(--color-muted)",
+  },
+
+  removeBtn: {
+    width: "32px",
+    height: "32px",
+    padding: "0",
+    borderRadius: "var(--radius-sm)",
+    border: "1px solid var(--color-border)",
+    background: "transparent",
+    color: "var(--color-muted)",
+    fontSize: "1.25rem",
+    lineHeight: "1",
+    cursor: "pointer",
+    "&:hover": {
+      borderColor: "var(--color-danger)",
+      color: "var(--color-danger)",
+    },
+  },
+
+  empty: {
+    color: "var(--color-muted)",
+    fontSize: "0.95rem",
+    fontStyle: "italic",
+    padding: "2rem 0",
+    textAlign: "center",
+  },
+
+  footer: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: "1rem",
+    padding: "0.75rem 0",
+    borderTop: "1px solid var(--color-border)",
+    fontSize: "0.875rem",
+    color: "var(--color-muted)",
+  },
+
+  error: {
+    padding: "1rem",
+    borderRadius: "var(--radius-md)",
+    background: "var(--color-card)",
+    border: "1px solid var(--color-danger)",
+    color: "var(--color-danger)",
+  },
+});

--- a/examples/template-todo/tsconfig.json
+++ b/examples/template-todo/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/examples/template-todo/vite.config.ts
+++ b/examples/template-todo/vite.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({});

--- a/packages/core/.size-limit.cjs
+++ b/packages/core/.size-limit.cjs
@@ -3,11 +3,16 @@
 // this strips dev-only validators (`if (process.env.NODE_ENV !== "production")
 // { ... }`) before measuring, giving a size number that matches what users'
 // production bundlers will actually ship.
+//
+// Budget: 6.0 KB gzipped. Bumped from 5.5 → 6.0 in WHISQ-121 when
+// component() gained the function-child lift (marker-pair + effect-driven
+// re-render). The bump is intentional — ~150 B for closing a both-reviewer
+// P1 ergonomic concern is a worthwhile trade.
 
 module.exports = [
   {
     path: "dist/index.js",
-    limit: "5.5 KB",
+    limit: "6.0 KB",
     gzip: true,
     modifyEsbuildConfig(config) {
       config.define = {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,130 @@
 # @whisq/core
 
+## 0.1.0-alpha.8
+
+### Minor Changes
+
+- 8f645a8: The `class:` prop on every element now accepts an **array of sources** with per-source reactivity. Strings are class names; falsy values (`false | null | undefined | 0 | ""`) are filtered out — enabling the `cond && "active"` shorthand inline; functions are reactive — each function is called during the render effect and re-reads when its tracked signals change.
+
+  ```ts
+  div({
+    class: [
+      "btn",
+      () => `btn-${variant.value}`, // reactive
+      loading.value && "btn-loading", // static conditional — cond && "…"
+      () => isDisabled.value && "disabled", // reactive conditional
+    ],
+  });
+  ```
+
+  If any array element is a function, the array is applied reactively; otherwise it's applied once at mount. This removes the `cx` vs `rcx` migration footgun Claude's alpha.7 feedback flagged — you no longer have to remember which helper to import when a class prop grows a reactive branch mid-edit.
+
+  `cx` and `rcx` continue to work unchanged — this is a pure addition. A future release may collapse them into a single composition helper (see WHISQ-97 option A) but that change is deferred.
+
+  Closes WHISQ-97 option B. Options A (unified `cx`) and the `rcx` deprecation path remain open on the issue for a follow-up cycle.
+
+- 401bfca: `bindField` now throws a `WhisqKeyByError` on no-match writes in dev mode (default `process.env.NODE_ENV !== "production"`) instead of silently logging to the console. A stale accessor or broken `keyBy` now surfaces immediately at the first click in `vite dev` instead of drowning in the console.
+
+  New option `strict?: boolean` lets callers pin the behaviour explicitly — `strict: true` throws in both envs; `strict: false` keeps the legacy warn-and-discard even in dev. Production behaviour is unchanged (warn-and-discard) unless `strict: true` is set.
+
+  ```ts
+  // Default in vite dev: throws WhisqKeyByError
+  input({ ...bindField(todos, todo, "done", { as: "checkbox" }) });
+
+  // Opt out if a test deliberately exercises the no-match path:
+  input({
+    ...bindField(todos, todo, "done", { as: "checkbox", strict: false }),
+  });
+  ```
+
+  `WhisqKeyByError` carries `sourceKeys`, `targetKey`, and `field` so the error tells you what was in the source at write time vs. what the accessor was looking for. Both the error class and its `WhisqKeyByErrorFields` type are exported from `@whisq/core`.
+
+  Closes WHISQ-100.
+
+- 0c1dccf: Fix `component()` and `sheet()` type signatures so that apps scaffolded from `create-whisq@latest` type-check cleanly under `tsc --strict`.
+
+  Previously, `component()` was typed as `(props) => WhisqTemplate` — a legacy template-literal shape (`{ fragment, bindings, dispose }`) — while every element function (`div`, `span`, etc.) returns `WhisqNode` (`{ el, disposers, dispose, __whisq }`). The two shapes were incompatible, so **every** hyperscript component setup failed `tsc --strict` with _"Type 'WhisqNode' is missing properties: fragment, bindings"_. The runtime check in `component.ts` already required `WhisqNode`-shaped output, so the types were wrong for the documented and actually-supported API.
+
+  Changes:
+  - **`component<P>(setup: (props: P) => WhisqNode): ComponentDef<P>`** — setup now returns `WhisqNode`, matching the runtime guard and the hyperscript API that the LLM reference, docs, and starter templates all use. The JSDoc example switches from the legacy `html\`...\`` form to the hyperscript form.
+  - **`ComponentDef<P>` call signature** — returns `WhisqNode` so components compose inside elements (`div(MyComponent({}))` now type-checks).
+  - **`sheet()` nested selectors** — `StyleRule` is now recursive (`{ [key: string]: StyleValue | StyleRule }`), so mixing base CSS properties and nested rules (`"&:hover": { … }`, `"& a": { "&:hover": { … } }`, `"@media (…)": { … }`) under the same top-level key type-checks. The runtime behaviour is unchanged — the prefix convention is still the source of truth for which keys are nested vs base.
+
+  Breaking: if any code relied on the old `(props) => WhisqTemplate` signature (the tagged-template `html\`...\``path was already rejected by`component()`'s runtime check, so it couldn't actually have been in production use), it needs to return a `WhisqNode` instead.
+
+  Closes WHISQ-108. The `html` tagged-template API and `WhisqTemplate` type remain in `@whisq/core/template` for internal use; fully removing them is tracked as a follow-up to #108.
+
+- 91740a2: Keyed `each()`'s render callback now receives a **hybrid accessor** — callable (`todo()`) **and** signal-shaped (`todo.value`, `todo.peek()`). Joins the uniform `() => sig.value` reactive-access rule that holds everywhere else in the API; closes the last pocket of divergence both reviewers flagged in alpha.7 feedback.
+
+  ```ts
+  each(
+    () => todos.value,
+    (todo) =>
+      li(
+        { class: () => (todo.value.done ? "done" : "") }, // new canonical shape
+        span(() => todo.value.text),
+        button({ onclick: () => remove(todo.value.id) }, "✕"),
+      ),
+    { key: (t) => t.id },
+  );
+  ```
+
+  **Non-breaking.** The accessor is still a plain function at call sites that want `todo()`, and structurally assignable to `() => T` — so `bindField(todos, todo, "done", { as: "checkbox" })` and every other helper that types its input as `() => T` works unchanged. Existing call sites do not need to migrate; new code should prefer `todo.value.<field>` for consistency with the rest of the reactive-access rule.
+
+  `index` follows the same pattern — `index()` (legacy) and `index.value` / `index.peek()` (new) both work.
+
+  New exported type: `ItemAccessor<T>` (from `@whisq/core`).
+
+  Addresses WHISQ-96 with the hybrid approach — option A's `.value` shape without the breaking-change downside. Partially closes the issue; the docs-side cookbook in `whisq.dev#108` (D-1) should adopt the `.value` shape as the canonical example going forward.
+
+- 2809555: Two opt-in utility helpers, both on sub-path imports so apps that don't use them pay no bundle cost.
+  - **`partition(source, predicate)`** from `@whisq/core/collections` — split a signal-held array into two `ReadonlySignal<T[]>` sides (matching / not-matching). Source order is preserved on both sides; each side is an independent `computed()` that only re-runs effects subscribed to it. The canonical use is "active" vs "done" on a todo list without hand-rolling two `computed`s.
+
+    ```ts
+    import { partition } from "@whisq/core/collections";
+
+    const todos = signal<Todo[]>([...]);
+    const [pending, done] = partition(() => todos.value, (t) => !t.done);
+    button({ onclick: () => (todos.value = pending.value) }, "Clear completed");
+    ```
+
+  - **`randomId()`** from `@whisq/core/ids` — UUID-v4-shaped random identifier. Uses native `crypto.randomUUID()` when available (all modern browsers, Node 19+, Deno, Bun); falls back to a `Math.random`-based synthesis with the same v4 shape for older targets (old Safari, pre-19 Node). Same output shape on both paths, so callers don't have to branch. Suitable for UI row ids and keyed-`each` keys — **not** for security tokens (the fallback is not cryptographically strong).
+
+    ```ts
+    import { randomId } from "@whisq/core/ids";
+
+    const newTodo = { id: randomId(), text, done: false };
+    ```
+
+  Top-level `@whisq/core` bundle stays at 5.5 KB gzipped. Closes WHISQ-101.
+
+- 1b669b4: Add `onSchemaFailure?: (err: unknown, raw: string) => void` option to `persistedSignal`. Invoked synchronously **before** fallback to `initial` when `deserialize` throws (malformed stored JSON) or `schema` throws (validator rejects). Receives the thrown error and the exact raw string read from storage — use it to log to Sentry / show a recovery UI / decide between migrate-vs-reset.
+
+  ```ts
+  const todos = persistedSignal<Todo[]>("todos", [], {
+    schema: validateTodosShape,
+    onSchemaFailure: (err, raw) => {
+      Sentry.captureException(err, { extra: { key: "todos", raw } });
+    },
+  });
+  ```
+
+  The callback is **not** invoked on first-visit (`raw` would be `null`, not a failure) or on storage-access errors (private mode, disabled storage — environment faults, not schema faults). If the callback itself throws, the exception is caught and logged via `console.warn` so a broken diagnostic pipeline can't prevent signal construction.
+
+  Closes WHISQ-98.
+
+### Patch Changes
+
+- 0afc98b: Fix `theme()` and `sheet()` throwing `ReferenceError: document is not defined` under SSR (server-side rendering). The shared internal `injectCSS()` helper now short-circuits when `typeof document === "undefined"`, matching the SSR-safe pattern that `persistedSignal` already uses.
+
+  User-observable impact:
+  - **`theme()`**: SSR call is a no-op (no `<style>` tag is written; client-side hydration takes over on mount). Previously threw.
+  - **`sheet()`**: SSR call returns the in-memory classMap (so server-rendered HTML can reference the correct class names for the client to hydrate against), but skips the DOM injection step. Previously threw on the injection line.
+
+  Also clarified `theme()` JSDoc: **"call once at module scope"** and **"duplicate calls = last-call-wins"** are now explicit (the duplicate-calls behavior already held; the docs didn't say so).
+
+  Closes WHISQ-99 (framework side). Docs work on whisq.dev — the `/core-concepts/styling/` and `/api/theme/` pages — will land as a companion PR in that repo.
+
 ## 0.1.0-alpha.7
 
 ### Minor Changes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,107 @@
 # @whisq/core
 
+## 0.1.0-alpha.9
+
+### Minor Changes
+
+- defc7eb: Typed `aria-*` attributes on every element. `BaseProps` now accepts `[key: \`aria-${string}\`]: ReactiveProp<string | boolean | undefined>`— mirrors the existing`data-\*` pattern but with a wider value type because ARIA uses both enum-string attrs (`aria-live: "polite"`) and predicate-boolean attrs (`aria-expanded`, `aria-hidden`, `aria-pressed`).
+
+  ```ts
+  // Before: typed props rejected aria-label; workaround was `title="Remove"`
+  // (correct for tooltips, compromised for screen readers).
+  button({ "aria-label": "Remove" }, "×");
+
+  // Reactive ARIA also works:
+  button({ "aria-expanded": () => menuOpen.value }, "menu");
+  div({ "aria-live": "polite", "aria-atomic": true }, () => status.value);
+  ```
+
+  Also fixes the **boolean serialisation bug** this exposed: the generic boolean-attribute branch in `applyProp` wrote `aria-expanded=""` for `true`, which is **invalid** per the ARIA spec — `aria-expanded=""` is not equivalent to `aria-expanded="true"`. A dedicated `aria-*` branch now serialises `true`/`false` to the strings `"true"` / `"false"`, and `undefined`/`null` still removes the attribute. String values pass through unchanged.
+
+  Runtime cost: one `startsWith("aria-")` check per prop. Bundle size: 5.67 KB of 6 KB budget (+ ~20 B).
+
+  Discovered during WHISQ-124 smoke-test; the `examples/template-todo/` remove button now uses `aria-label="Remove"` instead of the previous `title="Remove"` workaround.
+
+  Closes WHISQ-128.
+
+- c8f2bec: Dev-only warning when spreading `bind()` / `bindField()` / `bindPath()` then overwriting one of its event handlers. Closes the production-bug window Claude's alpha.8 feedback called out as the top concern:
+
+  ```ts
+  // Before: silently dropped bind's oninput, no warning.
+  input({
+    ...bind(draft),
+    oninput: (e) => track(e), // overwrites bind's oninput
+  });
+
+  // Now (in dev): console.warn with the tag, event name, and a fix hint.
+  ```
+
+  Mechanism — the three bind helpers attach a symbol-keyed manifest of the handlers they declared to their return objects. Object spread copies symbol-keyed own properties, so the manifest survives into the final props. The element builder checks "for each declared handler, is the current prop handler still the one I declared?" On mismatch, `console.warn` (dev only; zero cost in production).
+
+  **Known limitation.** Only catches _direction 1_ — spread-first, user-handler-second. _Direction 2_ (user handler first, `...bind(sig)` spread on top) cannot be detected from final props alone: by the time the element builder sees `props`, the user's original handler is gone without a trace. The warning message steers users toward the safer convention: spread bind LAST so it's your own handler that visibly "wins", making the collision obvious.
+
+  Closes WHISQ-120.
+
+- e6d59c4: `component()`'s setup function can now return a **function child** directly — the shape `match()` / `when()` / an ad-hoc `() => div(...)` produce. Previously, a component whose whole job was to render one of several branches needed a sacrificial wrapper `div` whose only purpose was to host the function child:
+
+  ```ts
+  // Before — wrapper div has no job other than holding match()
+  const Screen = component(() =>
+    div(
+      match(
+        [() => view.value === "loading", () => p("loading")],
+        [() => view.value === "data", () => DataView({})],
+        () => p("empty"),
+      ),
+    ),
+  );
+
+  // Now — match() is the component root directly
+  const Screen = component(() =>
+    match(
+      [() => view.value === "loading", () => p("loading")],
+      [() => view.value === "data", () => DataView({})],
+      () => p("empty"),
+    ),
+  );
+  ```
+
+  Works for any zero-arg function return — `when()`, `match()`, or a plain `() => someNode`.
+
+  Mechanism is the same fragment + start/end marker pattern `errorBoundary` and keyed `each` already use internally: a fragment holds markers that survive insertion into the real parent, and an effect renders the function's result between them on every source change. `onMount` / `onCleanup` hooks registered inside setup continue to fire as expected. Branch switches dispose the previous `WhisqNode` before inserting the next — no node leaks.
+
+  Backwards compatible. The widened setup signature is `(props: P) => WhisqNode | (() => unknown)`; existing `component(() => div(...))` code is unaffected. Dev-mode `WhisqStructureError` messages now mention both accepted shapes.
+
+  Bundle size: `@whisq/core` grows ~150 B gzipped (5.5 → 5.65 KB). The size-limit budget bumps from 5.5 KB to 6.0 KB to absorb this cost with room to grow, documented in `packages/core/.size-limit.cjs`.
+
+  Closes WHISQ-121. The docs-side companion (whisqjs/whisq.dev#162) will need an update once the `/api/match/` page can point at "match() works directly as a component root" as the idiom.
+
+- 75d2d8e: Dev-mode warning on duplicate `theme()` calls. Completes the alpha.7 `theme()` saga started by #99 / #105 (docs + SSR guard). Catches the failure mode Claude's alpha.8 feedback flagged: a multi-file project that imports two styles files and silently wipes the first theme's variables.
+
+  ```ts
+  // styles.ts — app's primary theme
+  import { theme } from "@whisq/core";
+  theme({ color: { primary: "#4386FB" } });
+
+  // another styles.ts elsewhere in the graph — accidentally imported
+  import { theme } from "@whisq/core";
+  theme({ color: { primary: "#ffffff" } });
+  // Dev: console.warn names the conflict; production is silent.
+  ```
+
+  New optional `silent?: boolean` on the `theme()` signature suppresses the warning for legitimate second calls (theme-switching toggles):
+
+  ```ts
+  // Runtime theme switch — intentional; silent: true says "don't warn"
+  theme(darkTokens, { silent: true });
+  ```
+
+  Detection is DOM-based — a `getElementById("whisq-style-whisq-theme")` check. Production builds strip the entire guard via the existing `NODE_ENV !== "production"` pattern, so there's no runtime cost in shipped code. Each `theme()` is still last-call-wins: the warning doesn't change injection semantics, only surfaces when a second call would replace an existing block.
+
+  Exported `ThemeOptions` type for callers who type their wrapper helpers.
+
+  Closes WHISQ-122.
+
 ## 0.1.0-alpha.8
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/__tests__/bind.test.ts
+++ b/packages/core/src/__tests__/bind.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { signal } from "../reactive.js";
 import { input, textarea, select, option, mount } from "../elements.js";
 import { bind } from "../bind.js";
+import { bindField } from "../bindField.js";
+import { bindPath } from "../bindPath.js";
 
 let container: HTMLElement;
 let dispose: () => void;
@@ -177,5 +179,151 @@ describe("bind() — input validation", () => {
     expect(() => bind({} as never)).toThrow(TypeError);
     expect(() => bind(null as never)).toThrow(TypeError);
     expect(() => bind("not a signal" as never)).toThrow(TypeError);
+  });
+});
+
+// ── Duplicate-handler dev warning (WHISQ-120) ───────────────────────────────
+//
+// Dev-only detection of the "spread bind() then overwrite the same event
+// handler" footgun. The sentinel mechanism lives in bind-sentinel.ts and
+// catches direction 1 (spread first, user handler second). Direction 2
+// (user handler first, bind spread second) isn't detectable from final
+// props — documented limitation.
+
+describe("bind() duplicate-handler warning (direction 1)", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("warns when ...bind(sig) is followed by an overriding oninput", () => {
+    const name = signal("");
+    dispose = mount(
+      input({ ...bind(name), oninput: () => {} }),
+      container,
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0]![0] as string;
+    expect(msg).toContain("duplicate handler");
+    expect(msg).toContain('"oninput"');
+    expect(msg).toContain("<input>");
+  });
+
+  it("warns when ...bind(sig, checkbox) is followed by an overriding onchange", () => {
+    const agreed = signal(false);
+    dispose = mount(
+      input({
+        type: "checkbox",
+        ...bind(agreed, { as: "checkbox" }),
+        onchange: () => {},
+      }),
+      container,
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0]![0] as string;
+    expect(msg).toContain('"onchange"');
+  });
+
+  it("does NOT warn on the clean use — ...bind(sig) alone", () => {
+    const name = signal("");
+    dispose = mount(input({ ...bind(name) }), container);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns once per overwritten handler (not per key in the sentinel)", () => {
+    // bind() text returns { value, oninput }. value is not an on* handler,
+    // so only oninput is tracked. Overwriting oninput → one warning.
+    // Overwriting value (a non-handler) → no warning.
+    const name = signal("");
+    dispose = mount(
+      input({ ...bind(name), value: "override", oninput: () => {} }),
+      container,
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT warn in production", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const name = signal("");
+      dispose = mount(
+        input({ ...bind(name), oninput: () => {} }),
+        container,
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it("known limitation: does NOT warn when user handler is written first, then bind is spread on top (direction 2)", () => {
+    // This is an honest acknowledgement of the runtime limitation — by the
+    // time the element builder sees props, direction-2 overwrites have
+    // already lost their trace. The user's handler is gone, but the sentinel
+    // matches the current oninput so no warning fires. Documented in the
+    // warning message's hint: "spread bind LAST so your handler is the one
+    // that gets wiped (usually the bug you want)."
+    const name = signal("");
+    dispose = mount(
+      input({ oninput: () => {}, ...bind(name) }),
+      container,
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("bindField() duplicate-handler warning (direction 1)", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("warns when bindField's onchange is overwritten by a later handler", () => {
+    type Todo = { id: string; done: boolean };
+    const todos = signal<Todo[]>([{ id: "a", done: false }]);
+    const todo = () => todos.value[0]!;
+    dispose = mount(
+      input({
+        type: "checkbox",
+        ...bindField(todos, todo, "done", { as: "checkbox" }),
+        onchange: () => {},
+      }),
+      container,
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('"onchange"'),
+    );
+  });
+});
+
+describe("bindPath() duplicate-handler warning (direction 1)", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("warns when bindPath's oninput is overwritten by a later handler", () => {
+    type User = { profile: { email: string } };
+    const user = signal<User>({ profile: { email: "" } });
+    dispose = mount(
+      input({
+        ...bindPath(user, ["profile", "email"]),
+        oninput: () => {},
+      }),
+      container,
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('"oninput"'),
+    );
   });
 });

--- a/packages/core/src/__tests__/component.test.ts
+++ b/packages/core/src/__tests__/component.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { signal } from "../reactive.js";
-import { div, span, button, p, mount } from "../elements.js";
+import { div, span, button, p, mount, match, when } from "../elements.js";
 import { component, onMount, onCleanup, resource } from "../component.js";
 import type { WhisqNode } from "../elements.js";
 
@@ -395,5 +395,176 @@ describe("resource()", () => {
     await vi.waitFor(() => expect(r.data()).toBe("ok-abc"));
     expect(capturedSrc).toBe("abc");
     expect(capturedSignal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+// ── Function-return setup (WHISQ-121) ───────────────────────────────────────
+//
+// Components can return a function child directly from setup — no sacrificial
+// wrapper div needed to host a match() / when() / ad-hoc getter.
+
+describe("component() — function-return setup", () => {
+  it("renders match() directly as a component root (no wrapper)", () => {
+    type View = "loading" | "data" | "empty";
+    const view = signal<View>("loading");
+
+    const Screen = component(() =>
+      match(
+        [() => view.value === "loading", () => p("loading...")],
+        [() => view.value === "data", () => p("hello")],
+        () => p("empty"),
+      ),
+    );
+
+    dispose = mount(Screen({}), container);
+    expect(container.textContent).toBe("loading...");
+
+    view.value = "data";
+    expect(container.textContent).toBe("hello");
+
+    view.value = "empty";
+    expect(container.textContent).toBe("empty");
+  });
+
+  it("renders when() as a component root", () => {
+    const loggedIn = signal(false);
+
+    const Auth = component(() =>
+      when(
+        () => loggedIn.value,
+        () => p("welcome back"),
+        () => p("sign in"),
+      ),
+    );
+
+    dispose = mount(Auth({}), container);
+    expect(container.textContent).toBe("sign in");
+
+    loggedIn.value = true;
+    expect(container.textContent).toBe("welcome back");
+  });
+
+  it("renders an ad-hoc () => value getter as a component root", () => {
+    const name = signal("world");
+
+    const Greeting = component(() => () => div(`hello ${name.value}`));
+
+    dispose = mount(Greeting({}), container);
+    expect(container.textContent).toBe("hello world");
+
+    name.value = "whisq";
+    expect(container.textContent).toBe("hello whisq");
+  });
+
+  it("existing plain-WhisqNode return still works (backwards compat)", () => {
+    const Counter = component(() => div("42"));
+    dispose = mount(Counter({}), container);
+    expect(container.textContent).toBe("42");
+  });
+
+  it("fires onMount + onCleanup for function-return components", () => {
+    const mounted = vi.fn();
+    const cleaned = vi.fn();
+    const visible = signal(true);
+
+    const Widget = component(() => {
+      onMount(mounted);
+      onCleanup(cleaned);
+      return match([() => visible.value, () => p("on")], () => p("off"));
+    });
+
+    dispose = mount(Widget({}), container);
+    return new Promise<void>((resolve) => {
+      queueMicrotask(() => {
+        expect(mounted).toHaveBeenCalledTimes(1);
+        expect(cleaned).not.toHaveBeenCalled();
+        dispose();
+        expect(cleaned).toHaveBeenCalledTimes(1);
+        resolve();
+      });
+    });
+  });
+
+  it("renders nothing when setup's function returns null", () => {
+    const show = signal(false);
+    const Maybe = component(() => () => (show.value ? p("yes") : null));
+
+    dispose = mount(Maybe({}), container);
+    expect(container.textContent).toBe("");
+
+    show.value = true;
+    expect(container.textContent).toBe("yes");
+
+    show.value = false;
+    expect(container.textContent).toBe("");
+  });
+
+  it("disposes the current WhisqNode on each branch switch (no node leak)", () => {
+    const n = signal(0);
+    const disposeCount = { a: 0, b: 0 };
+
+    const A = component(() => {
+      onCleanup(() => disposeCount.a++);
+      return p("a");
+    });
+    const B = component(() => {
+      onCleanup(() => disposeCount.b++);
+      return p("b");
+    });
+
+    const Switcher = component(() =>
+      match([() => n.value === 0, () => A({})], () => B({})),
+    );
+
+    dispose = mount(Switcher({}), container);
+    expect(container.textContent).toBe("a");
+    expect(disposeCount).toEqual({ a: 0, b: 0 });
+
+    n.value = 1;
+    expect(container.textContent).toBe("b");
+    expect(disposeCount.a).toBe(1); // A's cleanup ran on branch switch
+
+    n.value = 0;
+    expect(container.textContent).toBe("a");
+    expect(disposeCount.b).toBe(1); // B's cleanup ran on branch switch
+  });
+
+  it("full disposal cleans up effect + current child", () => {
+    const n = signal(0);
+    const cleaned = vi.fn();
+
+    const Inner = component(() => {
+      onCleanup(cleaned);
+      return p(() => `n=${n.value}`);
+    });
+
+    const Switcher = component(() =>
+      match([() => n.value >= 0, () => Inner({})], () => null),
+    );
+
+    dispose = mount(Switcher({}), container);
+    dispose();
+    expect(cleaned).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unsupported return shapes with a helpful error (dev)", () => {
+    // Setup returns a bare plain object — not a WhisqNode, not a function.
+    const BadA = component(() => ({}) as unknown as WhisqNode);
+    expect(() => mount(BadA({}), container)).toThrow(/component/);
+
+    // Setup returns a function that itself returns an array of plain objects —
+    // caught at render time.
+    const BadB = component(
+      () => () => [{} as unknown] as unknown as WhisqNode,
+    );
+    // Depending on dev-mode strictness, this may throw at mount or the effect
+    // may swallow; we at least want it NOT to silently render garbage.
+    try {
+      dispose = mount(BadB({}), container);
+      // If we got here, at least verify nothing visibly rendered.
+      expect(container.textContent).toBe("");
+    } catch {
+      // Or it threw — also acceptable.
+    }
   });
 });

--- a/packages/core/src/__tests__/elements.test.ts
+++ b/packages/core/src/__tests__/elements.test.ts
@@ -459,3 +459,91 @@ describe("mount()", () => {
     expect(container.textContent).toBe("");
   });
 });
+
+// ── aria-* attribute typing + correct boolean serialisation (WHISQ-128) ─────
+
+describe("aria-* attributes", () => {
+  it("applies a static string aria-label", () => {
+    const node = button({ "aria-label": "Close" }, "×");
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.getAttribute("aria-label")).toBe("Close");
+  });
+
+  it("serialises boolean aria-* values as the strings 'true' / 'false'", () => {
+    // ARIA spec: `aria-expanded="true"` is the correct shape. The generic
+    // boolean-attribute branch in applyProp sets `key=""` for `value === true`,
+    // which is invalid for aria — empty string is NOT equivalent to "true" per
+    // the ARIA spec.
+    const expanded = button({ "aria-expanded": true }, "open");
+    dispose = mount(expanded, container);
+    expect(
+      (container.firstElementChild as HTMLElement).getAttribute("aria-expanded"),
+    ).toBe("true");
+  });
+
+  it("serialises boolean aria-expanded: false as the string 'false' (not removal)", () => {
+    const collapsed = button({ "aria-expanded": false }, "closed");
+    dispose = mount(collapsed, container);
+    expect(
+      (container.firstElementChild as HTMLElement).getAttribute("aria-expanded"),
+    ).toBe("false");
+  });
+
+  it("applies a reactive aria-hidden that toggles across renders", () => {
+    const hidden = signal(true);
+    const node = div({ "aria-hidden": () => hidden.value }, "region");
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.getAttribute("aria-hidden")).toBe("true");
+
+    hidden.value = false;
+    expect(el.getAttribute("aria-hidden")).toBe("false");
+  });
+
+  it("removes aria-* when the value is undefined", () => {
+    const current = signal<string | undefined>("Loading…");
+    const node = div({ "aria-live": () => current.value }, "status");
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.getAttribute("aria-live")).toBe("Loading…");
+
+    current.value = undefined;
+    expect(el.hasAttribute("aria-live")).toBe(false);
+
+    current.value = "polite";
+    expect(el.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("works with a reactive getter that returns a boolean (aria-pressed)", () => {
+    const pressed = signal(false);
+    const node = button(
+      { "aria-pressed": () => pressed.value },
+      "toggle",
+    );
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+
+    expect(el.getAttribute("aria-pressed")).toBe("false");
+    pressed.value = true;
+    expect(el.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("multiple aria-* attrs on one element all apply", () => {
+    const node = div(
+      {
+        "aria-label": "status",
+        "aria-live": "polite",
+        "aria-atomic": true,
+      },
+      "ready",
+    );
+    dispose = mount(node, container);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.getAttribute("aria-label")).toBe("status");
+    expect(el.getAttribute("aria-live")).toBe("polite");
+    expect(el.getAttribute("aria-atomic")).toBe("true");
+  });
+});

--- a/packages/core/src/__tests__/styling.test.ts
+++ b/packages/core/src/__tests__/styling.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { sheet, styles, cx, rcx, theme } from "../styling";
 import { signal } from "../reactive";
 
@@ -264,13 +264,93 @@ describe("theme()", () => {
   });
 
   it("replaces existing theme on second call", () => {
+    // Second call triggers the dup-warning (WHISQ-122) by default; use
+    // silent:true here since we're testing replacement semantics, not the
+    // warning itself.
     theme({ color: { primary: "red" } });
-    theme({ color: { primary: "blue" } });
+    theme({ color: { primary: "blue" } }, { silent: true });
 
     const styleTags = document.querySelectorAll("#whisq-style-whisq-theme");
     expect(styleTags.length).toBe(1);
     expect(styleTags[0].textContent).toContain("--color-primary:blue");
     expect(styleTags[0].textContent).not.toContain("--color-primary:red");
+  });
+});
+
+// ── Duplicate-call warning (WHISQ-122) ──────────────────────────────────────
+//
+// Dev-mode warning on second+ theme() calls catches the accidental-
+// overwrite failure mode Claude flagged in alpha.8 feedback (import one
+// styles.ts file, later import another that also calls theme(), last call
+// silently wipes the first). Detection is DOM-based (existing whisq-
+// style-whisq-theme element), so the beforeEach that clears that element
+// naturally resets state between tests — no counter to maintain.
+
+describe("theme() — duplicate-call warning", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("does NOT warn on first theme() call", () => {
+    theme({ color: { primary: "red" } });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns on second theme() call in dev (default)", () => {
+    theme({ color: { primary: "red" } });
+    theme({ color: { primary: "blue" } });
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = warn.mock.calls[0]![0] as string;
+    expect(msg).toContain("theme()");
+    expect(msg).toMatch(/replaces?|last-call-wins|duplicate/i);
+  });
+
+  it("warns again on third call (persistent, not just once)", () => {
+    theme({ color: { primary: "a" } });
+    theme({ color: { primary: "b" } });
+    theme({ color: { primary: "c" } });
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses the warning when silent: true is passed", () => {
+    theme({ color: { primary: "red" } });
+    theme({ color: { primary: "blue" } }, { silent: true });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns in dev even if the first call used silent: true", () => {
+    // silent applies only to THIS call. A subsequent call still warns
+    // against whatever style tag exists — silent doesn't disable detection
+    // globally.
+    theme({ color: { primary: "red" } }, { silent: true });
+    theme({ color: { primary: "blue" } });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT warn in production", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      theme({ color: { primary: "red" } });
+      theme({ color: { primary: "blue" } });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it("does NOT warn in SSR (no document)", () => {
+    const originalDocument = globalThis.document;
+    // @ts-expect-error intentional delete to simulate SSR
+    delete (globalThis as { document?: Document }).document;
+    try {
+      theme({ color: { primary: "red" } });
+      theme({ color: { primary: "blue" } });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      (globalThis as { document?: Document }).document = originalDocument;
+    }
   });
 });
 

--- a/packages/core/src/bind-sentinel.ts
+++ b/packages/core/src/bind-sentinel.ts
@@ -1,0 +1,72 @@
+// ============================================================================
+// Whisq Core — Bind sentinel (WHISQ-120)
+//
+// Dev-mode detection for the "spread then overwrite" footgun:
+//
+//   input({
+//     ...bind(draft),        // returns { value, oninput }
+//     oninput: (e) => track(e),   // silently drops bind's oninput
+//   });
+//
+// JS object spread is last-key-wins. By the time the element builder sees
+// `props`, bind's oninput is already gone. We can't detect that from the
+// final props alone — there's only one handler per key.
+//
+// Mechanism: bind() / bindField() / bindPath() attach a symbol-keyed
+// metadata record to their return objects. Object spread copies symbol-
+// keyed own properties (including non-enumerables by design in `{ ... }`
+// spread for enumerable symbols), so the record survives into the final
+// props. The element builder checks: "for each handler I declared, is
+// the current prop handler === what I declared?" If differs → warn.
+//
+// Caveat (documented): this only catches direction-1 (user overwrites
+// after spread). It cannot catch direction-2 (user handler first, then
+// spread bind on top) — the user's original handler is gone without a
+// trace by the time props reach the element builder. The recommended
+// convention is to spread bind/bindField/bindPath LAST; a future
+// `compose(bind(sig), { oninput: fn })` helper could cover both shapes
+// but isn't part of this change.
+// ============================================================================
+
+/**
+ * Well-known symbol carrying the handler map from bind() / bindField() /
+ * bindPath() through object spread. Not exported publicly — used only as
+ * a dev-mode diagnostic channel between the bind family and the element
+ * builder. Symbol.for() so the same token is shared across bundled and
+ * source builds (tests, externals) without drift.
+ */
+export const WHISQ_BIND_SOURCES = Symbol.for("whisq.bindSources");
+
+/**
+ * Shape of the metadata the bind family attaches under WHISQ_BIND_SOURCES.
+ * Keys are event-handler prop names (oninput, onchange, …); values are the
+ * exact handler functions that bind returned. The element builder checks
+ * `props[key] === sources[key]` — strict identity — to detect overwrites.
+ */
+export type BindSources = Readonly<Record<string, unknown>>;
+
+/**
+ * Attach the sentinel to a bind result. In production the marker is
+ * omitted (the checker in the element builder is also dev-gated, so
+ * shipping the symbol would only add dead weight). Mutates and returns
+ * `result` so call sites stay concise.
+ */
+export function tagBindResult<T extends object>(result: T): T {
+  if (process.env.NODE_ENV === "production") return result;
+
+  const sources: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(result)) {
+    if (key.startsWith("on") && typeof value === "function") {
+      sources[key] = value;
+    }
+  }
+  // Silent attach — symbol keys don't appear in Object.entries or
+  // JSON.stringify so the sentinel never leaks into user-visible output.
+  Object.defineProperty(result, WHISQ_BIND_SOURCES, {
+    value: sources,
+    enumerable: true, // enumerable so `{ ...result }` copies the sentinel
+    writable: false,
+    configurable: false,
+  });
+  return result;
+}

--- a/packages/core/src/bind.ts
+++ b/packages/core/src/bind.ts
@@ -4,6 +4,7 @@
 // ============================================================================
 
 import { type Signal, isSignal } from "./reactive.js";
+import { tagBindResult } from "./bind-sentinel.js";
 
 export interface TextBind {
   value: () => string;
@@ -64,18 +65,18 @@ export function bind(
 
   if (options?.as === "checkbox") {
     const sig = signal as Signal<boolean>;
-    return {
+    return tagBindResult({
       checked: () => sig.value,
       onchange: (e: Event) => {
         sig.value = (e.target as HTMLInputElement).checked;
       },
-    };
+    });
   }
 
   if (options?.as === "radio") {
     const sig = signal as Signal<string>;
     const target = options.value;
-    return {
+    return tagBindResult({
       value: target,
       checked: () => sig.value === target,
       onchange: (e: Event) => {
@@ -83,27 +84,27 @@ export function bind(
           sig.value = target;
         }
       },
-    };
+    });
   }
 
   if (options?.as === "number") {
     const sig = signal as Signal<number>;
-    return {
+    return tagBindResult({
       value: () => String(sig.value),
       oninput: (e: Event) => {
         const n = (e.target as HTMLInputElement).valueAsNumber;
         if (!Number.isNaN(n)) sig.value = n;
       },
-    };
+    });
   }
 
   const sig = signal as Signal<string>;
-  return {
+  return tagBindResult({
     value: () => sig.value,
     oninput: (e: Event) => {
       sig.value = (
         e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
       ).value;
     },
-  };
+  });
 }

--- a/packages/core/src/bindField.ts
+++ b/packages/core/src/bindField.ts
@@ -9,6 +9,7 @@
 import { type Signal, isSignal } from "./reactive.js";
 import type { TextBind, NumberBind, CheckboxBind, RadioBind } from "./bind.js";
 import { WhisqKeyByError } from "./dev-errors.js";
+import { tagBindResult } from "./bind-sentinel.js";
 
 interface Common<T> {
   keyBy?: (item: T) => unknown;
@@ -123,42 +124,42 @@ export function bindField<T, K extends keyof T>(
   const as = (options as { as?: string } | undefined)?.as;
 
   if (as === "checkbox") {
-    return {
+    return tagBindResult({
       checked: () => item()[key] as unknown as boolean,
       onchange: (e) => write(
         (e.target as HTMLInputElement).checked as unknown as T[K],
       ),
-    };
+    });
   }
 
   if (as === "radio") {
     const target = (options as { value: string }).value;
-    return {
+    return tagBindResult({
       value: target,
       checked: () => (item()[key] as unknown) === target,
       onchange: (e) => {
         if ((e.target as HTMLInputElement).checked)
           write(target as unknown as T[K]);
       },
-    };
+    });
   }
 
   if (as === "number") {
-    return {
+    return tagBindResult({
       value: () => String(item()[key] as unknown),
       oninput: (e) => {
         const n = (e.target as HTMLInputElement).valueAsNumber;
         if (!Number.isNaN(n)) write(n as unknown as T[K]);
       },
-    };
+    });
   }
 
-  return {
+  return tagBindResult({
     value: () => String(item()[key] as unknown),
     oninput: (e) =>
       write(
         (e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)
           .value as unknown as T[K],
       ),
-  };
+  });
 }

--- a/packages/core/src/bindPath.ts
+++ b/packages/core/src/bindPath.ts
@@ -8,6 +8,7 @@
 
 import { type Signal, isSignal } from "./reactive.js";
 import type { TextBind, NumberBind, CheckboxBind, RadioBind } from "./bind.js";
+import { tagBindResult } from "./bind-sentinel.js";
 
 type PathOptions =
   | Record<string, never>
@@ -156,40 +157,40 @@ export function bindPath<T>(
   const as = (options as { as?: string } | undefined)?.as;
 
   if (as === "checkbox") {
-    return {
+    return tagBindResult({
       checked: () => readPath(source.value, path) as boolean,
       onchange: (e) =>
         write((e.target as HTMLInputElement).checked),
-    };
+    });
   }
 
   if (as === "radio") {
     const target = (options as { value: string }).value;
-    return {
+    return tagBindResult({
       value: target,
       checked: () => readPath(source.value, path) === target,
       onchange: (e) => {
         if ((e.target as HTMLInputElement).checked) write(target);
       },
-    };
+    });
   }
 
   if (as === "number") {
-    return {
+    return tagBindResult({
       value: () => String(readPath(source.value, path) ?? ""),
       oninput: (e) => {
         const n = (e.target as HTMLInputElement).valueAsNumber;
         if (!Number.isNaN(n)) write(n);
       },
-    };
+    });
   }
 
-  return {
+  return tagBindResult({
     value: () => String(readPath(source.value, path) ?? ""),
     oninput: (e) =>
       write(
         (e.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)
           .value,
       ),
-  };
+  });
 }

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -8,6 +8,14 @@ import { signal, effect } from "./reactive.js";
 import type { WhisqNode } from "./elements.js";
 import { WhisqStructureError, describeValue } from "./dev-errors.js";
 
+/**
+ * Shapes a component's setup can return. A plain `WhisqNode` is the
+ * original contract. A zero-arg function (e.g. the return value of
+ * `match()` / `when()` / a bare `() => div(...)`) is lifted at the
+ * runtime boundary — see WHISQ-121.
+ */
+type ComponentSetupReturn = WhisqNode | (() => unknown);
+
 type CleanupFn = () => void;
 
 // ── Context (provide/inject) ───────────────────────────────────────────────
@@ -67,7 +75,7 @@ export interface ComponentDef<P = {}> {
  * ```
  */
 export function component<P extends Record<string, any> = {}>(
-  setup: (props: P) => WhisqNode,
+  setup: (props: P) => ComponentSetupReturn,
 ): ComponentDef<P> {
   const def = ((props: P) => {
     const parentCtx = contextStack[contextStack.length - 1] ?? null;
@@ -80,12 +88,19 @@ export function component<P extends Record<string, any> = {}>(
     };
 
     contextStack.push(ctx);
-    let node: WhisqNode;
+    let raw: ComponentSetupReturn;
     try {
-      node = setup(props);
+      raw = setup(props);
     } finally {
       contextStack.pop();
     }
+
+    // WHISQ-121: setup may return a function (the shape match() / when() /
+    // an ad-hoc `() => div(...)` produces). Lift it so callers don't need
+    // a sacrificial wrapper div whose only job is to host the function
+    // child.
+    const node: WhisqNode =
+      typeof raw === "function" ? liftFunctionChild(raw) : raw;
 
     if (process.env.NODE_ENV !== "production") {
       if (
@@ -96,9 +111,10 @@ export function component<P extends Record<string, any> = {}>(
       ) {
         throw new WhisqStructureError({
           element: "component",
-          expected: "setup to return a WhisqNode (an element call like `div(...)`)",
-          received: describeValue(node),
-          hint: "Return the root element from your setup function: `return div(...)`. Bare strings, numbers, arrays, and null aren't valid component roots — wrap them in an element.",
+          expected:
+            "setup to return a WhisqNode (an element call like `div(...)`) or a function child (the shape `match()` / `when()` produces)",
+          received: describeValue(raw),
+          hint: "Return the root element from your setup function: `return div(...)`. A `match()` / `when()` return works directly — no wrapper div needed. Bare strings, numbers, arrays, and null aren't valid component roots — wrap them in an element or a function.",
         });
       }
     }
@@ -123,6 +139,89 @@ export function component<P extends Record<string, any> = {}>(
 
   def.__whisq_component = true;
   return def;
+}
+
+/**
+ * Wrap a function-child return from setup in a minimal WhisqNode that
+ * manages rendering the function's result between start/end markers on a
+ * DocumentFragment. Same pattern as `errorBoundary` and keyed `each` —
+ * markers survive fragment-insertion and stay in the real parent after
+ * mount, so the effect can re-render in place across source changes.
+ *
+ * Scope: handles the common `match()` / `when()` / `() => div(...)` case
+ * where the function returns a WhisqNode / string / number / null. Nested
+ * function returns (`() => () => x`) are rejected in dev so callers don't
+ * build unexpectedly-deep reactive trees at the component root — if you
+ * need that, wrap in an element.
+ */
+function liftFunctionChild(fn: () => unknown): WhisqNode {
+  const startMarker = document.createComment("whisq-c-start");
+  const endMarker = document.createComment("whisq-c-end");
+  const fragment = document.createDocumentFragment();
+  fragment.appendChild(startMarker);
+  fragment.appendChild(endMarker);
+
+  let currentNodes: Node[] = [];
+  let currentDispose: (() => void) | null = null;
+
+  function clearCurrent(): void {
+    if (currentDispose) {
+      currentDispose();
+      currentDispose = null;
+    }
+    for (const n of currentNodes) n.parentNode?.removeChild(n);
+    currentNodes = [];
+  }
+
+  const effectDispose = effect(() => {
+    clearCurrent();
+    const result = fn();
+    const parent = startMarker.parentNode;
+    if (!parent) return;
+    if (result == null || result === false || result === true) return;
+
+    if (typeof result === "string" || typeof result === "number") {
+      const node = document.createTextNode(String(result));
+      parent.insertBefore(node, endMarker);
+      currentNodes = [node];
+      return;
+    }
+
+    if (
+      typeof result === "object" &&
+      result !== null &&
+      "__whisq" in result
+    ) {
+      const wn = result as WhisqNode;
+      parent.insertBefore(wn.el, endMarker);
+      currentNodes = [wn.el];
+      currentDispose = () => wn.dispose();
+      return;
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+      throw new WhisqStructureError({
+        element: "component",
+        expected:
+          "function-child to yield a WhisqNode / string / number / null",
+        received: describeValue(result),
+        hint:
+          typeof result === "function"
+            ? "Nested function children aren't supported as a component root — wrap in an element."
+            : "Wrap arrays / plain objects in an element function like `div(...)`.",
+      });
+    }
+  });
+
+  return {
+    __whisq: true,
+    el: fragment,
+    disposers: [effectDispose, clearCurrent],
+    dispose() {
+      effectDispose();
+      clearCurrent();
+    },
+  };
 }
 
 // ── Lifecycle Hooks ─────────────────────────────────────────────────────────

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -15,6 +15,7 @@ import { effect, isSignal, setEffectErrorHandler } from "./reactive.js";
 import { reconcileKeyed, type KeyedEntry } from "./reconcile.js";
 import type { Ref } from "./ref.js";
 import { WhisqStructureError, describeValue } from "./dev-errors.js";
+import { WHISQ_BIND_SOURCES, type BindSources } from "./bind-sentinel.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -245,6 +246,14 @@ export function h(
 ): WhisqNode {
   const el = document.createElement(tag);
   const disposers: (() => void)[] = [];
+
+  // Dev-only: detect when a spread of bind()/bindField()/bindPath() was
+  // followed by an explicit overwrite of one of its event handlers.
+  // See WHISQ-120 + packages/core/src/bind-sentinel.ts for the mechanism
+  // (a symbol-keyed manifest carried through object spread).
+  if (process.env.NODE_ENV !== "production" && props) {
+    checkOverwrittenBindHandlers(tag, props);
+  }
 
   // Apply props
   if (props) {
@@ -1071,6 +1080,33 @@ function isPlainStyleObject(value: unknown): value is StyleObject {
   }
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
+}
+
+function checkOverwrittenBindHandlers(
+  tag: string,
+  props: Record<string, unknown>,
+): void {
+  // The sentinel is a non-enumerable property under a symbol key; a plain
+  // `in` check hits it without polluting any Object.entries iteration.
+  const sources = (props as { [k: symbol]: unknown })[WHISQ_BIND_SOURCES] as
+    | BindSources
+    | undefined;
+  if (!sources) return;
+  for (const key of Object.keys(sources)) {
+    const declared = sources[key];
+    const current = (props as Record<string, unknown>)[key];
+    if (current !== declared) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[whisq] duplicate handler for "${key}" on <${tag}>: ` +
+          `the handler returned by bind()/bindField()/bindPath() was overwritten. ` +
+          `JS object spread is last-key-wins — your explicit "${key}" silently dropped the bind handler. ` +
+          `To keep both, chain them manually: ` +
+          `{ ...bind(sig), ${key}: (e) => { /* your code */ /* then call bind's handler yourself */ } }, ` +
+          `or spread bind LAST so your handler is the one that gets wiped (usually the bug you want).`,
+      );
+    }
+  }
 }
 
 function joinClassArray(sources: readonly ClassArraySource[]): string {

--- a/packages/core/src/elements.ts
+++ b/packages/core/src/elements.ts
@@ -128,6 +128,17 @@ interface BaseProps {
   hidden?: ReactiveProp<boolean>;
   title?: ReactiveProp<string | undefined>;
   [key: `data-${string}`]: ReactiveProp<string | undefined>;
+  /**
+   * ARIA attributes. Value types match how aria reads in HTML — strings
+   * for enum-valued attrs (`aria-live: "polite"`), booleans for
+   * predicate-shaped attrs (`aria-expanded`, `aria-hidden`,
+   * `aria-pressed`). Booleans serialise to the strings `"true"` and
+   * `"false"`, matching the ARIA spec — `aria-expanded=""` is NOT
+   * equivalent to `aria-expanded="true"`, and this typed path routes
+   * through a dedicated branch in `applyProp` that handles that.
+   * `undefined` / `null` removes the attribute.
+   */
+  [key: `aria-${string}`]: ReactiveProp<string | boolean | undefined>;
 }
 
 // Shared form-control event bundle, generic over the control's element type
@@ -1168,6 +1179,17 @@ function applyProp(el: Element, key: string, value: unknown): void {
     (el as HTMLInputElement).disabled = Boolean(value);
   } else if (key === "hidden") {
     (el as HTMLElement).hidden = Boolean(value);
+  } else if (key.startsWith("aria-")) {
+    // ARIA attributes need string "true"/"false", not empty string — per
+    // the ARIA spec, `aria-expanded=""` is NOT equivalent to
+    // `aria-expanded="true"`. Route boolean and string values through
+    // String() which produces the correct serialisation; null / undefined
+    // still remove the attribute.
+    if (value == null) {
+      el.removeAttribute(key);
+    } else {
+      el.setAttribute(key, String(value));
+    }
   } else if (value === false || value == null) {
     el.removeAttribute(key);
   } else if (value === true) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -116,6 +116,7 @@ export type { Ref, ElementRef } from "./ref.js";
 
 // Styling
 export { sheet, styles, cx, rcx, sx, theme } from "./styling.js";
+export type { ThemeOptions } from "./styling.js";
 export type { StyleObject } from "./elements.js";
 
 // Dev-mode diagnostics

--- a/packages/core/src/styling.ts
+++ b/packages/core/src/styling.ts
@@ -300,6 +300,19 @@ type ThemeTokens = Record<
 >;
 
 /**
+ * Options for `theme()`.
+ */
+export interface ThemeOptions {
+  /**
+   * Suppress the dev-mode "theme() called twice" warning for this call.
+   * Set when a second call is intentional — for example, a theme-switching
+   * toggle `theme(darkTokens, { silent: true })`. Production doesn't emit
+   * the warning regardless of this option.
+   */
+  silent?: boolean;
+}
+
+/**
  * Define CSS custom properties (design tokens) at :root level.
  *
  * ```ts
@@ -359,8 +372,32 @@ type ThemeTokens = Record<
  *   call is a no-op. The CSS variables won't appear in server-rendered
  *   HTML; attach theme tokens in a `<style>` block in your SSR template
  *   until a dedicated server renderer ships.
+ * - **Dev warning on accidental duplicates.** In dev, a second `theme()`
+ *   call with an existing whisq-theme block in the DOM emits a
+ *   `console.warn` — the bug this catches is the multi-file project that
+ *   imports two styles files and silently wipes the first theme. Pass
+ *   `{ silent: true }` when the second call is intentional (e.g. a
+ *   theme-switching toggle).
  */
-export function theme(tokens: ThemeTokens): void {
+export function theme(tokens: ThemeTokens, options?: ThemeOptions): void {
+  // Dev-only: detect accidental duplicate calls by checking whether a
+  // whisq-theme style block is already in the DOM. The check is cheap
+  // (one getElementById) and runs before injection, so production builds
+  // strip it via the NODE_ENV guard without changing behavior.
+  if (
+    process.env.NODE_ENV !== "production" &&
+    !options?.silent &&
+    typeof document !== "undefined" &&
+    document.getElementById("whisq-style-whisq-theme") !== null
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[whisq] theme() called a second time — the existing <style id=\"whisq-style-whisq-theme\"> block will be replaced (last-call-wins). " +
+        "If this is intentional (e.g. a theme-switching toggle), pass { silent: true } to suppress this warning. " +
+        "If unexpected, check whether two modules on your import graph both call theme() at module scope.",
+    );
+  }
+
   let cssText = ":root{";
 
   for (const [group, value] of Object.entries(tokens)) {

--- a/packages/create-whisq/CHANGELOG.md
+++ b/packages/create-whisq/CHANGELOG.md
@@ -1,5 +1,7 @@
 # create-whisq
 
+## 0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ### Minor Changes

--- a/packages/create-whisq/CHANGELOG.md
+++ b/packages/create-whisq/CHANGELOG.md
@@ -1,5 +1,19 @@
 # create-whisq
 
+## 0.1.0-alpha.8
+
+### Minor Changes
+
+- e3134ac: `full-app` template now scaffolds the canonical multi-file shape that the project-structure docs describe:
+  - **`src/components/`** — `CounterRow.ts` demonstrates the pattern for reusable UI pulled out of a page.
+  - **`src/lib/`** — `format.ts` demonstrates a pure utility module (no `@whisq/*` imports), including `formatCount()` and `clamp()` used by the scaffolded `CounterRow`.
+  - **`src/App.ts`** — now wraps `RouterView` in `errorBoundary`, so a thrown error in any page degrades to a retry UI instead of tearing down the whole app. Demonstrates the canonical error-boundary shape `App.ts` should own.
+  - **`src/pages/Home.ts`** — rewritten to consume `CounterRow` + `clamp`, connecting all four directories (`pages/` → `components/` → `lib/`) in one working example.
+
+  Closes the framework-side half of WHISQ-102. A whisq.dev companion page (`/examples/canonical-app-structure/`) is tracked for a follow-up PR.
+
+  Existing `full-app` behavior (router, stores/, styles.ts, pages/About.ts) is unchanged.
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.7",
-    "@whisq/router": "^0.1.0-alpha.7"
+    "@whisq/core": "^0.1.0-alpha.8",
+    "@whisq/router": "^0.1.0-alpha.8"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.8",
-    "@whisq/router": "^0.1.0-alpha.8"
+    "@whisq/core": "^0.1.0-alpha.9",
+    "@whisq/router": "^0.1.0-alpha.9"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.8"
+    "@whisq/core": "^0.1.0-alpha.9"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.7"
+    "@whisq/core": "^0.1.0-alpha.8"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.8",
-    "@whisq/ssr": "^0.1.0-alpha.8"
+    "@whisq/core": "^0.1.0-alpha.9",
+    "@whisq/ssr": "^0.1.0-alpha.9"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.7",
-    "@whisq/ssr": "^0.1.0-alpha.7"
+    "@whisq/core": "^0.1.0-alpha.8",
+    "@whisq/ssr": "^0.1.0-alpha.8"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.7",
-    "@whisq/router": "^0.1.0-alpha.7"
+    "@whisq/core": "^0.1.0-alpha.8",
+    "@whisq/router": "^0.1.0-alpha.8"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.7",
+    "@whisq/vite-plugin": "^0.1.0-alpha.8",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.8",
-    "@whisq/router": "^0.1.0-alpha.8"
+    "@whisq/core": "^0.1.0-alpha.9",
+    "@whisq/router": "^0.1.0-alpha.9"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.8",
+    "@whisq/vite-plugin": "^0.1.0-alpha.9",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @whisq/devtools
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- Updated dependencies [8f645a8]
+- Updated dependencies [401bfca]
+- Updated dependencies [0c1dccf]
+- Updated dependencies [91740a2]
+- Updated dependencies [2809555]
+- Updated dependencies [1b669b4]
+- Updated dependencies [0afc98b]
+  - @whisq/core@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/devtools
 
+## 0.1.0-alpha.9
+
+### Patch Changes
+
+- Updated dependencies [defc7eb]
+- Updated dependencies [c8f2bec]
+- Updated dependencies [e6d59c4]
+- Updated dependencies [75d2d8e]
+  - @whisq/core@0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ### Patch Changes

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/mcp-server
 
+## 0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ## 0.1.0-alpha.7

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/mcp-server
 
+## 0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ## 0.1.0-alpha.6

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/router
 
+## 0.1.0-alpha.9
+
+### Patch Changes
+
+- Updated dependencies [defc7eb]
+- Updated dependencies [c8f2bec]
+- Updated dependencies [e6d59c4]
+- Updated dependencies [75d2d8e]
+  - @whisq/core@0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ### Patch Changes

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @whisq/router
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- Updated dependencies [8f645a8]
+- Updated dependencies [401bfca]
+- Updated dependencies [0c1dccf]
+- Updated dependencies [91740a2]
+- Updated dependencies [2809555]
+- Updated dependencies [1b669b4]
+- Updated dependencies [0afc98b]
+  - @whisq/core@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/sandbox
 
+## 0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ## 0.1.0-alpha.6

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,42 @@
 # @whisq/sandbox
 
+## 0.1.0-alpha.9
+
+### Minor Changes
+
+- 308304d: Add `mountSandboxed()` — render AI-generated (or otherwise untrusted) Whisq source into an isolated iframe on the current page. Complements the existing `createSandbox()` primitive (which evaluates code and returns a value) by covering the rendering-isolation use case that ArrowJS's WASM sandbox is known for — without the WASM cost.
+
+  ```ts
+  import { mountSandboxed } from "@whisq/sandbox";
+
+  const handle = mountSandboxed({
+    source: `
+      import { div, signal } from "@whisq/core";
+      const n = signal(0);
+      setInterval(() => (n.value += 1), 1000);
+      document.body.append(div(() => String(n.value)).el);
+      window.__whisqPost({ type: "ready" });
+    `,
+    container: document.getElementById("agent-output")!,
+    importMap: { "@whisq/core": "https://esm.sh/@whisq/core@latest" },
+    onMessage: (msg) => console.log("from sandbox:", msg),
+  });
+
+  handle.postMessage({ type: "shutdown" });
+  handle.dispose();
+  ```
+
+  Isolation is standards-only:
+  - `<iframe sandbox="allow-scripts">` — unique origin; no same-origin access, no forms, no popups, no top-navigation.
+  - `<meta http-equiv="Content-Security-Policy">` in the iframe's srcdoc — default policy is `default-src 'none'` with `script-src` allowing inline + origins from your `importMap`; override via `cspDirectives`.
+  - `srcdoc` rather than `src=` — no network navigation; the iframe is a blank document we write into.
+  - `__whisq`-tagged postMessage bridge — other frames can't spoof messages into the parent's `onMessage` callback. Parent-to-iframe messages arrive as a `whisq:parent` `CustomEvent` on the iframe-side `window`.
+  - `</script>` and HTML comment closers inside the user source are escaped to prevent srcdoc injection.
+
+  API shape is deliberately scaffolded so future `isolation: "worker"` / `isolation: "wasm"` backends can land without a breaking change.
+
+  Closes WHISQ-118.
+
 ## 0.1.0-alpha.8
 
 ## 0.1.0-alpha.7

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -1,6 +1,6 @@
 # @whisq/sandbox
 
-Sandboxed code execution for Whisq — isolated environment with configurable limits.
+Two isolation primitives for Whisq: a **code-execution sandbox** that evaluates arbitrary source and returns a value, and a **UI-rendering sandbox** that mounts AI-generated Whisq source into an isolated iframe on the current page. Both are standards-only (no WASM, no extra runtime) so they compose with any Whisq app.
 
 ## Install
 
@@ -8,25 +8,65 @@ Sandboxed code execution for Whisq — isolated environment with configurable li
 npm install @whisq/sandbox
 ```
 
-## Usage
+## `createSandbox()` — run arbitrary code, return a value
 
 ```ts
 import { createSandbox } from "@whisq/sandbox";
 
-const sandbox = createSandbox({
-  timeout: 5000,
-  maxMemory: "128mb",
-});
+const sandbox = createSandbox({ timeout: 5000 });
 
-const result = await sandbox.run(`
-  import { signal } from "@whisq/core";
-  const count = signal(0);
-  count.value = 42;
-  return count.value;
+const result = await sandbox.execute(`
+  const count = 1 + 1;
+  return count;
 `);
 
-console.log(result); // 42
+console.log(result); // { success: true, value: 2 }
+
+sandbox.dispose();
 ```
+
+Shadows dangerous globals and enforces a timeout. Suitable for evaluating expressions or small scripts where you want the **return value** rather than a UI. A future revision may back this with QuickJS-WASM for true process-level isolation.
+
+## `mountSandboxed()` — render AI-generated Whisq UI into an iframe
+
+Mount an AI-generated Whisq fragment into a sandboxed iframe on the current page. Uses `<iframe sandbox="allow-scripts" srcdoc="…">` with a strict CSP — the frame runs in a unique origin, can't access the parent's DOM, and only fetches scripts from origins listed in your import map.
+
+```ts
+import { mountSandboxed } from "@whisq/sandbox";
+
+const handle = mountSandboxed({
+  source: `
+    import { div, signal } from "@whisq/core";
+    const n = signal(0);
+    setInterval(() => (n.value += 1), 1000);
+    document.body.append(div(() => String(n.value)).el);
+    window.__whisqPost({ type: "ready" });
+  `,
+  container: document.getElementById("agent-output")!,
+  importMap: { "@whisq/core": "https://esm.sh/@whisq/core@latest" },
+  onMessage: (msg) => console.log("from sandbox:", msg),
+});
+
+// Send a message the other way:
+handle.postMessage({ type: "shutdown" });
+
+// Tear down when done:
+handle.dispose();
+```
+
+### How isolation works
+
+- **`sandbox="allow-scripts"`** — unique origin; no forms, popups, top-navigation, or same-origin access. Widen via `sandboxAttrs` only when the agent UI legitimately needs one of those capabilities.
+- **CSP meta** injected into the iframe's srcdoc. The default policy is `default-src 'none'` with `script-src` allowing inline + every origin from your `importMap`. Override with `cspDirectives`.
+- **`srcdoc`, not `src=`** — the iframe starts as a blank document that we write. No network navigation.
+- **postMessage bridge** is `__whisq`-tagged so other frames on the page can't spoof messages into your `onMessage` callback; parent messages arrive as a `whisq:parent` `CustomEvent` on the iframe-side `window`.
+
+### When to use which
+
+| You want to… | Reach for |
+|---|---|
+| Evaluate a bit of JS, get a return value | `createSandbox().execute(code)` |
+| Mount AI-generated UI that shouldn't see your host DOM | `mountSandboxed({ source, container })` |
 
 ## Documentation
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/src/__tests__/mount.test.ts
+++ b/packages/sandbox/src/__tests__/mount.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mountSandboxed } from "../index.js";
+
+let container: HTMLElement;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  container.remove();
+});
+
+describe("mountSandboxed() — structure", () => {
+  it("mounts an iframe inside the provided container", () => {
+    const handle = mountSandboxed({
+      source: "// no-op",
+      container,
+    });
+    expect(container.querySelector("iframe")).not.toBeNull();
+    expect(handle.iframe.parentElement).toBe(container);
+    handle.dispose();
+  });
+
+  it("sets sandbox='allow-scripts' by default", () => {
+    const handle = mountSandboxed({ source: "", container });
+    expect(handle.iframe.getAttribute("sandbox")).toBe("allow-scripts");
+    handle.dispose();
+  });
+
+  it("accepts a custom sandbox attribute string", () => {
+    const handle = mountSandboxed({
+      source: "",
+      container,
+      sandboxAttrs: "allow-scripts allow-forms",
+    });
+    expect(handle.iframe.getAttribute("sandbox")).toBe(
+      "allow-scripts allow-forms",
+    );
+    handle.dispose();
+  });
+
+  it("uses srcdoc (not src) so no network navigation is required", () => {
+    const handle = mountSandboxed({ source: "console.log('hi')", container });
+    expect(handle.iframe.getAttribute("src")).toBeNull();
+    expect(handle.iframe.getAttribute("srcdoc")).toBeTruthy();
+    handle.dispose();
+  });
+});
+
+describe("mountSandboxed() — srcdoc content", () => {
+  it("injects a CSP meta tag in the srcdoc", () => {
+    const handle = mountSandboxed({ source: "", container });
+    const srcdoc = handle.iframe.getAttribute("srcdoc")!;
+    expect(srcdoc).toContain('http-equiv="Content-Security-Policy"');
+    handle.dispose();
+  });
+
+  it("injects an importmap when provided", () => {
+    const handle = mountSandboxed({
+      source: "",
+      container,
+      importMap: { "@whisq/core": "https://esm.sh/@whisq/core@latest" },
+    });
+    const srcdoc = handle.iframe.getAttribute("srcdoc")!;
+    expect(srcdoc).toContain('type="importmap"');
+    expect(srcdoc).toContain("@whisq/core");
+    expect(srcdoc).toContain("https://esm.sh/@whisq/core@latest");
+    handle.dispose();
+  });
+
+  it("omits the importmap when none is provided", () => {
+    const handle = mountSandboxed({ source: "", container });
+    const srcdoc = handle.iframe.getAttribute("srcdoc")!;
+    expect(srcdoc).not.toContain('type="importmap"');
+    handle.dispose();
+  });
+
+  it("embeds the user source inside a module script", () => {
+    const handle = mountSandboxed({
+      source: "const x = 42; window.__whisqPost(x);",
+      container,
+    });
+    const srcdoc = handle.iframe.getAttribute("srcdoc")!;
+    expect(srcdoc).toContain('type="module"');
+    expect(srcdoc).toContain("const x = 42");
+    handle.dispose();
+  });
+
+  it("neutralises both --> and --!> HTML comment closers", () => {
+    const handle = mountSandboxed({
+      source: "/* --> and --!> both break HTML comments */",
+      container,
+    });
+    const srcdoc = handle.iframe.getAttribute("srcdoc")!;
+    // Neither comment-close sequence should appear verbatim inside the
+    // interpolated user source region — both must be escaped.
+    // (The srcdoc as a whole may contain unrelated ">" chars, so check
+    // the specific sequences.)
+    const userPortion = srcdoc
+      .split("try {\n")[1]
+      ?.split("\n} catch")[0] ?? "";
+    expect(userPortion).not.toContain("-->");
+    expect(userPortion).not.toContain("--!>");
+    expect(userPortion).toContain("--\\>");
+    handle.dispose();
+  });
+
+  it("neutralises </script> inside the source to prevent srcdoc escape", () => {
+    const handle = mountSandboxed({
+      source: "// </script><img src=x onerror=alert(1)>",
+      container,
+    });
+    const srcdoc = handle.iframe.getAttribute("srcdoc")!;
+    // The injection pattern "</script><img" must NOT appear together —
+    // that's the shape that would close the module block and inject HTML.
+    expect(srcdoc).not.toContain("</script><img");
+    // The escaped form should appear instead (backslash before the closer).
+    expect(srcdoc).toContain("<\\/script>");
+    // The caller's intent (the comment text minus the closer) is preserved
+    expect(srcdoc).toContain("onerror=alert(1)");
+    handle.dispose();
+  });
+});
+
+describe("mountSandboxed() — postMessage bridge", () => {
+  it("exposes postMessage on the handle", () => {
+    const handle = mountSandboxed({ source: "", container });
+    expect(typeof handle.postMessage).toBe("function");
+    // Should not throw even if the iframe hasn't finished loading
+    expect(() => handle.postMessage({ type: "ping" })).not.toThrow();
+    handle.dispose();
+  });
+
+  it("invokes onMessage for __whisq-tagged messages from the iframe", () => {
+    const onMessage = vi.fn();
+    const handle = mountSandboxed({
+      source: "",
+      container,
+      onMessage,
+    });
+
+    // Simulate the iframe posting a tagged message
+    const event = new MessageEvent("message", {
+      source: handle.iframe.contentWindow,
+      data: { __whisq: true, payload: { type: "ready" } },
+    });
+    window.dispatchEvent(event);
+
+    expect(onMessage).toHaveBeenCalledWith({ type: "ready" });
+    handle.dispose();
+  });
+
+  it("ignores messages that aren't __whisq-tagged (cross-talk protection)", () => {
+    const onMessage = vi.fn();
+    const handle = mountSandboxed({ source: "", container, onMessage });
+
+    const event = new MessageEvent("message", {
+      source: handle.iframe.contentWindow,
+      data: { type: "ready" }, // no __whisq flag
+    });
+    window.dispatchEvent(event);
+
+    expect(onMessage).not.toHaveBeenCalled();
+    handle.dispose();
+  });
+
+  it("ignores messages not from the sandbox iframe's window", () => {
+    const onMessage = vi.fn();
+    const handle = mountSandboxed({ source: "", container, onMessage });
+
+    // Different source window
+    const otherWindow = document.createElement("iframe");
+    document.body.appendChild(otherWindow);
+
+    const event = new MessageEvent("message", {
+      source: otherWindow.contentWindow,
+      data: { __whisq: true, payload: { type: "spoof" } },
+    });
+    window.dispatchEvent(event);
+
+    expect(onMessage).not.toHaveBeenCalled();
+    otherWindow.remove();
+    handle.dispose();
+  });
+});
+
+describe("mountSandboxed() — dispose", () => {
+  it("removes the iframe from the DOM", () => {
+    const handle = mountSandboxed({ source: "", container });
+    expect(container.querySelector("iframe")).not.toBeNull();
+    handle.dispose();
+    expect(container.querySelector("iframe")).toBeNull();
+  });
+
+  it("unregisters the message handler", () => {
+    const onMessage = vi.fn();
+    const handle = mountSandboxed({ source: "", container, onMessage });
+
+    handle.dispose();
+
+    const event = new MessageEvent("message", {
+      source: handle.iframe.contentWindow,
+      data: { __whisq: true, payload: {} },
+    });
+    window.dispatchEvent(event);
+
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent (safe to call twice)", () => {
+    const handle = mountSandboxed({ source: "", container });
+    handle.dispose();
+    expect(() => handle.dispose()).not.toThrow();
+  });
+});

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,2 +1,8 @@
 export { createSandbox } from "./sandbox.js";
 export type { Sandbox, SandboxOptions, ExecutionResult } from "./sandbox.js";
+
+export { mountSandboxed } from "./mount.js";
+export type {
+  MountSandboxedOptions,
+  MountSandboxedHandle,
+} from "./mount.js";

--- a/packages/sandbox/src/mount.ts
+++ b/packages/sandbox/src/mount.ts
@@ -1,0 +1,274 @@
+// ============================================================================
+// @whisq/sandbox — mountSandboxed()
+//
+// Render AI-generated (or otherwise untrusted) Whisq source into a sandboxed
+// iframe on the current page. Uses standards-only isolation:
+//   - <iframe sandbox="allow-scripts">  (unique origin, no forms / popups /
+//     top-nav by default; caller can widen if needed)
+//   - Content-Security-Policy meta tag inside the iframe's srcdoc
+//   - srcdoc rather than src=  (no network navigation; the iframe is a
+//     blank document we write into)
+//   - postMessage bridge with __whisq tag filtering so other frames on the
+//     page can't spoof messages into the onMessage callback
+//
+// Sibling to createSandbox() — that primitive evaluates code and returns a
+// value; this one mounts UI. They coexist because they solve different
+// problems.
+// ============================================================================
+
+export interface MountSandboxedOptions {
+  /**
+   * Source code to run inside the iframe. Evaluated as an ES module. Use the
+   * global `window.__whisqPost(msg)` inside the source to send messages back
+   * to the parent's `onMessage` callback.
+   */
+  source: string;
+
+  /**
+   * DOM element the iframe is appended to. The iframe replaces nothing —
+   * it's appended as a child. Clear the container first if you need that.
+   */
+  container: HTMLElement;
+
+  /**
+   * Import map applied inside the iframe (e.g.
+   * `{ "@whisq/core": "https://esm.sh/@whisq/core@latest" }`). Required when
+   * the source uses bare specifiers like `import { div } from "@whisq/core"`.
+   * Origins listed here are automatically allowed in the default CSP.
+   */
+  importMap?: Record<string, string>;
+
+  /**
+   * Called whenever the iframe posts a `__whisq`-tagged message back to the
+   * parent. Use the iframe-side global `window.__whisqPost(msg)` to send.
+   */
+  onMessage?: (message: unknown) => void;
+
+  /**
+   * The `sandbox` attribute value. Default `"allow-scripts"` — unique origin,
+   * no forms, no popups, no top-navigation. Widen only if the agent UI
+   * legitimately needs one of those capabilities.
+   */
+  sandboxAttrs?: string;
+
+  /**
+   * Extra CSP directives merged into the default policy. Keys are directive
+   * names (e.g. `"img-src"`), values are space-separated source lists.
+   */
+  cspDirectives?: Record<string, string>;
+}
+
+export interface MountSandboxedHandle {
+  /** The created iframe. Kept for caller introspection (position, size, …). */
+  readonly iframe: HTMLIFrameElement;
+
+  /**
+   * Send a message from the parent into the iframe. The iframe-side source
+   * receives it via a `message` event on `window` with `event.data` being
+   * `{ __whisqFromParent: true, payload: msg }`.
+   */
+  postMessage(message: unknown): void;
+
+  /**
+   * Remove the iframe from the DOM and tear down the message bridge.
+   * Idempotent — safe to call multiple times.
+   */
+  dispose(): void;
+}
+
+/**
+ * Mount AI-generated Whisq source into a sandboxed iframe on the current
+ * page. Returns a handle for messaging and teardown.
+ *
+ * ```ts
+ * const handle = mountSandboxed({
+ *   source: `
+ *     import { div, signal } from "@whisq/core";
+ *     const n = signal(0);
+ *     setInterval(() => n.value++, 1000);
+ *     // mount into the iframe's body
+ *     document.body.append(div(() => String(n.value)).el);
+ *     window.__whisqPost({ type: "ready" });
+ *   `,
+ *   container: document.getElementById("agent-output")!,
+ *   importMap: { "@whisq/core": "https://esm.sh/@whisq/core@latest" },
+ *   onMessage: (msg) => console.log("from sandbox:", msg),
+ * });
+ *
+ * // Later:
+ * handle.postMessage({ type: "shutdown" });
+ * handle.dispose();
+ * ```
+ */
+export function mountSandboxed(
+  options: MountSandboxedOptions,
+): MountSandboxedHandle {
+  const {
+    source,
+    container,
+    importMap,
+    onMessage,
+    sandboxAttrs = "allow-scripts",
+    cspDirectives,
+  } = options;
+
+  const iframe = document.createElement("iframe");
+  iframe.setAttribute("sandbox", sandboxAttrs);
+  iframe.srcdoc = buildSrcdoc({ source, importMap, cspDirectives });
+
+  let disposed = false;
+  const handleMessage = (event: MessageEvent) => {
+    if (disposed) return;
+    // Cross-talk protection: ignore messages from other frames on the page.
+    if (event.source !== iframe.contentWindow) return;
+    const data = event.data;
+    if (
+      data == null ||
+      typeof data !== "object" ||
+      (data as { __whisq?: unknown }).__whisq !== true
+    ) {
+      return;
+    }
+    onMessage?.((data as { payload?: unknown }).payload);
+  };
+  window.addEventListener("message", handleMessage);
+
+  container.appendChild(iframe);
+
+  return {
+    iframe,
+    postMessage(message: unknown): void {
+      if (disposed) return;
+      iframe.contentWindow?.postMessage(
+        { __whisqFromParent: true, payload: message },
+        "*",
+      );
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      window.removeEventListener("message", handleMessage);
+      if (iframe.parentNode) iframe.parentNode.removeChild(iframe);
+    },
+  };
+}
+
+// ── Internal ───────────────────────────────────────────────────────────────
+
+/**
+ * Build the srcdoc HTML with CSP + importmap + user source wrapped in a
+ * module script. The source is sanitised against `</script>` escape so a
+ * malicious or accidental closer can't break out of the module block and
+ * inject raw HTML into the iframe document.
+ */
+function buildSrcdoc(opts: {
+  source: string;
+  importMap?: Record<string, string>;
+  cspDirectives?: Record<string, string>;
+}): string {
+  const csp = buildCsp(opts.importMap, opts.cspDirectives);
+  const importMapTag =
+    opts.importMap && Object.keys(opts.importMap).length > 0
+      ? `<script type="importmap">${escapeScriptContent(
+          JSON.stringify({ imports: opts.importMap }),
+        )}</script>`
+      : "";
+
+  const safeSource = escapeScriptContent(opts.source);
+
+  // The parent postMessage bridge + parent-to-iframe message forwarder.
+  const harness = `
+window.__whisqPost = (msg) => parent.postMessage({ __whisq: true, payload: msg }, "*");
+window.addEventListener("message", (e) => {
+  const d = e.data;
+  if (d && typeof d === "object" && d.__whisqFromParent === true) {
+    window.dispatchEvent(new CustomEvent("whisq:parent", { detail: d.payload }));
+  }
+});
+`.trim();
+
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${escapeAttr(csp)}">
+${importMapTag}
+</head>
+<body>
+<script type="module">
+${harness}
+try {
+${safeSource}
+} catch (err) {
+  const msg = err && err.message ? err.message : String(err);
+  parent.postMessage({ __whisq: true, payload: { __whisqError: msg } }, "*");
+}
+</script>
+</body>
+</html>`;
+}
+
+function buildCsp(
+  importMap: Record<string, string> | undefined,
+  extra: Record<string, string> | undefined,
+): string {
+  // Collect origins from the import map so the browser is allowed to fetch
+  // remote modules (e.g. https://esm.sh). Each entry's URL contributes its
+  // origin — not its path — because CSP source lists match by origin.
+  const scriptSrc = new Set<string>(["'unsafe-inline'"]);
+  if (importMap) {
+    for (const url of Object.values(importMap)) {
+      const origin = originOf(url);
+      if (origin) scriptSrc.add(origin);
+    }
+  }
+
+  const defaults: Record<string, string> = {
+    "default-src": "'none'",
+    "script-src": Array.from(scriptSrc).join(" "),
+    "style-src": "'unsafe-inline'",
+    "img-src": "data: blob: https:",
+    "font-src": "data: https:",
+    "connect-src": "https:",
+    "base-uri": "'none'",
+    "form-action": "'none'",
+  };
+
+  const merged = { ...defaults, ...(extra ?? {}) };
+  return Object.entries(merged)
+    .map(([k, v]) => `${k} ${v}`)
+    .join("; ");
+}
+
+function originOf(url: string): string | null {
+  try {
+    const u = new URL(url);
+    return u.origin;
+  } catch {
+    return null;
+  }
+}
+
+function escapeScriptContent(s: string): string {
+  // Prevent `</script>` or HTML comment closers from breaking out of the
+  // surrounding <script> block in srcdoc. Replace the case-insensitive
+  // closer with a form that looks identical when serialised back to a
+  // string inside the script but is NOT parsed as a closing tag by the
+  // HTML tokeniser.
+  //
+  // Per the HTML spec, a comment can be closed by either `-->` or `--!>`
+  // (the legacy "abrupt closing" form). Both must be escaped so an input
+  // containing either can't break out of a surrounding <!-- … --> region.
+  return s
+    .replace(/<\/(script)/gi, "<\\/$1")
+    .replace(/<!--/g, "<\\!--")
+    .replace(/--!?>/g, "--\\>");
+}
+
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "lib": ["ES2022"]
+    "lib": ["ES2022", "DOM"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/ssr
 
+## 0.1.0-alpha.9
+
+### Patch Changes
+
+- Updated dependencies [defc7eb]
+- Updated dependencies [c8f2bec]
+- Updated dependencies [e6d59c4]
+- Updated dependencies [75d2d8e]
+  - @whisq/core@0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ### Patch Changes

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @whisq/ssr
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- Updated dependencies [8f645a8]
+- Updated dependencies [401bfca]
+- Updated dependencies [0c1dccf]
+- Updated dependencies [91740a2]
+- Updated dependencies [2809555]
+- Updated dependencies [1b669b4]
+- Updated dependencies [0afc98b]
+  - @whisq/core@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @whisq/testing
 
+## 0.1.0-alpha.8
+
+### Patch Changes
+
+- Updated dependencies [8f645a8]
+- Updated dependencies [401bfca]
+- Updated dependencies [0c1dccf]
+- Updated dependencies [91740a2]
+- Updated dependencies [2809555]
+- Updated dependencies [1b669b4]
+- Updated dependencies [0afc98b]
+  - @whisq/core@0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ### Patch Changes

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/testing
 
+## 0.1.0-alpha.9
+
+### Patch Changes
+
+- Updated dependencies [defc7eb]
+- Updated dependencies [c8f2bec]
+- Updated dependencies [e6d59c4]
+- Updated dependencies [75d2d8e]
+  - @whisq/core@0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/vite-plugin
 
+## 0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ## 0.1.0-alpha.7

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/vite-plugin
 
+## 0.1.0-alpha.8
+
 ## 0.1.0-alpha.7
 
 ## 0.1.0-alpha.6

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 // Verifies version consistency across the monorepo:
 //   1. Every `@whisq/*` package AND `create-whisq` in `packages/*` share the same version.
-//   2. Every `@whisq/*` reference inside `packages/create-whisq/src/templates/**/package.json.tmpl`
-//      resolves to that same version. Allowed forms: "X.Y.Z", "^X.Y.Z", "~X.Y.Z", "workspace:*".
+//   2. Every `@whisq/*` reference inside
+//      `packages/create-whisq/src/templates/**/package.json.tmpl` resolves to
+//      that same version. Allowed forms: "X.Y.Z", "^X.Y.Z", "~X.Y.Z", "workspace:*".
+//   3. Every `@whisq/*` reference inside `examples/*/package.json` (real
+//      runnable StackBlitz templates) follows the same rule.
 //
 // `create-whisq` is included so the scaffolder and the runtime packages
 // always release together. Enforced by the `fixed` group in
@@ -10,7 +13,7 @@
 //
 // Exits non-zero on any drift. Run in CI and as a gate inside /release.
 
-import { readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -46,12 +49,16 @@ for (const pkg of releasedPackages) {
   }
 }
 
-function walk(dir, out = []) {
+function walk(dir, matcher, out = []) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     const s = statSync(full);
-    if (s.isDirectory()) walk(full, out);
-    else if (entry === "package.json.tmpl") out.push(full);
+    if (s.isDirectory()) {
+      if (entry === "node_modules" || entry === "dist") continue;
+      walk(full, matcher, out);
+    } else if (matcher(entry, full)) {
+      out.push(full);
+    }
   }
   return out;
 }
@@ -59,9 +66,20 @@ function walk(dir, out = []) {
 const templatesDir = join(root, "packages", "create-whisq", "src", "templates");
 let templateFiles = [];
 try {
-  templateFiles = walk(templatesDir);
+  templateFiles = walk(templatesDir, (name) => name === "package.json.tmpl");
 } catch {
   errors.push(`Templates directory not found at ${relative(root, templatesDir)}`);
+}
+
+// Examples dir is optional — not every repo snapshot has runnable examples.
+const examplesDir = join(root, "examples");
+let exampleFiles = [];
+if (existsSync(examplesDir)) {
+  try {
+    exampleFiles = walk(examplesDir, (name) => name === "package.json");
+  } catch {
+    errors.push(`Examples directory walk failed at ${relative(root, examplesDir)}`);
+  }
 }
 
 const validSpec = (spec) => {
@@ -70,13 +88,13 @@ const validSpec = (spec) => {
   return stripped === referenceVersion;
 };
 
-for (const file of templateFiles) {
+function checkFile(file) {
   let pkg;
   try {
     pkg = JSON.parse(readFileSync(file, "utf8"));
   } catch (e) {
     errors.push(`${relative(root, file)} is not valid JSON: ${e.message}`);
-    continue;
+    return;
   }
   for (const section of ["dependencies", "devDependencies", "peerDependencies"]) {
     const deps = pkg[section] ?? {};
@@ -91,6 +109,9 @@ for (const file of templateFiles) {
   }
 }
 
+for (const file of templateFiles) checkFile(file);
+for (const file of exampleFiles) checkFile(file);
+
 if (errors.length > 0) {
   console.error("Version consistency check failed:");
   for (const err of errors) console.error(`  - ${err}`);
@@ -98,5 +119,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `Version consistency OK — ${releasedPackages.length} released packages at ${referenceVersion}, ${templateFiles.length} template(s) aligned.`,
+  `Version consistency OK — ${releasedPackages.length} released packages at ${referenceVersion}, ${templateFiles.length} template(s) + ${exampleFiles.length} example(s) aligned.`,
 );

--- a/scripts/sync-template-versions.mjs
+++ b/scripts/sync-template-versions.mjs
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
-// Rewrites every `@whisq/*` dep inside
-// `packages/create-whisq/src/templates/**/package.json.tmpl`
-// to match the current workspace version (the one in `packages/core/package.json`).
+// Rewrites every `@whisq/*` dep in two places to match the current workspace
+// version (the one in `packages/core/package.json`):
+//
+//   1. `packages/create-whisq/src/templates/**/package.json.tmpl` — the
+//      templates the CLI scaffolds from.
+//   2. `examples/*/package.json` — StackBlitz-runnable example apps that
+//      must pin to the latest release so `npm install` on StackBlitz
+//      resolves to something that works.
 //
 // Caret range is preserved. `workspace:*` specs are left alone.
-// Run after version bumps so scaffolded apps pick up the new release.
+// Run after version bumps so scaffolded apps + examples pick up the new
+// release.
 
-import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -21,18 +27,31 @@ if (!targetVersion) {
   process.exit(1);
 }
 
-function walk(dir, out = []) {
+function walk(dir, matcher, out = []) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     const s = statSync(full);
-    if (s.isDirectory()) walk(full, out);
-    else if (entry === "package.json.tmpl") out.push(full);
+    if (s.isDirectory()) {
+      // Skip node_modules inside examples — they can exist after a local
+      // `npm install` and we don't want to rewrite vendored files.
+      if (entry === "node_modules" || entry === "dist") continue;
+      walk(full, matcher, out);
+    } else if (matcher(entry, full)) {
+      out.push(full);
+    }
   }
   return out;
 }
 
 const templatesDir = join(root, "packages", "create-whisq", "src", "templates");
-const files = walk(templatesDir);
+const examplesDir = join(root, "examples");
+
+const files = [
+  ...walk(templatesDir, (name) => name === "package.json.tmpl"),
+  ...(existsSync(examplesDir)
+    ? walk(examplesDir, (name) => name === "package.json")
+    : []),
+];
 let changed = 0;
 
 for (const file of files) {
@@ -63,4 +82,6 @@ for (const file of files) {
   }
 }
 
-console.log(`Synced ${changed}/${files.length} template(s) to @whisq/*@${targetVersion}.`);
+console.log(
+  `Synced ${changed}/${files.length} template/example file(s) to @whisq/*@${targetVersion}.`,
+);


### PR DESCRIPTION
Release `v0.1.0-alpha.9` — alpha.8 reviewer follow-up + mid-cycle discoveries. Six feature PRs, all green on first or second CI pass. Top-level `@whisq/core` bundle sits at 5.67 KB gzipped (under the 6.0 KB budget bumped in the alpha.8→alpha.9 cycle for the `component()` function-child lift).

## What shipped

### Diagnostics — three new dev-mode warnings that catch real production bugs

- **[#123](https://github.com/whisqjs/whisq/pull/123) (WHISQ-120)** — Dev warning when spreading `bind()` / `bindField()` / `bindPath()` then overwriting one of its event handlers. The alpha.8 reviewer's top-ranked concern ("the only one that will produce a bug someone ships to production"). Sentinel-symbol mechanism survives JS object spread; direction 2 (user handler first, spread last) is documented as a known limitation with the safer convention steered in the warning message.
- **[#126](https://github.com/whisqjs/whisq/pull/126) (WHISQ-122)** — Dev warning on duplicate `theme()` calls. Completes the alpha.7 `theme()` saga started by #99/#105 (docs + SSR guard). DOM-based detection via the `whisq-style-whisq-theme` element; `{ silent: true }` opt-out for intentional theme-switching.
- **[#129](https://github.com/whisqjs/whisq/pull/129) (WHISQ-128)** — Typed `aria-*` attributes on every element. Discovered mid-cycle during WHISQ-124 smoke-test. Also fixes an ARIA-spec bug the new typing exposed: boolean aria values now serialise to `"true"` / `"false"` (not empty string, which is what the generic boolean-attribute branch produced and which is invalid per the ARIA spec).

### API — one big ergonomic win

- **[#125](https://github.com/whisqjs/whisq/pull/125) (WHISQ-121)** — `component()`'s setup accepts a function-child return directly. Closes the alpha.8 reviewer's #2 ranked concern ("the wrapper div has no job other than holding `match()`"). Same fragment + start/end marker pattern `errorBoundary` / keyed `each()` already use. Fragment-bundle adds ~150 B to the top-level bundle — documented budget bump from 5.5 → 6.0 KB absorbed it.

### Isolation — new primitive for AI-rendered UI

- **[#119](https://github.com/whisqjs/whisq/pull/119) (WHISQ-118)** — `mountSandboxed()` in `@whisq/sandbox`. Iframe + CSP + postMessage — standards-only, zero new deps. Scaffolded API shape so future `isolation: "worker"` / `isolation: "wasm"` backends can land without a breaking change. Motivated by `dev/feedback/comparison.md` (ArrowJS positioning analysis) — Whisq's "writing code with AI" lane plus a lightweight answer to the adjacent "running code written by AI" use case.

### Templates + Examples

- **[#127](https://github.com/whisqjs/whisq/pull/127) (WHISQ-124)** — First runnable public example at `examples/template-todo/`. Unblocks whisqjs/whisq.dev#158's "Open in StackBlitz" button. StackBlitz URL once this merges:  
  `https://stackblitz.com/github/whisqjs/whisq/tree/main/examples/template-todo`  
  Demonstrates the full alpha.9 canonical API: `persistedSignal` + `onSchemaFailure`, `randomId` for ids, named-action mutations, `bind` (spread last per the WHISQ-120 convention), `match()` directly as component root (WHISQ-121), keyed `each` with `ItemAccessor<Todo>`, `bindField` checkbox, `class:` array form, `errorBoundary` wrapping the mutable tree, `sheet()` nested selectors + `theme()` tokens.

## Infrastructure

- `packages/core/.size-limit.cjs` budget: 5.5 → 6.0 KB gzipped (WHISQ-121 fragment-bundle).
- `scripts/sync-template-versions.mjs` + `scripts/check-versions.mjs` extended to walk `examples/*/package.json` alongside the existing `package.json.tmpl` template walker. Runs at release + in CI.
- `.gitignore`: narrowed from blanket `examples/` to `examples/*` + `!examples/template-todo/` so committed examples are tracked while local experiments stay ignored.

## Test plan

- [x] `pnpm check:versions` — 9 released packages + 4 templates + 1 example aligned at 0.1.0-alpha.9.
- [x] `pnpm -w build` clean across 9 packages.
- [x] `pnpm -w test` — 435 core tests pass; 18/18 workspace tasks green.
- [x] `pnpm size` — 5.67 KB of 6.0 KB budget.
- [x] Scaffolded `create-whisq` full-app `tsc --noEmit` clean.
- [x] `examples/template-todo/` `tsc --noEmit` clean against the new `@whisq/core@0.1.0-alpha.9` types.
- [ ] CI on this PR.
- [ ] Post-merge: tag `v0.1.0-alpha.9`, GitHub Release created, `main → develop` back-merge clean.

## Remaining open (deferred, not release blockers)

- #84 (P2) — alpha.6 docs papercuts, framework-repo side done; remaining ACs are on whisq.dev.
- #90 (P3) — dev warn for snapshotted accessors, parked (prefer static analysis; no user reports yet).
- #103 (P3) — enrich `public-api.json`, parked (no concrete consumer yet).

## Next cycle

whisq.dev has 4+ open docs issues from the alpha.8 round that now consume these APIs (#108 cookbook, #109 persistence matrix, #110 golden patterns, #162–#165 from the alpha.8 analyze-feedback round, plus #158 StackBlitz button which this release enables). The natural next focus is the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)