### PR TITLE
WHISQ-141: template-todo — add filter UI (all / active / done)

### DIFF
--- a/examples/template-todo/src/components/TodoList.ts
+++ b/examples/template-todo/src/components/TodoList.ts
@@ -8,24 +8,84 @@ import {
   each,
   match,
 } from "@whisq/core";
-import { todos, clearDone, pendingCount } from "../stores/todos";
+import {
+  todos,
+  visible,
+  filter,
+  setFilter,
+  clearDone,
+  pendingCount,
+  type Filter,
+} from "../stores/todos";
 import { TodoItem } from "./TodoItem";
 import { s } from "../styles";
 
+// Labels plus the underlying filter value — one tuple per tab, ordered for
+// a keyboard-natural left-to-right scan (broad → narrow).
+const FILTERS: readonly { value: Filter; label: string }[] = [
+  { value: "all",    label: "All"    },
+  { value: "active", label: "Active" },
+  { value: "done",   label: "Done"   },
+] as const;
+
+// Renders the three filter tab buttons. Active-state styling is expressed
+// via the alpha.8 `class: [...]` array form — the getter re-evaluates when
+// `filter.value` changes, so exactly one tab carries the active class at
+// any time, with no manual class-string assembly.
+const FilterTabs = () =>
+  div(
+    { class: s.filters, role: "tablist", "aria-label": "Filter todos" },
+    ...FILTERS.map(({ value, label }) =>
+      button(
+        {
+          class: [
+            s.filterBtn,
+            () => filter.value === value && s.filterBtnActive,
+          ],
+          role: "tab",
+          "aria-selected": () => filter.value === value,
+          onclick: () => setFilter(value),
+        },
+        label,
+      ),
+    ),
+  );
+
 // `match()` works directly as a component root (WHISQ-121) — no sacrificial
 // wrapper div needed just to host the returned function.
