### PR TITLE
WHISQ-134: createStorageNamespace + randomId({ prefix, rng })

### DIFF
--- a/.changeset/small-utility-helpers-omnibus.md
+++ b/.changeset/small-utility-helpers-omnibus.md
@@ -1,0 +1,27 @@
+---
+"@whisq/core": minor
+---
+
+Two small additive helpers to close the alpha.9 feedback loop — both opt-in on existing sub-path imports, no breaking changes.
+
+- **`createStorageNamespace(prefix)`** on `@whisq/core/persistence` — returns a `{ persistedSignal }` view whose storage keys are transparently rewritten to `${prefix}:${key}`. Use when several Whisq apps share an origin (marketing site + dashboard + demo playground on the same host) and must not collide. A thin compositional wrapper — everything `persistedSignal` already supports (storage kind, schema, onSchemaFailure, …) passes straight through. Empty or whitespace prefixes are rejected so a forgotten interpolation fails loudly instead of silently using `":key"`.
+
+  ```ts
+  import { createStorageNamespace } from "@whisq/core/persistence";
+
+  const app = createStorageNamespace("whisq-todo-app");
+  export const todos = app.persistedSignal<Todo[]>("todos", []);
+  //                                               ↑ actual key: "whisq-todo-app:todos"
+  ```
+
+- **`randomId(options?)`** on `@whisq/core/ids` — now accepts `{ prefix, rng }`. Zero-arg call is unchanged. `prefix` concatenates directly (no separator — pass `"todo_"` if that's what you want). `rng` replaces `Math.random` in the fallback synthesis and **also bypasses `crypto.randomUUID`**, so a seeded PRNG produces the same id on every platform. The primary use-case is deterministic ids for snapshot tests — no more globally stubbing `crypto.randomUUID`.
+
+  ```ts
+  import { randomId } from "@whisq/core/ids";
+
+  randomId();                            // default: crypto.randomUUID
+  randomId({ prefix: "todo_" });         // "todo_01K1…"
+  randomId({ rng: seedrandom(42) });     // deterministic across environments
+  ```
+
+Closes WHISQ-134. Source: `dev/feedback/latest/FRAMEWORK_FEEDBACK_CLAUDE_v0.1.0-alpha.9.md` (N5, N7).

--- a/packages/core/src/__tests__/ids.test.ts
+++ b/packages/core/src/__tests__/ids.test.ts
@@ -74,3 +74,62 @@ describe("randomId() — fallback path (crypto.randomUUID unavailable)", () => {
     }
   });
 });
+
+describe("randomId({ prefix })", () => {
+  it("prepends the prefix to the UUID with no separator", () => {
+    const id = randomId({ prefix: "todo_" });
+    expect(id.startsWith("todo_")).toBe(true);
+    expect(id.slice("todo_".length)).toMatch(V4_UUID_SHAPE);
+  });
+
+  it("empty prefix is a no-op (same shape as zero-arg call)", () => {
+    expect(randomId({ prefix: "" })).toMatch(V4_UUID_SHAPE);
+  });
+});
+
+describe("randomId({ rng })", () => {
+  it("produces deterministic output when rng is deterministic", () => {
+    const seeded = () => 0.5;
+    const a = randomId({ rng: seeded });
+    const b = randomId({ rng: seeded });
+    expect(a).toBe(b);
+    expect(a).toMatch(V4_UUID_SHAPE);
+  });
+
+  it("bypasses crypto.randomUUID when rng is supplied (the whole point)", () => {
+    const cryptoSpy = vi.spyOn(crypto, "randomUUID");
+    try {
+      const rng = () => 0.25;
+      randomId({ rng });
+      expect(cryptoSpy).not.toHaveBeenCalled();
+    } finally {
+      cryptoSpy.mockRestore();
+    }
+  });
+
+  it("respects both prefix and rng together", () => {
+    const id = randomId({ prefix: "t-", rng: () => 0 });
+    expect(id).toBe("t-00000000-0000-4000-8000-000000000000");
+  });
+
+  it("degenerate () => 0 rng produces the all-zero UUID (sanity / shape check)", () => {
+    expect(randomId({ rng: () => 0 })).toBe(
+      "00000000-0000-4000-8000-000000000000",
+    );
+  });
+
+  it("different rng functions may yield different sequences across calls", () => {
+    let i = 0;
+    const stepping = () => {
+      // feed 0, 1/16, 2/16, ... — each call advances, so successive calls differ
+      const n = (i % 16) / 16;
+      i += 1;
+      return n;
+    };
+    const a = randomId({ rng: stepping });
+    const b = randomId({ rng: stepping });
+    expect(a).not.toBe(b);
+    expect(a).toMatch(V4_UUID_SHAPE);
+    expect(b).toMatch(V4_UUID_SHAPE);
+  });
+});

