### PR TITLE
WHISQ-138: enriched public-api.json spike + MCP signals topic migration

### DIFF
--- a/.changeset/enriched-api-metadata-spike.md
+++ b/.changeset/enriched-api-metadata-spike.md
@@ -1,0 +1,31 @@
+---
+"@whisq/core": minor
+"@whisq/mcp-server": minor
+---
+
+**Spike:** first slice of the enriched `public-api.json` from #103 — ships a drift-validated per-symbol metadata manifest, populates it for the `signals` topic, and wires the MCP server's `signals` docs to consume it.
+
+### `@whisq/core`
+
+- New artefact: `dist/public-api-annotated.json`. Schema spec at `packages/core/docs/api-metadata-schema.md`. Current shape — `{ version, schemaVersion: 1, symbols: SymbolEntry[] }` — is frozen behind `schemaVersion` so consumers can guard against breaking changes.
+- New exports-map entry: `"@whisq/core/public-api-annotated.json"` — the public path consumers import from.
+- Hand-curated source of truth at `packages/core/metadata/api-enrichment.json`. The build step runs `scripts/generate-api-metadata.mjs` after `generate-public-api.mjs` and fails with a non-zero exit if:
+  - a `symbols[*].name` is not in `public-api.json` exports (drift),
+  - a `seeAlso[*]` reference is not in `public-api.json` exports (drift),
+  - any required field on a `SymbolEntry` is missing or wrong type,
+  - a duplicate symbol entry appears.
+- Populated for one topic this release: `signals` (`signal`, `computed`, `effect`, `batch`). The names-only `public-api.json` is unchanged — this is a sibling file, not a replacement. See #103 for the path to unification.
+
+### `@whisq/mcp-server`
+
+- New `@whisq/core` workspace dependency (was previously untyped docs; now consumes the annotated manifest).
+- `api-docs.ts` `signals` topic is generated from the enriched manifest at build time — no more hand-written drift. The other topics (`elements`, `components`, `routing`, …) remain hand-written until the schema stabilises; migrating them is a follow-up tracked against #103.
+- Load-bearing phrases consumers grep for (`signal(`, `computed(`, `.value`, `peek()`, `batch(() =>`) are locked in by a new regression test block.
+
+### Out of scope (follow-ups)
+
+- CI drift check between `public-api.json` and `public-api-annotated.json` (all existing exports must have enrichment) — follow-up once the other topics migrate.
+- Migrating the remaining MCP topics — mechanical once this spike's shape is validated across a release cycle.
+- Unifying the two manifests into one — option A in #103; gated on 1–2 releases of stable schema.
+
+Closes #138.

