### PR TITLE
WHISQ-140: authoritative latest-version resolver + unpkg @latest propagation check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,35 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # WHISQ-140 — warn-only: verify that unpkg's @latest alias for
+      # @whisq/core/dist/public-api.json has propagated to the version we
+      # just published. The alias is CDN-cached and can lag the npm
+      # registry by minutes to hours; AI tools that resolve "the current
+      # Whisq API" through @latest will silently read the previous
+      # version during that window. This check surfaces the lag in the
+      # release-run logs. `continue-on-error: true` keeps the release
+      # green while we characterise how long the propagation window is
+      # in practice — promote to a failing check once observed stable.
+      - name: Verify unpkg @latest propagation (warn-only)
+        if: steps.changesets.outputs.published == 'true'
+        continue-on-error: true
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set +e
+          URL="https://unpkg.com/@whisq/core@latest/dist/public-api.json"
+          echo "Fetching $URL — expecting version=$VERSION"
+          SERVED=$(curl -sSfL --max-time 30 "$URL" | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{try{process.stdout.write(JSON.parse(s).version||'')}catch{process.stdout.write('')}})")
+          if [ -z "$SERVED" ]; then
+            echo "::warning title=unpkg @latest propagation::Could not read version from $URL — CDN may be serving an older payload or is unreachable."
+            exit 0
+          fi
+          if [ "$SERVED" = "$VERSION" ]; then
+            echo "unpkg @latest is already serving $VERSION — propagation complete."
+          else
+            echo "::warning title=unpkg @latest propagation::npm registry published $VERSION, but $URL still serves $SERVED. AI tools resolving @latest will see the old version until the CDN cache refreshes."
+          fi
+
   backmerge:
     needs: publish
     if: needs.publish.outputs.published == 'true'