--- a/packages/core/src/__tests__/persistence.test.ts
+++ b/packages/core/src/__tests__/persistence.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { effect } from "../reactive.js";
 // Imported from the internal path. Public import is `@whisq/core/persistence`
 // (see packages/core/package.json exports).
-import { persistedSignal } from "../persistence.js";
+import { persistedSignal, createStorageNamespace } from "../persistence.js";
 
 beforeEach(() => {
   window.localStorage.clear();
@@ -264,5 +264,68 @@ describe("persistedSignal() — onSchemaFailure callback", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+});
+
+describe("createStorageNamespace()", () => {
+  it("writes under the '<prefix>:<key>' storage slot", () => {
+    const ns = createStorageNamespace("whisq-todo-app");
+    const todos = ns.persistedSignal<string[]>("todos", []);
+    todos.value = ["walk dog"];
+    expect(window.localStorage.getItem("whisq-todo-app:todos")).toBe(
+      '["walk dog"]',
+    );
+    // the un-prefixed key must NOT be touched
+    expect(window.localStorage.getItem("todos")).toBeNull();
+  });
+
+  it("reads from the prefixed slot on init", () => {
+    window.localStorage.setItem("app-a:count", "7");
+    const ns = createStorageNamespace("app-a");
+    const count = ns.persistedSignal("count", 0);
+    expect(count.value).toBe(7);
+  });
+
+  it("keeps two namespaces from colliding on the same key", () => {
+    const a = createStorageNamespace("app-a");
+    const b = createStorageNamespace("app-b");
+    const ca = a.persistedSignal("settings", { theme: "light" });
+    const cb = b.persistedSignal("settings", { theme: "dark" });
+    ca.value = { theme: "light" };
+    cb.value = { theme: "dark" };
+    expect(window.localStorage.getItem("app-a:settings")).toBe(
+      '{"theme":"light"}',
+    );
+    expect(window.localStorage.getItem("app-b:settings")).toBe(
+      '{"theme":"dark"}',
+    );
+  });
+
+  it("passes options (storage: 'session', schema, onSchemaFailure) through to persistedSignal", () => {
+    const ns = createStorageNamespace("ns-pass");
+    const onSchemaFailure = vi.fn();
+    const s = ns.persistedSignal("flag", false, {
+      storage: "session",
+      schema: (raw) => raw as boolean,
+      onSchemaFailure,
+    });
+    s.value = true;
+    expect(window.sessionStorage.getItem("ns-pass:flag")).toBe("true");
+    expect(window.localStorage.getItem("ns-pass:flag")).toBeNull();
+    expect(onSchemaFailure).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty or whitespace-only prefix", () => {
+    expect(() => createStorageNamespace("")).toThrow(TypeError);
+    expect(() => createStorageNamespace("   ")).toThrow(TypeError);
+  });
+
+  it("rejects a non-string prefix", () => {
+    expect(() =>
+      createStorageNamespace(undefined as unknown as string),
+    ).toThrow(TypeError);
+    expect(() =>
+      createStorageNamespace(null as unknown as string),
+    ).toThrow(TypeError);
   });
 });

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -12,41 +12,78 @@
 // ============================================================================
 
 /**
+ * Options for {@link randomId}.
+ *
+ * Both fields are optional; omitting both preserves the zero-arg behaviour.
+ */
+export interface RandomIdOptions {
+  /**
+   * String prepended to the UUID. No separator is inserted — pass
+   * `"todo_"` or `"item-"` if you want one. Handy for making `each({ key })`
+   * values self-describing (e.g. `todo_01K1…`).
+   */
+  prefix?: string;
+  /**
+   * Override the source of randomness. When supplied, `crypto.randomUUID()`
+   * is bypassed entirely and the fallback synthesis runs with this function
+   * in place of `Math.random`. The primary use-case is **deterministic ids
+   * for snapshot tests**: pass a seeded PRNG to get reproducible output.
+   *
+   * The function must return a value in `[0, 1)` (same contract as
+   * `Math.random`). A degenerate `() => 0` returns an all-zero UUID.
+   */
+  rng?: () => number;
+}
+
+/**
  * Generate a UUID-v4-shaped random identifier.
  *
  * ```ts
  * import { randomId } from "@whisq/core/ids";
  *
  * const todo = { id: randomId(), text, done: false };
+ * const scoped = randomId({ prefix: "todo_" });      // "todo_01K1..."
+ * const seeded = randomId({ rng: seedrandom(42) });  // deterministic
  * ```
  *
- * Prefers `crypto.randomUUID()` when the platform provides it (all modern
- * browsers; Node 19+; Deno; Bun). Otherwise falls back to a `Math.random`
- * synthesis — same v4 shape (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` where
- * `y ∈ {8, 9, a, b}`), but with weaker entropy. Good enough for UI row
+ * Without options, prefers `crypto.randomUUID()` when the platform provides
+ * it (all modern browsers; Node 19+; Deno; Bun). Otherwise falls back to a
+ * `Math.random` synthesis — same v4 shape (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`
+ * where `y ∈ {8, 9, a, b}`), but with weaker entropy. Good enough for UI row
  * ids and keyed-`each` keys; not for tokens, secrets, or deduplication
  * across independent clients.
+ *
+ * When `options.rng` is supplied, the native path is skipped regardless of
+ * platform so the same code yields the same id in every environment — the
+ * point is testability, not randomness.
  */
-export function randomId(): string {
+export function randomId(options?: RandomIdOptions): string {
+  const prefix = options?.prefix ?? "";
+  const rng = options?.rng;
+
+  if (rng) {
+    return prefix + fallbackUuid(rng);
+  }
+
   if (
     typeof crypto !== "undefined" &&
     typeof crypto.randomUUID === "function"
   ) {
-    return crypto.randomUUID();
+    return prefix + crypto.randomUUID();
   }
-  return fallbackUuid();
+  return prefix + fallbackUuid();
 }
 
-function fallbackUuid(): string {
+function fallbackUuid(rng: () => number = Math.random): string {
   // Compose 32 hex digits, then splice in the v4 version (4) and variant
   // (8/9/a/b) bits at positions 12 and 16. Output shape matches RFC 4122 v4.
   const hex = (digits: number): string => {
     let out = "";
     for (let i = 0; i < digits; i++) {
-      out += Math.floor(Math.random() * 16).toString(16);
+      out += Math.floor(rng() * 16).toString(16);
     }
     return out;
   };
-  const variant = ((Math.random() * 4) | 0) + 8; // 8..11 → 8,9,a,b
+  const variant = ((rng() * 4) | 0) + 8; // 8..11 → 8,9,a,b
   return `${hex(8)}-${hex(4)}-4${hex(3)}-${variant.toString(16)}${hex(3)}-${hex(12)}`;
 }

--- a/packages/core/src/persistence.ts
+++ b/packages/core/src/persistence.ts
@@ -145,3 +145,59 @@ export function persistedSignal<T>(
 
   return sig;
 }
+
+/**
+ * A namespaced persistence surface — exposes a `persistedSignal` that
+ * prepends a fixed prefix to every storage key, joined by `":"`.
+ */
+export interface StorageNamespace {
+  /**
+   * Like {@link persistedSignal}, but the storage key is transparently
+   * rewritten to `${prefix}:${key}`. The underlying storage behaviour is
+   * unchanged — SSR-safe, schema-validated, quota-safe.
+   */
+  persistedSignal<T>(
+    key: string,
+    initial: T,
+    options?: PersistedSignalOptions<T>,
+  ): Signal<T>;
+}
+
+/**
+ * Create a key-prefixed view over `persistedSignal` so several apps on the
+ * same origin can coexist without stomping on each other's storage slots.
+ *
+ * ```ts
+ * import { createStorageNamespace } from "@whisq/core/persistence";
+ *
+ * const app = createStorageNamespace("whisq-todo-app");
+ * export const todos = app.persistedSignal<Todo[]>("todos", []);
+ * //                                                ^ actual key: "whisq-todo-app:todos"
+ * export const settings = app.persistedSignal<Settings>("settings", DEFAULTS);
+ * ```
+ *
+ * Two namespaces with distinct prefixes never collide; within one namespace,
+ * keys follow the usual `persistedSignal` shape. The helper is a
+ * compositional thin wrapper — calling `app.persistedSignal(k, v, opts)` is
+ * exactly equivalent to `persistedSignal(\`${prefix}:${k}\`, v, opts)`.
+ *
+ * Empty or whitespace prefixes are rejected — they defeat the purpose and
+ * most often indicate the caller forgot to interpolate an app name.
+ */
+export function createStorageNamespace(prefix: string): StorageNamespace {
+  if (typeof prefix !== "string" || prefix.trim().length === 0) {
+    throw new TypeError(
+      "createStorageNamespace: prefix must be a non-empty string",
+    );
+  }
+
+  return {
+    persistedSignal<T>(
+      key: string,
+      initial: T,
+      options?: PersistedSignalOptions<T>,
+    ): Signal<T> {
+      return persistedSignal<T>(`${prefix}:${key}`, initial, options);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Two small additive helpers closing the last alpha.9 feedback concerns landed against `@whisq/core` (N5 + N7 from Claude's review).

- **`createStorageNamespace(prefix)`** on `@whisq/core/persistence` — returns a `{ persistedSignal }` view whose storage keys are transparently rewritten to `${prefix}:${key}`. Thin compositional wrapper; every existing option (`storage`, `schema`, `onSchemaFailure`, …) passes straight through. Empty or whitespace prefixes throw `TypeError` so a forgotten interpolation fails loudly.
- **`randomId(options?)`** on `@whisq/core/ids` — now accepts `{ prefix, rng }`. Zero-arg call unchanged (backwards compatible). `prefix` concatenates with no separator (caller chooses). `rng` replaces `Math.random` in the fallback synthesis **and** bypasses `crypto.randomUUID`, so a seeded PRNG yields the same id on every environment — the testability point the issue called out.

## Examples

```ts
import { createStorageNamespace } from "@whisq/core/persistence";
const app = createStorageNamespace("whisq-todo-app");
const todos = app.persistedSignal<Todo[]>("todos", []);
//                                        ↑ key: "whisq-todo-app:todos"

import { randomId } from "@whisq/core/ids";
randomId({ prefix: "todo_" });          // "todo_01K1…"
randomId({ rng: seedrandom(42) });      // deterministic across environments
```

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm test` — 26 files / 480 tests (+13 from baseline: 7 new ids + 6 new persistence)
- [x] `randomId({ prefix })` prepends without separator; empty prefix no-op; shape matches v4
- [x] `randomId({ rng })` is deterministic; bypasses `crypto.randomUUID`; combines with prefix; degenerate `() => 0` returns all-zero UUID
- [x] `createStorageNamespace` writes under `prefix:key`; reads from `prefix:key` on init; two namespaces isolated; options pass through to `persistedSignal`; rejects empty/whitespace/non-string prefix
- [x] No changes to existing `randomId()` / `persistedSignal()` signatures — drop-in backwards compatible

## Follow-up (docs repo)

`whisq.dev` `/api/randomid/` and `/api/persistedsignal/` pages should gain short sections on the new options — rides the next docs-bump cycle alongside the other alpha.10 doc updates.

Closes #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)