--- a/packages/core/docs/api-metadata-schema.md
+++ b/packages/core/docs/api-metadata-schema.md
@@ -1,0 +1,128 @@
+# Whisq Core — API Metadata Schema (v1)
+
+This document specifies the shape of `packages/core/dist/public-api-annotated.json` — the **enriched** companion to the names-only `dist/public-api.json`. It's the first consumer-facing artefact for AI-native tooling that needs structured knowledge about framework symbols: not just "does `signal` exist", but "what's its shape, what are its common misuse patterns, what else is worth reading next."
+
+Status: **schema v1, spike**. Populated for one topic (`signals`) as proof-of-value. Expected to stabilise across alpha.10–alpha.11 as consumers prove the shape; see #103 for the umbrella roadmap.
+
+## Why a separate manifest
+
+The existing `dist/public-api.json` is a **drift-guard**: a flat list of export names that external tooling (docs pages, the MCP server, pre-commit checks) uses to detect when the framework's exported surface has changed. Annotating it in-place would risk breaking those consumers. The enriched manifest is a sibling file with its own URL, its own contract, and an explicit `schemaVersion` field so consumers can guard against breaking changes as the shape evolves.
+
+Once v1 is validated (2+ releases, 2+ consumers), we may unify into a single file (see #103 option A). Until then, both files exist side-by-side.
+
+## File locations
+
+| File | Purpose |
+| --- | --- |
+| `packages/core/metadata/api-enrichment.json` | **Source of truth** — curated per-symbol metadata, hand-edited. Not shipped. |
+| `packages/core/dist/public-api-annotated.json` | **Build output** — version-stamped, drift-validated manifest. Shipped in the npm tarball. |
+| `packages/core/scripts/generate-api-metadata.mjs` | Generator — reads `metadata/api-enrichment.json` + `dist/public-api.json` + `package.json`, writes the build output. |
+
+Consumers import from the package exports map:
+
+```ts
+import annotated from "@whisq/core/public-api-annotated.json" with { type: "json" };
+```
+
+## Top-level shape
+
+```ts
+interface EnrichedManifest {
+  /** npm package version the manifest was generated for, e.g. "0.1.0-alpha.9". */
+  version: string;
+  /** Incremented on breaking changes to this schema. v1 as of this PR. */
+  schemaVersion: 1;
+  /** One entry per documented symbol. Ordered alphabetically by `name`. */
+  symbols: SymbolEntry[];
+}
+```
+
+## `SymbolEntry` shape
+
+```ts
+interface SymbolEntry {
+  /** The exported name. MUST appear in public-api.json (drift-validated). */
+  name: string;
+  /** What kind of declaration this is. */
+  kind: "function" | "class" | "type" | "interface" | "const" | "namespace";
+  /** The canonical TypeScript signature as a single string. */
+  signature: string;
+  /**
+   * One-sentence description. Complete sentence, not fragment. Leads with the verb
+   * for functions ("Create a reactive value.", "Compose two bind results.").
+   */
+  summary: string;
+  /**
+   * Zero-or-more known misuse patterns. Each is a complete sentence describing
+   * what goes wrong and how to avoid it. Keep to one-liners when possible; escape
+   * hatches and long explanations belong in the full docs, not here.
+   */
+  gotchas: string[];
+  /**
+   * Zero-or-more idiomatic examples. Code strings (no markdown fences). The
+   * consumer decides how to present them (Markdown code block, plain text, …).
+   */
+  examples: string[];
+  /** First version the symbol was exported. Used by the consumer for "since" hints. */
+  since: string;
+  /** Other symbol names the reader is likely to want next. Drift-validated. */
+  seeAlso: string[];
+  /**
+   * Coarse-grained topic grouping for consumers that organise docs by topic
+   * rather than by symbol. Aligns with the MCP server's `ApiTopic` enum where
+   * possible ("signals" | "elements" | "components" | "routing" | …).
+   */
+  topic: string;
+}
+```
+
+## Drift guards
+
+The generator MUST enforce, and fail the build with a non-zero exit code, if any of:
+
+1. A `symbols[*].name` that isn't in `public-api.json`'s `exports[]` list.
+2. A `seeAlso[*]` reference that isn't in `public-api.json`'s `exports[]` list.
+3. A missing required field on a `SymbolEntry`.
+
+This guarantees the enriched manifest can't reference ghosts or lag behind the names-only list.
+
+## Worked example — `signal()`
+
+The source-of-truth entry (hand-edited in `metadata/api-enrichment.json`):
+
+```json
+{
+  "name": "signal",
+  "kind": "function",
+  "signature": "signal<T>(initial: T): Signal<T>",
+  "summary": "Create a reactive value that tracks reads and notifies on writes.",
+  "gotchas": [
+    "Mutating an array or object in place (e.g. items.value.push(x)) does not trigger updates — use items.value = [...items.value, x] so the identity changes.",
+    "Passing a signal as an element child (e.g. div(count.value)) captures the value once. Wrap in a function (e.g. () => count.value) for reactive rendering.",
+    "peek() reads without tracking — do not use it inside a computed/effect expecting reactivity."
+  ],
+  "examples": [
+    "const count = signal(0);\ncount.value = 5;\ncount.update(n => n + 1);\ncount.peek();"
+  ],
+  "since": "0.1.0-alpha.1",
+  "seeAlso": ["computed", "effect", "batch"],
+  "topic": "signals"
+}
+```
+
+After the generator runs, that entry appears inside the top-level `symbols` array of `dist/public-api-annotated.json`, with the package's current `version` and `schemaVersion: 1` stamped in.
+
+## Evolution rules
+
+- **Additive changes** (new optional fields on `SymbolEntry`, new topics) do not bump `schemaVersion`.
+- **Breaking changes** (removing a field, renaming a field, changing a field's type) bump `schemaVersion` to `2`. Consumers guard on the number.
+- **The `topic` grouping is conventional, not enforced** — new topics can be added freely. The MCP server's `ApiTopic` enum is the de-facto registry.
+
+## Open items for v2+
+
+Tracked on #103 (umbrella):
+
+- Stability annotations (`experimental` | `stable` | `deprecated`) once Whisq reaches `0.1.0`.
+- Parameter-level documentation (`params[]`) for functions with complex options objects.
+- Unification with `public-api.json` (option A from #103) once schema is stable.
+- TSDoc auto-extraction as a secondary source, with curated enrichment filling gaps.

--- a/packages/core/metadata/api-enrichment.json
+++ b/packages/core/metadata/api-enrichment.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "symbols": [
+    {
+      "name": "signal",
+      "kind": "function",
+      "signature": "signal<T>(initial: T): Signal<T>",
+      "summary": "Create a reactive value that tracks reads and notifies on writes.",
+      "gotchas": [
+        "Mutating an array or object in place (e.g. items.value.push(x)) does not trigger updates — use items.value = [...items.value, x] so the identity changes.",
+        "Passing a signal as an element child (e.g. div(count.value)) captures the value once. Wrap in a function (e.g. () => count.value) for reactive rendering.",
+        "peek() reads without tracking — do not use it inside a computed/effect expecting reactivity."
+      ],
+      "examples": [
+        "const count = signal(0);\ncount.value;            // read (tracked)\ncount.value = 5;        // write (notifies)\ncount.update(n => n + 1);\ncount.peek();           // read (NOT tracked)"
+      ],
+      "since": "0.1.0-alpha.1",
+      "seeAlso": ["computed", "effect", "batch"],
+      "topic": "signals"
+    },
+    {
+      "name": "computed",
+      "kind": "function",
+      "signature": "computed<T>(fn: () => T): ReadonlySignal<T>",
+      "summary": "Derive a reactive value from other signals; re-runs lazily when its dependencies change.",
+      "gotchas": [
+        "The returned signal is read-only — you cannot write doubled.value = x. Attempting to coerces at the type level; at runtime the setter is absent.",
+        "Dependency tracking is dynamic — an unread branch of an if/else does not create a dependency. Structure the function so reactivity follows the actual read path."
+      ],
+      "examples": [
+        "const count = signal(0);\nconst doubled = computed(() => count.value * 2);\n// doubled.value re-reads when count.value changes"
+      ],
+      "since": "0.1.0-alpha.1",
+      "seeAlso": ["signal", "effect", "batch"],
+      "topic": "signals"
+    },
+    {
+      "name": "effect",
+      "kind": "function",
+      "signature": "effect(fn: () => void | (() => void)): () => void",
+      "summary": "Run a side effect that re-executes when any signal it reads changes.",
+      "gotchas": [
+        "Return a cleanup function from the effect body if you need to tear down subscriptions, timers, or event listeners — it runs before each re-execution and on final disposal.",
+        "Calling the dispose function is the only way to stop an effect. Component effects wired via onMount/onCleanup handle this automatically; standalone effects are the caller's responsibility."
+      ],
+      "examples": [
+        "const dispose = effect(() => {\n  console.log(count.value);\n  return () => console.log('cleanup');\n});\ndispose(); // stop receiving updates"
+      ],
+      "since": "0.1.0-alpha.1",
+      "seeAlso": ["signal", "computed", "batch"],
+      "topic": "signals"
+    },
+    {
+      "name": "batch",
+      "kind": "function",
+      "signature": "batch(fn: () => void): void",
+      "summary": "Group multiple signal writes so dependent effects and computeds re-run only once afterward.",
+      "gotchas": [
+        "batch() is synchronous — await inside the callback defeats the batching (writes after the await land outside the batch).",
+        "Throwing inside batch() still flushes pending effects before the error propagates so the UI doesn't get stranded in an inconsistent state."
+      ],
+      "examples": [
+        "batch(() => {\n  x.value = 1;\n  y.value = 2;\n});\n// one update cycle, not two"
+      ],
+      "since": "0.1.0-alpha.1",
+      "seeAlso": ["signal", "computed", "effect"],
+      "topic": "signals"
+    }
+  ]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,14 +26,15 @@
     "./ids": {
       "types": "./dist/ids.d.ts",
       "import": "./dist/ids.js"
-    }
+    },
+    "./public-api-annotated.json": "./dist/public-api-annotated.json"
   },
   "files": [
     "dist",
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node scripts/generate-public-api.mjs",
+    "build": "tsc -p tsconfig.build.json && node scripts/generate-public-api.mjs && node scripts/generate-api-metadata.mjs",
     "dev": "tsc --watch -p tsconfig.build.json",
     "test": "vitest run --passWithNoTests",
     "size": "size-limit",

--- a/packages/core/scripts/generate-api-metadata.mjs
+++ b/packages/core/scripts/generate-api-metadata.mjs
@@ -1,0 +1,204 @@
+// ============================================================================
+// Whisq Core — Enriched API metadata generator (WHISQ-138)
+//
+// Reads metadata/api-enrichment.json (curated source of truth) and merges it
+// with the current package version + the names-only export list from
+// dist/public-api.json. Writes dist/public-api-annotated.json — the first
+// consumer-facing artefact of the schema defined in
+// packages/core/docs/api-metadata-schema.md.
+//
+// Drift guards (non-zero exit on failure):
+//   1. Every symbols[*].name must be in public-api.json's exports[].
+//   2. Every seeAlso[*] reference must be in public-api.json's exports[].
+//   3. Every SymbolEntry must have all required fields with matching types.
+//
+// Pure validation / assembly logic is exported so the (future) test file can
+// exercise it without touching the filesystem. The CLI block at the bottom
+// handles IO; everything above it is deterministic data-in / data-out.
+// ============================================================================
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const REQUIRED_SYMBOL_FIELDS = [
+  "name",
+  "kind",
+  "signature",
+  "summary",
+  "gotchas",
+  "examples",
+  "since",
+  "seeAlso",
+  "topic",
+];
+
+const VALID_KINDS = new Set([
+  "function",
+  "class",
+  "type",
+  "interface",
+  "const",
+  "namespace",
+]);
+
+/**
+ * Validate a single SymbolEntry against the schema. Returns an array of
+ * human-readable error strings; empty array means the entry is valid.
+ */
+export function validateSymbolEntry(entry, exportNames) {
+  const errs = [];
+  if (typeof entry !== "object" || entry === null) {
+    return [`entry is not an object`];
+  }
+
+  for (const field of REQUIRED_SYMBOL_FIELDS) {
+    if (!(field in entry)) {
+      errs.push(`missing required field: "${field}"`);
+    }
+  }
+  if (errs.length > 0) return errs;
+
+  if (typeof entry.name !== "string" || entry.name.length === 0) {
+    errs.push(`name must be a non-empty string`);
+  }
+  if (!VALID_KINDS.has(entry.kind)) {
+    errs.push(
+      `kind "${entry.kind}" is not one of ${[...VALID_KINDS].join(" | ")}`,
+    );
+  }
+  for (const strField of ["signature", "summary", "since", "topic"]) {
+    if (typeof entry[strField] !== "string" || entry[strField].length === 0) {
+      errs.push(`${strField} must be a non-empty string`);
+    }
+  }
+  for (const arrField of ["gotchas", "examples", "seeAlso"]) {
+    if (!Array.isArray(entry[arrField])) {
+      errs.push(`${arrField} must be an array`);
+    } else if (entry[arrField].some((s) => typeof s !== "string")) {
+      errs.push(`${arrField} must contain only strings`);
+    }
+  }
+
+  if (errs.length > 0) return errs;
+
+  if (!exportNames.has(entry.name)) {
+    errs.push(
+      `name "${entry.name}" is not in public-api.json exports — drift`,
+    );
+  }
+  for (const ref of entry.seeAlso) {
+    if (!exportNames.has(ref)) {
+      errs.push(
+        `seeAlso reference "${ref}" (from ${entry.name}) is not in public-api.json exports — drift`,
+      );
+    }
+  }
+
+  return errs;
+}
+
+/**
+ * Build the annotated manifest. Returns `{ ok: true, manifest }` on success
+ * or `{ ok: false, errors }` when any drift / schema violation is found.
+ */
+export function buildAnnotatedManifest({ version, exports, enrichment }) {
+  const exportNames = new Set(exports);
+  const errors = [];
+
+  if (!enrichment || typeof enrichment !== "object") {
+    return { ok: false, errors: ["enrichment payload is missing or not an object"] };
+  }
+  if (enrichment.schemaVersion !== 1) {
+    errors.push(
+      `enrichment.schemaVersion must be 1 (got ${JSON.stringify(enrichment.schemaVersion)})`,
+    );
+  }
+  if (!Array.isArray(enrichment.symbols)) {
+    return {
+      ok: false,
+      errors: [...errors, "enrichment.symbols must be an array"],
+    };
+  }
+
+  const seenNames = new Set();
+  for (const entry of enrichment.symbols) {
+    const entryErrs = validateSymbolEntry(entry, exportNames);
+    if (entryErrs.length > 0) {
+      const label = typeof entry?.name === "string" ? entry.name : "<unknown>";
+      for (const err of entryErrs) {
+        errors.push(`[${label}] ${err}`);
+      }
+      continue;
+    }
+    if (seenNames.has(entry.name)) {
+      errors.push(`[${entry.name}] duplicate symbol entry`);
+    }
+    seenNames.add(entry.name);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const symbols = [...enrichment.symbols].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  return {
+    ok: true,
+    manifest: {
+      version,
+      schemaVersion: 1,
+      symbols,
+    },
+  };
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+const isDirectRun =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url === `file:///${process.argv[1].replace(/\\/g, "/")}`;
+
+if (isDirectRun) {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const pkgRoot = resolve(__dirname, "..");
+
+  const pkg = JSON.parse(
+    readFileSync(resolve(pkgRoot, "package.json"), "utf8"),
+  );
+
+  const publicApiPath = resolve(pkgRoot, "dist/public-api.json");
+  if (!existsSync(publicApiPath)) {
+    console.error(
+      `[generate-api-metadata] ${publicApiPath} not found — run generate-public-api.mjs first.`,
+    );
+    process.exit(1);
+  }
+  const publicApi = JSON.parse(readFileSync(publicApiPath, "utf8"));
+
+  const enrichmentPath = resolve(pkgRoot, "metadata/api-enrichment.json");
+  const enrichment = JSON.parse(readFileSync(enrichmentPath, "utf8"));
+
+  const result = buildAnnotatedManifest({
+    version: pkg.version,
+    exports: publicApi.exports,
+    enrichment,
+  });
+
+  if (!result.ok) {
+    console.error("[generate-api-metadata] validation failed:");
+    for (const err of result.errors) {
+      console.error(`  - ${err}`);
+    }
+    process.exit(1);
+  }
+
+  const outPath = resolve(pkgRoot, "dist/public-api-annotated.json");
+  writeFileSync(outPath, JSON.stringify(result.manifest, null, 2) + "\n");
+
+  console.log(
+    `Wrote ${outPath}: ${result.manifest.symbols.length} symbols, version ${result.manifest.version} (schemaVersion ${result.manifest.schemaVersion})`,
+  );
+}

--- a/packages/core/src/__tests__/generate-api-metadata.test.ts
+++ b/packages/core/src/__tests__/generate-api-metadata.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error — .mjs build script exports plain JS; typechecker can't see types.
+import {
+  validateSymbolEntry,
+  buildAnnotatedManifest,
+} from "../../scripts/generate-api-metadata.mjs";
+
+const exportNames = new Set([
+  "signal",
+  "computed",
+  "effect",
+  "batch",
+  "div",
+]);
+
+function validEntry(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    name: "signal",
+    kind: "function",
+    signature: "signal<T>(initial: T): Signal<T>",
+    summary: "Create a reactive value.",
+    gotchas: [],
+    examples: [],
+    since: "0.1.0-alpha.1",
+    seeAlso: ["computed", "effect"],
+    topic: "signals",
+    ...overrides,
+  };
+}
+
+describe("validateSymbolEntry", () => {
+  it("accepts a well-formed entry with no errors", () => {
+    const errs = validateSymbolEntry(validEntry(), exportNames);
+    expect(errs).toEqual([]);
+  });
+
+  it("reports missing required fields", () => {
+    const errs = validateSymbolEntry({ name: "signal" }, exportNames);
+    expect(errs.some((e: string) => e.includes("kind"))).toBe(true);
+    expect(errs.some((e: string) => e.includes("signature"))).toBe(true);
+    expect(errs.some((e: string) => e.includes("summary"))).toBe(true);
+  });
+
+  it("rejects unknown kinds", () => {
+    const errs = validateSymbolEntry(
+      validEntry({ kind: "widget" }),
+      exportNames,
+    );
+    expect(errs.some((e: string) => e.includes("kind"))).toBe(true);
+  });
+
+  it("rejects arrays that contain non-strings", () => {
+    const errs = validateSymbolEntry(
+      validEntry({ gotchas: ["ok", 42] }),
+      exportNames,
+    );
+    expect(errs.some((e: string) => e.includes("gotchas"))).toBe(true);
+  });
+
+  it("fails drift when name is not a known export", () => {
+    const errs = validateSymbolEntry(
+      validEntry({ name: "doesNotExist" }),
+      exportNames,
+    );
+    expect(errs.some((e: string) => e.includes("drift"))).toBe(true);
+  });
+
+  it("fails drift when a seeAlso reference is not a known export", () => {
+    const errs = validateSymbolEntry(
+      validEntry({ seeAlso: ["signal", "ghostSymbol"] }),
+      exportNames,
+    );
+    expect(errs.some((e: string) => e.includes("ghostSymbol"))).toBe(true);
+    expect(errs.some((e: string) => e.includes("drift"))).toBe(true);
+  });
+});
+
+describe("buildAnnotatedManifest", () => {
+  it("returns ok + stamps version + sorts symbols alphabetically", () => {
+    const result = buildAnnotatedManifest({
+      version: "9.9.9",
+      exports: [...exportNames],
+      enrichment: {
+        schemaVersion: 1,
+        symbols: [validEntry({ name: "effect" }), validEntry({ name: "batch" })],
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.manifest.version).toBe("9.9.9");
+    expect(result.manifest.schemaVersion).toBe(1);
+    expect(result.manifest.symbols.map((s: { name: string }) => s.name)).toEqual([
+      "batch",
+      "effect",
+    ]);
+  });
+
+  it("aggregates per-entry validation errors and labels them", () => {
+    const result = buildAnnotatedManifest({
+      version: "1.0.0",
+      exports: [...exportNames],
+      enrichment: {
+        schemaVersion: 1,
+        symbols: [
+          validEntry({ name: "nope" }), // drift
+          validEntry({ kind: "widget" }), // invalid kind
+        ],
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e: string) => e.startsWith("[nope]"))).toBe(true);
+    expect(result.errors.some((e: string) => e.startsWith("[signal]"))).toBe(true);
+  });
+
+  it("rejects a wrong schemaVersion at the top level", () => {
+    const result = buildAnnotatedManifest({
+      version: "1.0.0",
+      exports: [...exportNames],
+      enrichment: { schemaVersion: 999, symbols: [validEntry()] },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e: string) => e.includes("schemaVersion"))).toBe(
+      true,
+    );
+  });
+
+  it("flags duplicate symbol entries", () => {
+    const result = buildAnnotatedManifest({
+      version: "1.0.0",
+      exports: [...exportNames],
+      enrichment: {
+        schemaVersion: 1,
+        symbols: [validEntry({ name: "signal" }), validEntry({ name: "signal" })],
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e: string) => e.includes("duplicate"))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -35,6 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@whisq/core": "workspace:*",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/packages/mcp-server/src/__tests__/api-docs.test.ts
+++ b/packages/mcp-server/src/__tests__/api-docs.test.ts
@@ -15,6 +15,52 @@ describe("queryApi", () => {
     expect(result.content).toContain("computed(");
   });
 
+  describe("signals topic — load-bearing phrases after migration to enriched manifest (WHISQ-138)", () => {
+    // The signals topic is now generated from the @whisq/core enriched
+    // manifest rather than hand-written. These assertions pin the phrases
+    // consumers have depended on so a metadata edit can't silently drop them.
+    const content = queryApi("signals").content;
+
+    it("keeps the top-level '# Signals' heading", () => {
+      expect(content).toMatch(/^# Signals/);
+    });
+
+    it("covers the four core reactive primitives in their signature form", () => {
+      for (const snippet of [
+        "signal<T>(initial: T)",
+        "computed<T>(fn: () => T)",
+        "effect(fn:",
+        "batch(fn:",
+      ]) {
+        expect(content).toContain(snippet);
+      }
+    });
+
+    it("keeps the canonical usage phrases that API consumers grep for", () => {
+      for (const phrase of [
+        ".value",
+        "peek()",
+        "count.update",
+        "computed(() =>",
+        "batch(() =>",
+      ]) {
+        expect(content).toContain(phrase);
+      }
+    });
+
+    it("surfaces the array-mutation and stale-child gotchas (the two top signal footguns)", () => {
+      expect(content).toMatch(/items\.value\.push.*does not trigger/i);
+      expect(content).toMatch(/captures the value once/i);
+    });
+
+    it("links related primitives via See also", () => {
+      expect(content).toContain("**See also:**");
+      expect(content).toContain("computed");
+      expect(content).toContain("effect");
+      expect(content).toContain("batch");
+    });
+  });
+
   it("returns elements docs", () => {
     const result = queryApi("elements");
     expect(result.content).toContain("div(");

--- a/packages/mcp-server/src/tools/api-docs.ts
+++ b/packages/mcp-server/src/tools/api-docs.ts
@@ -1,7 +1,15 @@
 /**
  * Query Whisq API reference by topic. Returns structured documentation
  * that AI tools can use to generate accurate code.
+ *
+ * Topics are mostly hand-written below. The `signals` topic is generated
+ * from the enriched manifest shipped by @whisq/core (see WHISQ-138):
+ * `@whisq/core/public-api-annotated.json` is the drift-validated source of
+ * truth. The other topics remain hand-written for now — migrating them is
+ * tracked against #103.
  */
+
+import annotatedManifest from "@whisq/core/public-api-annotated.json" with { type: "json" };
 
 export type ApiTopic =
   | "signals"
@@ -19,6 +27,72 @@ export type ApiTopic =
 export interface ApiDocResult {
   topic: string;
   content: string;
+}
+
+interface EnrichedSymbol {
+  name: string;
+  kind: string;
+  signature: string;
+  summary: string;
+  gotchas: string[];
+  examples: string[];
+  since: string;
+  seeAlso: string[];
+  topic: string;
+}
+
+interface EnrichedManifest {
+  version: string;
+  schemaVersion: number;
+  symbols: EnrichedSymbol[];
+}
+
+const MANIFEST = annotatedManifest as EnrichedManifest;
+
+const TOPIC_TITLES: Record<ApiTopic, string> = {
+  overview: "Whisq API Overview",
+  signals: "Signals",
+  elements: "Elements",
+  components: "Components",
+  routing: "Routing (@whisq/router)",
+  styling: "Styling",
+  forms: "Forms",
+  lists: "Lists",
+  async: "Async Data",
+  ssr: "SSR (@whisq/ssr)",
+  testing: "Testing (@whisq/testing)",
+};
+
+function renderSymbol(symbol: EnrichedSymbol): string {
+  const parts: string[] = [];
+  parts.push(`## ${symbol.signature}`);
+  parts.push("");
+  parts.push(symbol.summary);
+  for (const example of symbol.examples) {
+    parts.push("");
+    parts.push("```ts");
+    parts.push(example);
+    parts.push("```");
+  }
+  if (symbol.gotchas.length > 0) {
+    parts.push("");
+    parts.push("**Gotchas:**");
+    for (const gotcha of symbol.gotchas) {
+      parts.push(`- ${gotcha}`);
+    }
+  }
+  if (symbol.seeAlso.length > 0) {
+    parts.push("");
+    parts.push(`**See also:** ${symbol.seeAlso.join(", ")}`);
+  }
+  return parts.join("\n");
+}
+
+function renderTopicFromManifest(topic: ApiTopic): string {
+  const title = TOPIC_TITLES[topic];
+  const symbols = MANIFEST.symbols.filter((s) => s.topic === topic);
+  const sections = symbols.map((s) => renderSymbol(s));
+  return [`# ${title}`, "", ...sections].join("\n");
 }
 
 const DOCS: Record<ApiTopic, string> = {
@@ -40,40 +114,7 @@ Whisq is an AI-native JavaScript/TypeScript framework. No JSX, no build step.
 import { signal, computed, effect, batch, div, span, button, component, mount } from "@whisq/core";
 \`\`\``,
 
-  signals: `# Signals
-
-## signal(initialValue)
-Create a reactive value.
-\`\`\`ts
-const count = signal(0);
-count.value;           // read (triggers tracking)
-count.value = 5;       // write (triggers updates)
-count.update(n => n + 1); // update via function
-count.peek();          // read WITHOUT tracking
-\`\`\`
-
-## computed(fn)
-Derived value that auto-updates when dependencies change.
-\`\`\`ts
-const doubled = computed(() => count.value * 2);
-\`\`\`
-
-## effect(fn)
-Side effect that re-runs when dependencies change.
-\`\`\`ts
-const dispose = effect(() => console.log(count.value));
-dispose(); // cleanup
-\`\`\`
-
-## batch(fn)
-Batch multiple signal updates into one notification.
-\`\`\`ts
-batch(() => { x.value = 1; y.value = 2; }); // one update cycle
-\`\`\`
-
-## Anti-patterns
-- items.value.push(x) — won't trigger. Use: items.value = [...items.value, x]
-- count.value as child — wrap in function: () => count.value`,
+  signals: renderTopicFromManifest("signals"),
 
   elements: `# Elements
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
+      '@whisq/core':
+        specifier: workspace:*
+        version: link:../core
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -2805,14 +2808,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
-
   '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -3910,7 +3905,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
## Summary

First slice of the #103 umbrella. Establishes the machine-readable enriched manifest, the drift-guarded generator, and a first-consumer proof with the MCP server's `signals` topic.

### `@whisq/core`

- **New artefact:** `dist/public-api-annotated.json` (shipped in npm tarball). Schema pinned to `schemaVersion: 1` behind the public import path `@whisq/core/public-api-annotated.json`.
- **Schema spec** at `packages/core/docs/api-metadata-schema.md` — top-level shape, `SymbolEntry` fields (`name`, `kind`, `signature`, `summary`, `gotchas[]`, `examples[]`, `since`, `seeAlso[]`, `topic`), drift-guard rules, evolution policy, worked `signal()` example.
- **Source of truth** at `packages/core/metadata/api-enrichment.json` — curated per-symbol metadata (signals topic only for this spike: `signal`, `computed`, `effect`, `batch`).
- **Generator** at `packages/core/scripts/generate-api-metadata.mjs` — runs after `generate-public-api.mjs` in the existing build step. Non-zero exit on any drift / schema violation.

### `@whisq/mcp-server`

- Gains `@whisq/core: workspace:*` dependency.
- `api-docs.ts` `signals` topic now rendered from the enriched manifest (`renderTopicFromManifest("signals")`) — no more hand-written drift. Other topics stay hand-written for now; migration tracked against #103.

## Drift guards

Generator fails the build if:
1. A `symbols[*].name` isn't in `public-api.json` exports.
2. A `seeAlso[*]` reference isn't in `public-api.json` exports.
3. A required `SymbolEntry` field is missing or wrong type.
4. `kind` isn't one of `function | class | type | interface | const | namespace`.
5. Array fields contain non-strings.
6. A symbol entry is duplicated.

## Test plan

- [x] `pnpm build` (workspace, via turbo `^build`) — green; `core` builds before `mcp-server`.
- [x] `pnpm test` (workspace) — **622 tests across 27 core + 5 mcp-server + 1 testing + 1 devtools + 1 router suites**, all green. **+15 new:**
  - `packages/core/src/__tests__/generate-api-metadata.test.ts` — 10 tests covering `validateSymbolEntry` (happy, missing-fields, invalid-kind, non-string-arrays, name-drift, seeAlso-drift) and `buildAnnotatedManifest` (version stamping, alphabetical sort, per-entry error labels, `schemaVersion` check, duplicate rejection).
  - `packages/mcp-server/src/__tests__/api-docs.test.ts` — 5 new regression assertions in a dedicated describe block locking the `# Signals` heading, four primitives' signatures, canonical phrases (`.value`, `peek()`, `count.update`, `computed(() =>`, `batch(() =>`), the two top footgun gotchas, and the See also line.

## Out of scope (follow-ups)

- CI drift check "every `public-api.json` export must have enrichment" — follow-up once more topics migrate.
- Migrating the remaining MCP topics (`elements`, `components`, `routing`, …) — mechanical once the schema validates through a release cycle.
- Unifying `public-api.json` and `public-api-annotated.json` into one — option A in #103; gated on 1–2 releases of stable schema.

Closes #138. Umbrella: #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)