--- a/packages/core/docs/api-metadata-schema.md
+++ b/packages/core/docs/api-metadata-schema.md
@@ -24,6 +24,47 @@ Consumers import from the package exports map:
 import annotated from "@whisq/core/public-api-annotated.json" with { type: "json" };
 ```
 
+## Consumer patterns (WHISQ-140)
+
+The manifest has two supported retrieval shapes. The choice matters because the unpkg `@latest` CDN alias can lag the npm registry's `latest` dist-tag by minutes to hours after each publish — a consumer that resolves "the current API" through the CDN alias will silently read the previous version's manifest during that window.
+
+### Pattern 1 — workspace-pinned (the MCP server)
+
+For code that builds against Whisq as a dependency and ships alongside it:
+
+```ts
+// packages/mcp-server/src/tools/api-docs.ts
+import annotatedManifest from "@whisq/core/public-api-annotated.json" with { type: "json" };
+```
+
+`@whisq/core` is a `workspace:*` dep; the symlink (or the installed tarball in downstream packages) always resolves to the exact version listed in `package.json`. There is no CDN and no lag window. The MCP server's `signals` topic uses this pattern — see `packages/mcp-server/src/tools/api-docs.ts`.
+
+Use this when the consumer ships with a pinned `@whisq/core` version — it is the cheapest and most reliable shape.
+
+### Pattern 2 — CDN-resolved via the registry (ad-hoc AI tooling)
+
+For AI scaffolders, docs generators, or any out-of-tree tool that wants the **latest published** manifest without pinning a dep:
+
+```sh
+# Never hit unpkg.com/@whisq/core@latest directly — it lags npm.
+# Resolve via the registry, then request the pinned version URL.
+
+URL=$(node packages/core/scripts/resolve-latest-api.mjs --url)
+curl -sSL "$URL" | jq .
+
+# Or as a one-liner for CI pipelines:
+VERSION=$(node packages/core/scripts/resolve-latest-api.mjs --version)
+curl -sSL "https://unpkg.com/@whisq/core@${VERSION}/dist/public-api.json"
+```
+
+The `resolve-latest-api.mjs` helper (WHISQ-140) hits `https://registry.npmjs.org/@whisq/core/latest` first — the registry API is authoritative and updates within seconds of publish — then constructs the `https://unpkg.com/@whisq/core@${version}/...` URL with an explicit version pin. unpkg serves pinned-version URLs out of the exact tarball, so the CDN-lag window is bypassed entirely.
+
+Use `--annotated-url` to target this document's subject (`public-api-annotated.json`) instead of the names-only `public-api.json`.
+
+### Anti-pattern — `unpkg.com/@whisq/core@latest/...`
+
+Fetching `https://unpkg.com/@whisq/core@latest/dist/public-api.json` (or `…@latest/dist/public-api-annotated.json`) is the shape that produces the silent-staleness bug. The `@latest` alias is CDN-cached; during the propagation window after a publish, the URL returns the previous version's manifest even though `npm view @whisq/core version` already reports the current one. AI workflows that fall into this trap produce feedback / code against an API surface that shipped under a different version number than they cite. The post-release CI check in `.github/workflows/release.yml` warns when this window is still open for the current publish.
+
 ## Top-level shape
 
 ```ts

--- a/packages/core/scripts/resolve-latest-api.mjs
+++ b/packages/core/scripts/resolve-latest-api.mjs
@@ -1,0 +1,155 @@
+// ============================================================================
+// Whisq Core — Authoritative "latest API manifest" URL resolver (WHISQ-140)
+//
+// The CDN-backed `unpkg.com/@whisq/core@latest/dist/public-api.json` URL can
+// lag the npm registry by minutes to hours after each publish. During that
+// window, AI tools that resolve "the latest Whisq" through the CDN silently
+// get the *previous* version's manifest — even though `npm view @whisq/core
+// version` reports the current one. The v0.1.0-alpha.9 Codex feedback was
+// written against a stale alpha.8 manifest before the reviewer noticed.
+//
+// This script eliminates the lag window: it hits the npm registry API first
+// (authoritative, low-latency), reads the current `version`, and prints the
+// pinned-version CDN URL that cannot serve stale content. AI scaffolders and
+// docs generators that want "the latest API surface" should chain the two:
+//
+//   CORE_VERSION=$(node packages/core/scripts/resolve-latest-api.mjs --version)
+//   curl -sSL "$(node packages/core/scripts/resolve-latest-api.mjs --url)"
+//
+// or the convenience one-shot:
+//
+//   curl -sSL "$(node packages/core/scripts/resolve-latest-api.mjs --url)" \
+//     | jq .
+//
+// Pure URL-building and version-parsing logic is exported so the unit test
+// exercises them without network I/O.
+// ============================================================================
+
+const REGISTRY_URL = "https://registry.npmjs.org/@whisq/core/latest";
+const DEFAULT_PACKAGE = "@whisq/core";
+
+/**
+ * Build the pinned unpkg URL for the `public-api.json` (names-only) manifest
+ * at a specific version. The `@${version}` pin means unpkg serves the exact
+ * tarball — never a cached "@latest" alias.
+ */
+export function pinnedPublicApiUrl(version, packageName = DEFAULT_PACKAGE) {
+  assertNonEmptyString(version, "version");
+  assertNonEmptyString(packageName, "packageName");
+  return `https://unpkg.com/${packageName}@${encodeURIComponent(version)}/dist/public-api.json`;
+}
+
+/**
+ * Build the pinned unpkg URL for the enriched `public-api-annotated.json`
+ * manifest (shipped since WHISQ-138) at a specific version.
+ */
+export function pinnedAnnotatedApiUrl(version, packageName = DEFAULT_PACKAGE) {
+  assertNonEmptyString(version, "version");
+  assertNonEmptyString(packageName, "packageName");
+  return `https://unpkg.com/${packageName}@${encodeURIComponent(version)}/dist/public-api-annotated.json`;
+}
+
+/**
+ * Validate and extract the `version` field from the npm registry's
+ * `/:pkg/latest` payload. Returns the parsed semver string or throws with
+ * a context-rich error the CLI surfaces verbatim.
+ */
+export function extractVersion(registryPayload) {
+  if (registryPayload === null || typeof registryPayload !== "object") {
+    throw new TypeError(
+      "registry payload is not an object — expected { version, ... }",
+    );
+  }
+  const version = registryPayload.version;
+  if (typeof version !== "string" || version.length === 0) {
+    throw new TypeError(
+      `registry payload is missing a string "version" field (got ${JSON.stringify(version)})`,
+    );
+  }
+  return version;
+}
+
+function assertNonEmptyString(value, name) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${name} must be a non-empty string`);
+  }
+}
+
+/**
+ * Resolve the current `@whisq/core` version via the npm registry. Caller
+ * supplies a fetch implementation — in the CLI that's the global `fetch`;
+ * tests pass a stub.
+ */
+export async function resolveLatestVersion({
+  fetch: fetchImpl = globalThis.fetch,
+  registryUrl = REGISTRY_URL,
+} = {}) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error(
+      "no fetch implementation — pass { fetch } or run on Node 18+ with global fetch",
+    );
+  }
+  const response = await fetchImpl(registryUrl);
+  if (!response || !response.ok) {
+    const status = response ? response.status : "no response";
+    throw new Error(
+      `npm registry ${registryUrl} returned ${status} — cannot resolve @whisq/core version`,
+    );
+  }
+  const payload = await response.json();
+  return extractVersion(payload);
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+const isDirectRun =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url === `file:///${process.argv[1].replace(/\\/g, "/")}`;
+
+if (isDirectRun) {
+  const args = process.argv.slice(2);
+  const mode = args[0] ?? "--url";
+
+  try {
+    const version = await resolveLatestVersion();
+    switch (mode) {
+      case "--version":
+        process.stdout.write(`${version}\n`);
+        break;
+      case "--url":
+        process.stdout.write(`${pinnedPublicApiUrl(version)}\n`);
+        break;
+      case "--annotated-url":
+        process.stdout.write(`${pinnedAnnotatedApiUrl(version)}\n`);
+        break;
+      case "--help":
+      case "-h":
+        process.stdout.write(
+          [
+            "resolve-latest-api — resolve @whisq/core latest via npm registry",
+            "",
+            "Usage: node packages/core/scripts/resolve-latest-api.mjs [--url | --annotated-url | --version | --help]",
+            "",
+            "  --url             Pinned URL for dist/public-api.json (default).",
+            "  --annotated-url   Pinned URL for dist/public-api-annotated.json.",
+            "  --version         Just the version string (e.g. 0.1.0-alpha.9).",
+            "  --help, -h        Print this help.",
+            "",
+            "The pinned URLs are immune to the unpkg @latest CDN-lag window — the",
+            "@${version} suffix targets the exact tarball on the registry.",
+          ].join("\n") + "\n",
+        );
+        break;
+      default:
+        process.stderr.write(
+          `resolve-latest-api: unknown option "${mode}" — run with --help\n`,
+        );
+        process.exit(2);
+    }
+  } catch (err) {
+    process.stderr.write(
+      `resolve-latest-api: ${(err && err.message) || err}\n`,
+    );
+    process.exit(1);
+  }
+}