+//
+// Three arms instead of two: a completely empty store vs. a filter that
+// hides every existing todo vs. rendering the list. The middle arm is what
+// makes filters discoverable without a log message — if the user switches
+// to "Done" on a list with no completed items, the tab stays highlighted
+// but the body explains why.
 export const TodoList = component(() =>
   match(
     [
       () => todos.value.length === 0,
       () => p({ class: s.empty }, "Nothing yet. Add a todo above."),
     ],
+    [
+      () => visible.value.length === 0,
+      () =>
+        div(
+          FilterTabs(),
+          p(
+            { class: s.empty },
+            () =>
+              filter.value === "active"
+                ? "Nothing active — everything's done."
+                : "Nothing done yet.",
+          ),
+        ),
+    ],
     () =>
       div(
+        FilterTabs(),
         ul(
           { class: s.list },
           each(
-            () => todos.value,
+            () => visible.value,
             (todo) => TodoItem({ todo }),
             { key: (t) => t.id },
           ),

--- a/examples/template-todo/src/stores/todos.ts
+++ b/examples/template-todo/src/stores/todos.ts
@@ -1,4 +1,4 @@
-import { computed } from "@whisq/core";
+import { computed, signal } from "@whisq/core";
 import { persistedSignal } from "@whisq/core/persistence";
 import { randomId } from "@whisq/core/ids";
 
@@ -7,6 +7,8 @@ export interface Todo {
   text: string;
   done: boolean;
 }
+
+export type Filter = "all" | "active" | "done";
 
 // Persisted signal: survives reloads, tabs share state. Schema versioned via
 // the key suffix — bump to `:v2` on shape change and the old value falls
@@ -17,9 +19,23 @@ export const todos = persistedSignal<Todo[]>("whisq-template-todo:v1", [], {
   },
 });
 
+// View filter — kept in memory (not persisted) so a fresh tab always starts
+// on "all" and the user's previous narrowing doesn't silently hide rows.
+export const filter = signal<Filter>("all");
+
 export const pendingCount = computed(
   () => todos.value.filter((t) => !t.done).length,
 );
+
+// The rows TodoList renders, driven by the current filter. Keyed `each()`
+// over this signal keeps row DOM nodes stable across filter changes so any
+// in-progress inline UI state (focus, selection) survives narrowing.
+export const visible = computed<Todo[]>(() => {
+  const f = filter.value;
+  if (f === "active") return todos.value.filter((t) => !t.done);
+  if (f === "done") return todos.value.filter((t) => t.done);
+  return todos.value;
+});
 
 // Mutations as named actions — every write goes through one of these so
 // the "set of ways state can change" stays auditable.
@@ -38,4 +54,8 @@ export const removeTodo = (id: string): void => {
 
 export const clearDone = (): void => {
   todos.value = todos.value.filter((t) => !t.done);
+};
+
+export const setFilter = (next: Filter): void => {
+  filter.value = next;
 };

--- a/examples/template-todo/src/styles.ts
+++ b/examples/template-todo/src/styles.ts
@@ -121,6 +121,39 @@ export const s = sheet({
     textAlign: "center",
   },
 
+  filters: {
+    display: "flex",
+    gap: "0.375rem",
+    marginBottom: "1rem",
+  },
+
+  filterBtn: {
+    flex: "1",
+    padding: "0.5rem 0.75rem",
+    borderRadius: "var(--radius-md)",
+    border: "1px solid var(--color-border)",
+    background: "transparent",
+    color: "var(--color-muted)",
+    fontSize: "0.85rem",
+    fontWeight: "600",
+    cursor: "pointer",
+    transition: "border-color 120ms, color 120ms, background 120ms",
+    "&:hover": {
+      borderColor: "var(--color-primary)",
+      color: "var(--color-text)",
+    },
+  },
+
+  filterBtnActive: {
+    borderColor: "var(--color-primary)",
+    background: "var(--color-primary)",
+    color: "#ffffff",
+    "&:hover": {
+      background: "var(--color-primary)",
+      color: "#ffffff",
+    },
+  },
+
   footer: {
     display: "flex",
     alignItems: "center",


### PR DESCRIPTION
## Summary

Closes the last Codex v0.1.0-alpha.9 docs-feedback concern: _"Add a complete todo example that combines persistence, filters, keyed `each()`, checkbox toggling, and an empty state."_ The template already had four of the five; filter UI was the only missing piece.

- **`stores/todos.ts`** — new `filter` signal (`"all" | "active" | "done"`, kept in memory — a fresh tab shouldn't silently hide rows because the last session was narrowed), `visible` computed, `setFilter` action.
- **`components/TodoList.ts`** — extracted a `FilterTabs()` helper rendering three tabs. Active-state styling uses the alpha.8 `class: [base, () => active && mod]` array form so exactly one tab reflects the current filter reactively with no manual class-string assembly. Tabs carry `role="tablist"`, `role="tab"`, and `aria-selected` — shows off the alpha.9 typed aria-\* surface (#128) in a real call site.
- **`match()` extended to three arms**: (1) no todos yet, (2) filter hides every existing todo, (3) render list + footer. The middle arm makes filters discoverable without a log — switching to "Done" on a list with no done items keeps the tab highlighted but swaps the body copy to explain why.
- **`styles.ts`** — new `filters` / `filterBtn` / `filterBtnActive` rules; active tab reuses the app's primary colour for visual consistency with the existing hover state.

## Why filters matter here (beyond the feedback ask)

Keyed `each()` only shows off its reason-for-being when the source list actually shrinks and grows. Filters demonstrate that rows keep their DOM identity across filter changes — any focus, selection, or in-progress inline state survives narrowing. Without filters, the template visually uses keyed `each()` but never exercises the behaviour.

## Test plan

- [x] Template typechecks cleanly under its own `tsconfig.json` (`strict: true`, `moduleResolution: "bundler"`) against a symlinked workspace `@whisq/core`. Zero errors, zero warnings.
- [x] `pnpm test` at workspace root — 634 tests across 28 core + 5 mcp-server + 1 testing + 1 devtools + 1 router + 1 ssr suites, all green (template isn't in pnpm-workspace scope so workspace tests are unaffected by design).
- [x] `node scripts/check-versions.mjs` — template still aligned at `0.1.0-alpha.9`.
- [x] No published-package delta — `examples/` sits outside the npm workspace and isn't shipped by any package tarball. Hence `skip-changeset`.

Closes #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)