--- a/packages/core/src/__tests__/resolve-latest-api.test.ts
+++ b/packages/core/src/__tests__/resolve-latest-api.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+// @ts-expect-error — plain .mjs tooling script; no .d.ts emitted.
+import {
+  pinnedPublicApiUrl,
+  pinnedAnnotatedApiUrl,
+  extractVersion,
+  resolveLatestVersion,
+} from "../../scripts/resolve-latest-api.mjs";
+
+describe("pinnedPublicApiUrl", () => {
+  it("targets the exact version's tarball on unpkg", () => {
+    expect(pinnedPublicApiUrl("0.1.0-alpha.9")).toBe(
+      "https://unpkg.com/@whisq/core@0.1.0-alpha.9/dist/public-api.json",
+    );
+  });
+
+  it("percent-encodes versions that contain characters (defensive; semver rarely does)", () => {
+    expect(pinnedPublicApiUrl("0.2.0-rc.1+build.42")).toBe(
+      "https://unpkg.com/@whisq/core@0.2.0-rc.1%2Bbuild.42/dist/public-api.json",
+    );
+  });
+
+  it("accepts a custom package name", () => {
+    expect(pinnedPublicApiUrl("1.0.0", "@whisq/other")).toBe(
+      "https://unpkg.com/@whisq/other@1.0.0/dist/public-api.json",
+    );
+  });
+
+  it("rejects an empty version", () => {
+    expect(() => pinnedPublicApiUrl("")).toThrow(TypeError);
+  });
+});
+
+describe("pinnedAnnotatedApiUrl", () => {
+  it("targets the enriched manifest file at the pinned version", () => {
+    expect(pinnedAnnotatedApiUrl("0.1.0-alpha.9")).toBe(
+      "https://unpkg.com/@whisq/core@0.1.0-alpha.9/dist/public-api-annotated.json",
+    );
+  });
+});
+
+describe("extractVersion", () => {
+  it("returns the version string from a well-formed registry payload", () => {
+    expect(extractVersion({ version: "0.1.0-alpha.9", name: "@whisq/core" }))
+      .toBe("0.1.0-alpha.9");
+  });
+
+  it("throws on a non-object payload", () => {
+    expect(() => extractVersion(null)).toThrow(TypeError);
+    expect(() => extractVersion("0.1.0")).toThrow(TypeError);
+  });
+
+  it("throws when version is missing / not a string / empty", () => {
+    expect(() => extractVersion({})).toThrow(/version/);
+    expect(() => extractVersion({ version: 9 })).toThrow(/version/);
+    expect(() => extractVersion({ version: "" })).toThrow(/version/);
+  });
+});
+
+describe("resolveLatestVersion", () => {
+  it("fetches the registry URL and returns the version", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ version: "1.2.3", name: "@whisq/core" }),
+    }));
+    const version = await resolveLatestVersion({ fetch: fetchImpl });
+    expect(version).toBe("1.2.3");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/@whisq/core/latest",
+    );
+  });
+
+  it("honours a custom registryUrl (useful for mocking)", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ version: "2.0.0" }),
+    }));
+    await resolveLatestVersion({
+      fetch: fetchImpl,
+      registryUrl: "https://example.test/@whisq%2Fcore/latest",
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://example.test/@whisq%2Fcore/latest",
+    );
+  });
+
+  it("throws a context-rich error on non-2xx responses", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    }));
+    await expect(
+      resolveLatestVersion({ fetch: fetchImpl }),
+    ).rejects.toThrow(/503/);
+  });
+
+  it("throws when no fetch implementation is available", async () => {
+    await expect(
+      // @ts-expect-error — intentionally passing a non-function
+      resolveLatestVersion({ fetch: null }),
+    ).rejects.toThrow(/fetch/i);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the CDN-lag footgun the Codex v0.1.0-alpha.9 feedback surfaced: `unpkg.com/@whisq/core@latest/dist/public-api.json` can serve the *previous* version's manifest for minutes to hours after each publish, even though `npm view @whisq/core version` already reports the new one. That lag caused the Codex feedback docs to be initially written against alpha.8 — a direct hit on Whisq's "AI-native" positioning.

Three moves:

### 1. `packages/core/scripts/resolve-latest-api.mjs`

Zero-dep CLI. Hits `https://registry.npmjs.org/@whisq/core/latest` (authoritative, sub-second after publish), reads `version`, prints the **pinned** `https://unpkg.com/@whisq/core@${version}/dist/public-api.json` URL. Pinned-version URLs are served out of the exact tarball and bypass the lag window entirely.

Modes: `--url` (default), `--annotated-url` (for the enriched manifest), `--version`, `--help`.

```sh
node packages/core/scripts/resolve-latest-api.mjs --url
# → https://unpkg.com/@whisq/core@0.1.0-alpha.9/dist/public-api.json

VERSION=$(node packages/core/scripts/resolve-latest-api.mjs --version)
curl -sSL "https://unpkg.com/@whisq/core@${VERSION}/dist/public-api-annotated.json"
```

Pure URL-building and version-parsing are exported for unit testing. Only the CLI block does I/O.

### 2. `packages/core/docs/api-metadata-schema.md` — new "Consumer patterns" section

Documents the two retrieval shapes:

- **Workspace-pinned** — as done by `packages/mcp-server/src/tools/api-docs.ts`. Immune by construction.
- **CDN-resolved via the registry** — for ad-hoc AI tooling that wants "latest" without pinning a dep. Uses the new helper.

Explicit anti-pattern call-out on `unpkg.com/@whisq/core@latest/...` with the silent-staleness failure mode described.

### 3. `.github/workflows/release.yml` — post-publish propagation check

After `changesets/action` reports `published: true`, a new step fetches `unpkg.com/@whisq/core@latest/dist/public-api.json` and compares the served `version` to the just-published one. Emits a GitHub Actions `::warning::` annotation on mismatch.

**Warn-only** (`continue-on-error: true`) for this first release cycle — we need to observe the propagation window empirically before promoting to a failing check. Current stance keeps the release green while surfacing the lag in the run log for the release author.

## Test plan

- [x] `pnpm build` — 9 tasks green
- [x] `pnpm test` — 634 tests across the workspace; **+12** new in `packages/core/src/__tests__/resolve-latest-api.test.ts`:
  - `pinnedPublicApiUrl` / `pinnedAnnotatedApiUrl`: happy path, percent-encoding (defensive against `+` in versions), custom package name, empty-version rejection
  - `extractVersion`: happy path, non-object rejection, missing-/wrong-type-/empty- version rejection
  - `resolveLatestVersion`: fetches registry URL, honours custom registry URL, non-2xx error, missing fetch error
- [x] CLI smoke-tested against the live npm registry — returns `0.1.0-alpha.9` and the two pinned URLs correctly
- [x] No published-package delta: `scripts/`, `docs/`, and `.github/` sit outside `@whisq/core`'s `files: [dist, README.md]` tarball boundary — hence the `skip-changeset` label

## Docs-side follow-up

[`whisqjs/whisq.dev#199`](https://github.com/whisqjs/whisq.dev/issues/199) tracks surfacing this helper + the CDN-lag warning in the LLM reference card and `/api/imports/`. Gated on this PR landing so the docs reference a helper that exists on disk.

Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)