### PR TITLE
Release v0.1.0-alpha.10

### DIFF
--- a/.changeset/compose-bind-helper.md
+++ b/.changeset/compose-bind-helper.md
@@ -1,0 +1,22 @@
+---
+"@whisq/core": minor
+---
+
+New `compose(bindResult, extras)` helper for order-independent composition of `bind()` / `bindField()` / `bindPath()` results with user-supplied event handlers.
+
+The dev warning added in alpha.9 caught _direction 1_ (user handler after the bind spread) but _direction 2_ (user handler before the spread) was undetectable from final props alone — the user's handler was gone without a trace by the time the element builder ran. `compose()` sidesteps the order dependency entirely: shared handler keys chain both handlers (bind first, user second), and non-handler props follow normal object-spread semantics (extras win).
+
+```ts
+import { bind, compose, input } from "@whisq/core";
+
+input({
+  ...compose(bind(draft), {
+    oninput: (e) => track(e),            // fires after bind writes draft
+    onfocus: () => analytics.focus(),    // bind has no onfocus — attaches cleanly
+  }),
+});
+```
+
+The compose result re-tags its bind-sentinel with the composed handler as the "declared" one, so the alpha.9 duplicate-handler warning does not fire on a well-formed `compose()` spread, but still fires if someone overwrites the compose result afterward.
+
+Closes WHISQ-132.

--- a/.changeset/enriched-api-metadata-spike.md
+++ b/.changeset/enriched-api-metadata-spike.md
@@ -1,0 +1,31 @@
+---
+"@whisq/core": minor
+"@whisq/mcp-server": minor
+---
+
+**Spike:** first slice of the enriched `public-api.json` from #103 — ships a drift-validated per-symbol metadata manifest, populates it for the `signals` topic, and wires the MCP server's `signals` docs to consume it.
+
+### `@whisq/core`
+
+- New artefact: `dist/public-api-annotated.json`. Schema spec at `packages/core/docs/api-metadata-schema.md`. Current shape — `{ version, schemaVersion: 1, symbols: SymbolEntry[] }` — is frozen behind `schemaVersion` so consumers can guard against breaking changes.
+- New exports-map entry: `"@whisq/core/public-api-annotated.json"` — the public path consumers import from.
+- Hand-curated source of truth at `packages/core/metadata/api-enrichment.json`. The build step runs `scripts/generate-api-metadata.mjs` after `generate-public-api.mjs` and fails with a non-zero exit if:
+  - a `symbols[*].name` is not in `public-api.json` exports (drift),
+  - a `seeAlso[*]` reference is not in `public-api.json` exports (drift),
+  - any required field on a `SymbolEntry` is missing or wrong type,
+  - a duplicate symbol entry appears.
+- Populated for one topic this release: `signals` (`signal`, `computed`, `effect`, `batch`). The names-only `public-api.json` is unchanged — this is a sibling file, not a replacement. See #103 for the path to unification.
+
+### `@whisq/mcp-server`
+
+- New `@whisq/core` workspace dependency (was previously untyped docs; now consumes the annotated manifest).
+- `api-docs.ts` `signals` topic is generated from the enriched manifest at build time — no more hand-written drift. The other topics (`elements`, `components`, `routing`, …) remain hand-written until the schema stabilises; migrating them is a follow-up tracked against #103.
+- Load-bearing phrases consumers grep for (`signal(`, `computed(`, `.value`, `peek()`, `batch(() =>`) are locked in by a new regression test block.
+
+### Out of scope (follow-ups)
+
+- CI drift check between `public-api.json` and `public-api-annotated.json` (all existing exports must have enrichment) — follow-up once the other topics migrate.
+- Migrating the remaining MCP topics — mechanical once this spike's shape is validated across a release cycle.
+- Unifying the two manifests into one — option A in #103; gated on 1–2 releases of stable schema.
+
+Closes #138.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -25,7 +25,9 @@
     "clarify-ref-accessor",
     "component-accepts-function-child-return",
     "component-types-and-sheet-nested-selectors",
+    "compose-bind-helper",
     "each-keyed-accessor-callback",
+    "enriched-api-metadata-spike",
     "export-event-types",
     "friendlier-runtime-errors",
     "full-app-template-canonical-shape",
@@ -37,6 +39,8 @@
     "persistedsignal-onschemafailure",
     "project-structure-conventions",
     "reactive-shapes-taxonomy",
+    "small-utility-helpers-omnibus",
+    "subpath-friendly-errors",
     "theme-duplicate-call-warning",
     "theme-sheet-ssr-guard"
   ]

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -16,11 +16,14 @@
     "access-shapes-canonical-doc",
     "accessor-boundaries-docs",
     "alpha-5-batch",
+    "aria-attribute-typing",
     "array-accepting-class-prop",
+    "bind-duplicate-handler-warning",
     "bindfield-dev-strict-mode",
     "bindfield-for-array-items",
     "bindpath-for-nested-records",
     "clarify-ref-accessor",
+    "component-accepts-function-child-return",
     "component-types-and-sheet-nested-selectors",
     "each-keyed-accessor-callback",
     "export-event-types",
@@ -28,11 +31,13 @@
     "full-app-template-canonical-shape",
     "hybrid-item-accessor-keyed-each",
     "match-api-clarity",
+    "mount-sandboxed",
     "partition-and-random-id-helpers",
     "persisted-signal",
     "persistedsignal-onschemafailure",
     "project-structure-conventions",
     "reactive-shapes-taxonomy",
+    "theme-duplicate-call-warning",
     "theme-sheet-ssr-guard"
   ]
 }

--- a/.changeset/small-utility-helpers-omnibus.md
+++ b/.changeset/small-utility-helpers-omnibus.md
@@ -1,0 +1,27 @@
+---
+"@whisq/core": minor
+---
+
+Two small additive helpers to close the alpha.9 feedback loop — both opt-in on existing sub-path imports, no breaking changes.
+
+- **`createStorageNamespace(prefix)`** on `@whisq/core/persistence` — returns a `{ persistedSignal }` view whose storage keys are transparently rewritten to `${prefix}:${key}`. Use when several Whisq apps share an origin (marketing site + dashboard + demo playground on the same host) and must not collide. A thin compositional wrapper — everything `persistedSignal` already supports (storage kind, schema, onSchemaFailure, …) passes straight through. Empty or whitespace prefixes are rejected so a forgotten interpolation fails loudly instead of silently using `":key"`.
+
+  ```ts
+  import { createStorageNamespace } from "@whisq/core/persistence";
+
+  const app = createStorageNamespace("whisq-todo-app");
+  export const todos = app.persistedSignal<Todo[]>("todos", []);
+  //                                               ↑ actual key: "whisq-todo-app:todos"
+  ```
+
+- **`randomId(options?)`** on `@whisq/core/ids` — now accepts `{ prefix, rng }`. Zero-arg call is unchanged. `prefix` concatenates directly (no separator — pass `"todo_"` if that's what you want). `rng` replaces `Math.random` in the fallback synthesis and **also bypasses `crypto.randomUUID`**, so a seeded PRNG produces the same id on every platform. The primary use-case is deterministic ids for snapshot tests — no more globally stubbing `crypto.randomUUID`.
+
+  ```ts
+  import { randomId } from "@whisq/core/ids";
+
+  randomId();                            // default: crypto.randomUUID
+  randomId({ prefix: "todo_" });         // "todo_01K1…"
+  randomId({ rng: seedrandom(42) });     // deterministic across environments
+  ```
+
+Closes WHISQ-134. Source: `dev/feedback/latest/FRAMEWORK_FEEDBACK_CLAUDE_v0.1.0-alpha.9.md` (N5, N7).

--- a/.changeset/subpath-friendly-errors.md
+++ b/.changeset/subpath-friendly-errors.md
@@ -1,0 +1,27 @@
+---
+"@whisq/core": minor
+---
+
+Friendly runtime errors for sub-path exports imported from the main `@whisq/core` path.
+
+Apps of any size reach into multiple sub-path imports: `@whisq/core/persistence`, `/ids`, `/collections`, `/forms`. This is the right shape for tree-shaking — unused sub-paths add zero bytes — but an AI or human writing `import { partition } from "@whisq/core"` used to hit the generic bundler "not exported" error with no hint about where the symbol actually lives.
+
+The main entry now re-exports these sub-path names as runtime stubs. Importing one compiles cleanly; calling it throws with a message that names the correct sub-path and links to the docs page:
+
+```ts
+import { partition } from "@whisq/core";      // compiles
+const [a, b] = partition(() => xs.value, p);  // → Error("partition" is not exported from "@whisq/core". Import it from "@whisq/core/collections" instead. See https://whisq.dev/api/partition/)
+```
+
+Each stub carries `@deprecated` JSDoc so editor hover surfaces the correct sub-path without running the code.
+
+Symbols covered:
+
+- `partition`, `signalMap`, `signalSet` → `@whisq/core/collections`
+- `randomId` → `@whisq/core/ids`
+- `persistedSignal` → `@whisq/core/persistence`
+- `bindPath` → `@whisq/core/forms`
+
+Stubs are plain `export function`s in a side-effect-free module; bundlers with standard unused-export elimination (esbuild, Rollup, Vite) drop them to zero bytes in apps that don't import them. Verified by building a minimal `import { signal }` app: the produced bundle contains no stub names, no error strings, and no sub-path-stubs module reference.
+
+Closes WHISQ-133.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,35 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # WHISQ-140 — warn-only: verify that unpkg's @latest alias for
+      # @whisq/core/dist/public-api.json has propagated to the version we
+      # just published. The alias is CDN-cached and can lag the npm
+      # registry by minutes to hours; AI tools that resolve "the current
+      # Whisq API" through @latest will silently read the previous
+      # version during that window. This check surfaces the lag in the
+      # release-run logs. `continue-on-error: true` keeps the release
+      # green while we characterise how long the propagation window is
+      # in practice — promote to a failing check once observed stable.
+      - name: Verify unpkg @latest propagation (warn-only)
+        if: steps.changesets.outputs.published == 'true'
+        continue-on-error: true
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set +e
+          URL="https://unpkg.com/@whisq/core@latest/dist/public-api.json"
+          echo "Fetching $URL — expecting version=$VERSION"
+          SERVED=$(curl -sSfL --max-time 30 "$URL" | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{try{process.stdout.write(JSON.parse(s).version||'')}catch{process.stdout.write('')}})")
+          if [ -z "$SERVED" ]; then
+            echo "::warning title=unpkg @latest propagation::Could not read version from $URL — CDN may be serving an older payload or is unreachable."
+            exit 0
+          fi
+          if [ "$SERVED" = "$VERSION" ]; then
+            echo "unpkg @latest is already serving $VERSION — propagation complete."
+          else
+            echo "::warning title=unpkg @latest propagation::npm registry published $VERSION, but $URL still serves $SERVED. AI tools resolving @latest will see the old version until the CDN cache refreshes."
+          fi
+
   backmerge:
     needs: publish
     if: needs.publish.outputs.published == 'true'

--- a/examples/template-todo/package.json
+++ b/examples/template-todo/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.8"
+    "@whisq/core": "^0.1.0-alpha.9"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/examples/template-todo/package.json
+++ b/examples/template-todo/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.9"
+    "@whisq/core": "^0.1.0-alpha.10"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/examples/template-todo/src/components/TodoList.ts
+++ b/examples/template-todo/src/components/TodoList.ts
@@ -8,24 +8,84 @@ import {
   each,
   match,
 } from "@whisq/core";
-import { todos, clearDone, pendingCount } from "../stores/todos";
+import {
+  todos,
+  visible,
+  filter,
+  setFilter,
+  clearDone,
+  pendingCount,
+  type Filter,
+} from "../stores/todos";
 import { TodoItem } from "./TodoItem";
 import { s } from "../styles";
 
+// Labels plus the underlying filter value — one tuple per tab, ordered for
+// a keyboard-natural left-to-right scan (broad → narrow).
+const FILTERS: readonly { value: Filter; label: string }[] = [
+  { value: "all",    label: "All"    },
+  { value: "active", label: "Active" },
+  { value: "done",   label: "Done"   },
+] as const;
+
+// Renders the three filter tab buttons. Active-state styling is expressed
+// via the alpha.8 `class: [...]` array form — the getter re-evaluates when
+// `filter.value` changes, so exactly one tab carries the active class at
+// any time, with no manual class-string assembly.
+const FilterTabs = () =>
+  div(
+    { class: s.filters, role: "tablist", "aria-label": "Filter todos" },
+    ...FILTERS.map(({ value, label }) =>
+      button(
+        {
+          class: [
+            s.filterBtn,
+            () => filter.value === value && s.filterBtnActive,
+          ],
+          role: "tab",
+          "aria-selected": () => filter.value === value,
+          onclick: () => setFilter(value),
+        },
+        label,
+      ),
+    ),
+  );
+
 // `match()` works directly as a component root (WHISQ-121) — no sacrificial
 // wrapper div needed just to host the returned function.
+//
+// Three arms instead of two: a completely empty store vs. a filter that
+// hides every existing todo vs. rendering the list. The middle arm is what
+// makes filters discoverable without a log message — if the user switches
+// to "Done" on a list with no completed items, the tab stays highlighted
+// but the body explains why.
 export const TodoList = component(() =>
   match(
     [
       () => todos.value.length === 0,
       () => p({ class: s.empty }, "Nothing yet. Add a todo above."),
     ],
+    [
+      () => visible.value.length === 0,
+      () =>
+        div(
+          FilterTabs(),
+          p(
+            { class: s.empty },
+            () =>
+              filter.value === "active"
+                ? "Nothing active — everything's done."
+                : "Nothing done yet.",
+          ),
+        ),
+    ],
     () =>
       div(
+        FilterTabs(),
         ul(
           { class: s.list },
           each(
-            () => todos.value,
+            () => visible.value,
             (todo) => TodoItem({ todo }),
             { key: (t) => t.id },
           ),

--- a/examples/template-todo/src/stores/todos.ts
+++ b/examples/template-todo/src/stores/todos.ts
@@ -1,4 +1,4 @@
-import { computed } from "@whisq/core";
+import { computed, signal } from "@whisq/core";
 import { persistedSignal } from "@whisq/core/persistence";
 import { randomId } from "@whisq/core/ids";
 
@@ -7,6 +7,8 @@ export interface Todo {
   text: string;
   done: boolean;
 }
+
+export type Filter = "all" | "active" | "done";
 
 // Persisted signal: survives reloads, tabs share state. Schema versioned via
 // the key suffix — bump to `:v2` on shape change and the old value falls
@@ -17,9 +19,23 @@ export const todos = persistedSignal<Todo[]>("whisq-template-todo:v1", [], {
   },
 });
 
+// View filter — kept in memory (not persisted) so a fresh tab always starts
+// on "all" and the user's previous narrowing doesn't silently hide rows.
+export const filter = signal<Filter>("all");
+
 export const pendingCount = computed(
   () => todos.value.filter((t) => !t.done).length,
 );
+
+// The rows TodoList renders, driven by the current filter. Keyed `each()`
+// over this signal keeps row DOM nodes stable across filter changes so any
+// in-progress inline UI state (focus, selection) survives narrowing.
+export const visible = computed<Todo[]>(() => {
+  const f = filter.value;
+  if (f === "active") return todos.value.filter((t) => !t.done);
+  if (f === "done") return todos.value.filter((t) => t.done);
+  return todos.value;
+});
 
 // Mutations as named actions — every write goes through one of these so
 // the "set of ways state can change" stays auditable.
@@ -38,4 +54,8 @@ export const removeTodo = (id: string): void => {
 
 export const clearDone = (): void => {
   todos.value = todos.value.filter((t) => !t.done);
+};
+
+export const setFilter = (next: Filter): void => {
+  filter.value = next;
 };

--- a/examples/template-todo/src/styles.ts
+++ b/examples/template-todo/src/styles.ts
@@ -121,6 +121,39 @@ export const s = sheet({
     textAlign: "center",
   },
 
+  filters: {
+    display: "flex",
+    gap: "0.375rem",
+    marginBottom: "1rem",
+  },
+
+  filterBtn: {
+    flex: "1",
+    padding: "0.5rem 0.75rem",
+    borderRadius: "var(--radius-md)",
+    border: "1px solid var(--color-border)",
+    background: "transparent",
+    color: "var(--color-muted)",
+    fontSize: "0.85rem",
+    fontWeight: "600",
+    cursor: "pointer",
+    transition: "border-color 120ms, color 120ms, background 120ms",
+    "&:hover": {
+      borderColor: "var(--color-primary)",
+      color: "var(--color-text)",
+    },
+  },
+
+  filterBtnActive: {
+    borderColor: "var(--color-primary)",
+    background: "var(--color-primary)",
+    color: "#ffffff",
+    "&:hover": {
+      background: "var(--color-primary)",
+      color: "#ffffff",
+    },
+  },
+
   footer: {
     display: "flex",
     alignItems: "center",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,107 @@
 # @whisq/core
 
+## 0.1.0-alpha.9
+
+### Minor Changes
+
+- defc7eb: Typed `aria-*` attributes on every element. `BaseProps` now accepts `[key: \`aria-${string}\`]: ReactiveProp<string | boolean | undefined>`— mirrors the existing`data-\*` pattern but with a wider value type because ARIA uses both enum-string attrs (`aria-live: "polite"`) and predicate-boolean attrs (`aria-expanded`, `aria-hidden`, `aria-pressed`).
+
+  ```ts
+  // Before: typed props rejected aria-label; workaround was `title="Remove"`
+  // (correct for tooltips, compromised for screen readers).
+  button({ "aria-label": "Remove" }, "×");
+
+  // Reactive ARIA also works:
+  button({ "aria-expanded": () => menuOpen.value }, "menu");
+  div({ "aria-live": "polite", "aria-atomic": true }, () => status.value);
+  ```
+
+  Also fixes the **boolean serialisation bug** this exposed: the generic boolean-attribute branch in `applyProp` wrote `aria-expanded=""` for `true`, which is **invalid** per the ARIA spec — `aria-expanded=""` is not equivalent to `aria-expanded="true"`. A dedicated `aria-*` branch now serialises `true`/`false` to the strings `"true"` / `"false"`, and `undefined`/`null` still removes the attribute. String values pass through unchanged.
+
+  Runtime cost: one `startsWith("aria-")` check per prop. Bundle size: 5.67 KB of 6 KB budget (+ ~20 B).
+
+  Discovered during WHISQ-124 smoke-test; the `examples/template-todo/` remove button now uses `aria-label="Remove"` instead of the previous `title="Remove"` workaround.
+
+  Closes WHISQ-128.
+
+- c8f2bec: Dev-only warning when spreading `bind()` / `bindField()` / `bindPath()` then overwriting one of its event handlers. Closes the production-bug window Claude's alpha.8 feedback called out as the top concern:
+
+  ```ts
+  // Before: silently dropped bind's oninput, no warning.
+  input({
+    ...bind(draft),
+    oninput: (e) => track(e), // overwrites bind's oninput
+  });
+
+  // Now (in dev): console.warn with the tag, event name, and a fix hint.
+  ```
+
+  Mechanism — the three bind helpers attach a symbol-keyed manifest of the handlers they declared to their return objects. Object spread copies symbol-keyed own properties, so the manifest survives into the final props. The element builder checks "for each declared handler, is the current prop handler still the one I declared?" On mismatch, `console.warn` (dev only; zero cost in production).
+
+  **Known limitation.** Only catches _direction 1_ — spread-first, user-handler-second. _Direction 2_ (user handler first, `...bind(sig)` spread on top) cannot be detected from final props alone: by the time the element builder sees `props`, the user's original handler is gone without a trace. The warning message steers users toward the safer convention: spread bind LAST so it's your own handler that visibly "wins", making the collision obvious.
+
+  Closes WHISQ-120.
+
+- e6d59c4: `component()`'s setup function can now return a **function child** directly — the shape `match()` / `when()` / an ad-hoc `() => div(...)` produce. Previously, a component whose whole job was to render one of several branches needed a sacrificial wrapper `div` whose only purpose was to host the function child:
+
+  ```ts
+  // Before — wrapper div has no job other than holding match()
+  const Screen = component(() =>
+    div(
+      match(
+        [() => view.value === "loading", () => p("loading")],
+        [() => view.value === "data", () => DataView({})],
+        () => p("empty"),
+      ),
+    ),
+  );
+
+  // Now — match() is the component root directly
+  const Screen = component(() =>
+    match(
+      [() => view.value === "loading", () => p("loading")],
+      [() => view.value === "data", () => DataView({})],
+      () => p("empty"),
+    ),
+  );
+  ```
+
+  Works for any zero-arg function return — `when()`, `match()`, or a plain `() => someNode`.
+
+  Mechanism is the same fragment + start/end marker pattern `errorBoundary` and keyed `each` already use internally: a fragment holds markers that survive insertion into the real parent, and an effect renders the function's result between them on every source change. `onMount` / `onCleanup` hooks registered inside setup continue to fire as expected. Branch switches dispose the previous `WhisqNode` before inserting the next — no node leaks.
+
+  Backwards compatible. The widened setup signature is `(props: P) => WhisqNode | (() => unknown)`; existing `component(() => div(...))` code is unaffected. Dev-mode `WhisqStructureError` messages now mention both accepted shapes.
+
+  Bundle size: `@whisq/core` grows ~150 B gzipped (5.5 → 5.65 KB). The size-limit budget bumps from 5.5 KB to 6.0 KB to absorb this cost with room to grow, documented in `packages/core/.size-limit.cjs`.
+
+  Closes WHISQ-121. The docs-side companion (whisqjs/whisq.dev#162) will need an update once the `/api/match/` page can point at "match() works directly as a component root" as the idiom.
+
+- 75d2d8e: Dev-mode warning on duplicate `theme()` calls. Completes the alpha.7 `theme()` saga started by #99 / #105 (docs + SSR guard). Catches the failure mode Claude's alpha.8 feedback flagged: a multi-file project that imports two styles files and silently wipes the first theme's variables.
+
+  ```ts
+  // styles.ts — app's primary theme
+  import { theme } from "@whisq/core";
+  theme({ color: { primary: "#4386FB" } });
+
+  // another styles.ts elsewhere in the graph — accidentally imported
+  import { theme } from "@whisq/core";
+  theme({ color: { primary: "#ffffff" } });
+  // Dev: console.warn names the conflict; production is silent.
+  ```
+
+  New optional `silent?: boolean` on the `theme()` signature suppresses the warning for legitimate second calls (theme-switching toggles):
+
+  ```ts
+  // Runtime theme switch — intentional; silent: true says "don't warn"
+  theme(darkTokens, { silent: true });
+  ```
+
+  Detection is DOM-based — a `getElementById("whisq-style-whisq-theme")` check. Production builds strip the entire guard via the existing `NODE_ENV !== "production"` pattern, so there's no runtime cost in shipped code. Each `theme()` is still last-call-wins: the warning doesn't change injection semantics, only surfaces when a second call would replace an existing block.
+
+  Exported `ThemeOptions` type for callers who type their wrapper helpers.
+
+  Closes WHISQ-122.
+
 ## 0.1.0-alpha.8
 
 ### Minor Changes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,98 @@
 # @whisq/core
 
+## 0.1.0-alpha.10
+
+### Minor Changes
+
+- 987fde7: New `compose(bindResult, extras)` helper for order-independent composition of `bind()` / `bindField()` / `bindPath()` results with user-supplied event handlers.
+
+  The dev warning added in alpha.9 caught _direction 1_ (user handler after the bind spread) but _direction 2_ (user handler before the spread) was undetectable from final props alone — the user's handler was gone without a trace by the time the element builder ran. `compose()` sidesteps the order dependency entirely: shared handler keys chain both handlers (bind first, user second), and non-handler props follow normal object-spread semantics (extras win).
+
+  ```ts
+  import { bind, compose, input } from "@whisq/core";
+
+  input({
+    ...compose(bind(draft), {
+      oninput: (e) => track(e), // fires after bind writes draft
+      onfocus: () => analytics.focus(), // bind has no onfocus — attaches cleanly
+    }),
+  });
+  ```
+
+  The compose result re-tags its bind-sentinel with the composed handler as the "declared" one, so the alpha.9 duplicate-handler warning does not fire on a well-formed `compose()` spread, but still fires if someone overwrites the compose result afterward.
+
+  Closes WHISQ-132.
+
+- fe295e0: **Spike:** first slice of the enriched `public-api.json` from #103 — ships a drift-validated per-symbol metadata manifest, populates it for the `signals` topic, and wires the MCP server's `signals` docs to consume it.
+
+  ### `@whisq/core`
+  - New artefact: `dist/public-api-annotated.json`. Schema spec at `packages/core/docs/api-metadata-schema.md`. Current shape — `{ version, schemaVersion: 1, symbols: SymbolEntry[] }` — is frozen behind `schemaVersion` so consumers can guard against breaking changes.
+  - New exports-map entry: `"@whisq/core/public-api-annotated.json"` — the public path consumers import from.
+  - Hand-curated source of truth at `packages/core/metadata/api-enrichment.json`. The build step runs `scripts/generate-api-metadata.mjs` after `generate-public-api.mjs` and fails with a non-zero exit if:
+    - a `symbols[*].name` is not in `public-api.json` exports (drift),
+    - a `seeAlso[*]` reference is not in `public-api.json` exports (drift),
+    - any required field on a `SymbolEntry` is missing or wrong type,
+    - a duplicate symbol entry appears.
+  - Populated for one topic this release: `signals` (`signal`, `computed`, `effect`, `batch`). The names-only `public-api.json` is unchanged — this is a sibling file, not a replacement. See #103 for the path to unification.
+
+  ### `@whisq/mcp-server`
+  - New `@whisq/core` workspace dependency (was previously untyped docs; now consumes the annotated manifest).
+  - `api-docs.ts` `signals` topic is generated from the enriched manifest at build time — no more hand-written drift. The other topics (`elements`, `components`, `routing`, …) remain hand-written until the schema stabilises; migrating them is a follow-up tracked against #103.
+  - Load-bearing phrases consumers grep for (`signal(`, `computed(`, `.value`, `peek()`, `batch(() =>`) are locked in by a new regression test block.
+
+  ### Out of scope (follow-ups)
+  - CI drift check between `public-api.json` and `public-api-annotated.json` (all existing exports must have enrichment) — follow-up once the other topics migrate.
+  - Migrating the remaining MCP topics — mechanical once this spike's shape is validated across a release cycle.
+  - Unifying the two manifests into one — option A in #103; gated on 1–2 releases of stable schema.
+
+  Closes #138.
+
+- 94caac8: Two small additive helpers to close the alpha.9 feedback loop — both opt-in on existing sub-path imports, no breaking changes.
+  - **`createStorageNamespace(prefix)`** on `@whisq/core/persistence` — returns a `{ persistedSignal }` view whose storage keys are transparently rewritten to `${prefix}:${key}`. Use when several Whisq apps share an origin (marketing site + dashboard + demo playground on the same host) and must not collide. A thin compositional wrapper — everything `persistedSignal` already supports (storage kind, schema, onSchemaFailure, …) passes straight through. Empty or whitespace prefixes are rejected so a forgotten interpolation fails loudly instead of silently using `":key"`.
+
+    ```ts
+    import { createStorageNamespace } from "@whisq/core/persistence";
+
+    const app = createStorageNamespace("whisq-todo-app");
+    export const todos = app.persistedSignal<Todo[]>("todos", []);
+    //                                               ↑ actual key: "whisq-todo-app:todos"
+    ```
+
+  - **`randomId(options?)`** on `@whisq/core/ids` — now accepts `{ prefix, rng }`. Zero-arg call is unchanged. `prefix` concatenates directly (no separator — pass `"todo_"` if that's what you want). `rng` replaces `Math.random` in the fallback synthesis and **also bypasses `crypto.randomUUID`**, so a seeded PRNG produces the same id on every platform. The primary use-case is deterministic ids for snapshot tests — no more globally stubbing `crypto.randomUUID`.
+
+    ```ts
+    import { randomId } from "@whisq/core/ids";
+
+    randomId(); // default: crypto.randomUUID
+    randomId({ prefix: "todo_" }); // "todo_01K1…"
+    randomId({ rng: seedrandom(42) }); // deterministic across environments
+    ```
+
+  Closes WHISQ-134. Source: `dev/feedback/latest/FRAMEWORK_FEEDBACK_CLAUDE_v0.1.0-alpha.9.md` (N5, N7).
+
+- 310dd97: Friendly runtime errors for sub-path exports imported from the main `@whisq/core` path.
+
+  Apps of any size reach into multiple sub-path imports: `@whisq/core/persistence`, `/ids`, `/collections`, `/forms`. This is the right shape for tree-shaking — unused sub-paths add zero bytes — but an AI or human writing `import { partition } from "@whisq/core"` used to hit the generic bundler "not exported" error with no hint about where the symbol actually lives.
+
+  The main entry now re-exports these sub-path names as runtime stubs. Importing one compiles cleanly; calling it throws with a message that names the correct sub-path and links to the docs page:
+
+  ```ts
+  import { partition } from "@whisq/core"; // compiles
+  const [a, b] = partition(() => xs.value, p); // → Error("partition" is not exported from "@whisq/core". Import it from "@whisq/core/collections" instead. See https://whisq.dev/api/partition/)
+  ```
+
+  Each stub carries `@deprecated` JSDoc so editor hover surfaces the correct sub-path without running the code.
+
+  Symbols covered:
+  - `partition`, `signalMap`, `signalSet` → `@whisq/core/collections`
+  - `randomId` → `@whisq/core/ids`
+  - `persistedSignal` → `@whisq/core/persistence`
+  - `bindPath` → `@whisq/core/forms`
+
+  Stubs are plain `export function`s in a side-effect-free module; bundlers with standard unused-export elimination (esbuild, Rollup, Vite) drop them to zero bytes in apps that don't import them. Verified by building a minimal `import { signal }` app: the produced bundle contains no stub names, no error strings, and no sub-path-stubs module reference.
+
+  Closes WHISQ-133.
+
 ## 0.1.0-alpha.9
 
 ### Minor Changes

--- a/packages/core/docs/api-metadata-schema.md
+++ b/packages/core/docs/api-metadata-schema.md
@@ -24,6 +24,47 @@ Consumers import from the package exports map:
 import annotated from "@whisq/core/public-api-annotated.json" with { type: "json" };
 ```
 
+## Consumer patterns (WHISQ-140)
+
+The manifest has two supported retrieval shapes. The choice matters because the unpkg `@latest` CDN alias can lag the npm registry's `latest` dist-tag by minutes to hours after each publish — a consumer that resolves "the current API" through the CDN alias will silently read the previous version's manifest during that window.
+
+### Pattern 1 — workspace-pinned (the MCP server)
+
+For code that builds against Whisq as a dependency and ships alongside it:
+
+```ts
+// packages/mcp-server/src/tools/api-docs.ts
+import annotatedManifest from "@whisq/core/public-api-annotated.json" with { type: "json" };
+```
+
+`@whisq/core` is a `workspace:*` dep; the symlink (or the installed tarball in downstream packages) always resolves to the exact version listed in `package.json`. There is no CDN and no lag window. The MCP server's `signals` topic uses this pattern — see `packages/mcp-server/src/tools/api-docs.ts`.
+
+Use this when the consumer ships with a pinned `@whisq/core` version — it is the cheapest and most reliable shape.
+
+### Pattern 2 — CDN-resolved via the registry (ad-hoc AI tooling)
+
+For AI scaffolders, docs generators, or any out-of-tree tool that wants the **latest published** manifest without pinning a dep:
+
+```sh
+# Never hit unpkg.com/@whisq/core@latest directly — it lags npm.
+# Resolve via the registry, then request the pinned version URL.
+
+URL=$(node packages/core/scripts/resolve-latest-api.mjs --url)
+curl -sSL "$URL" | jq .
+
+# Or as a one-liner for CI pipelines:
+VERSION=$(node packages/core/scripts/resolve-latest-api.mjs --version)
+curl -sSL "https://unpkg.com/@whisq/core@${VERSION}/dist/public-api.json"
+```
+
+The `resolve-latest-api.mjs` helper (WHISQ-140) hits `https://registry.npmjs.org/@whisq/core/latest` first — the registry API is authoritative and updates within seconds of publish — then constructs the `https://unpkg.com/@whisq/core@${version}/...` URL with an explicit version pin. unpkg serves pinned-version URLs out of the exact tarball, so the CDN-lag window is bypassed entirely.
+
+Use `--annotated-url` to target this document's subject (`public-api-annotated.json`) instead of the names-only `public-api.json`.
+
+### Anti-pattern — `unpkg.com/@whisq/core@latest/...`
+
+Fetching `https://unpkg.com/@whisq/core@latest/dist/public-api.json` (or `…@latest/dist/public-api-annotated.json`) is the shape that produces the silent-staleness bug. The `@latest` alias is CDN-cached; during the propagation window after a publish, the URL returns the previous version's manifest even though `npm view @whisq/core version` already reports the current one. AI workflows that fall into this trap produce feedback / code against an API surface that shipped under a different version number than they cite. The post-release CI check in `.github/workflows/release.yml` warns when this window is still open for the current publish.
+
 ## Top-level shape
 
 ```ts

--- a/packages/core/docs/api-metadata-schema.md
+++ b/packages/core/docs/api-metadata-schema.md
@@ -1,0 +1,128 @@
+# Whisq Core — API Metadata Schema (v1)
+
+This document specifies the shape of `packages/core/dist/public-api-annotated.json` — the **enriched** companion to the names-only `dist/public-api.json`. It's the first consumer-facing artefact for AI-native tooling that needs structured knowledge about framework symbols: not just "does `signal` exist", but "what's its shape, what are its common misuse patterns, what else is worth reading next."
+
+Status: **schema v1, spike**. Populated for one topic (`signals`) as proof-of-value. Expected to stabilise across alpha.10–alpha.11 as consumers prove the shape; see #103 for the umbrella roadmap.
+
+## Why a separate manifest
+
+The existing `dist/public-api.json` is a **drift-guard**: a flat list of export names that external tooling (docs pages, the MCP server, pre-commit checks) uses to detect when the framework's exported surface has changed. Annotating it in-place would risk breaking those consumers. The enriched manifest is a sibling file with its own URL, its own contract, and an explicit `schemaVersion` field so consumers can guard against breaking changes as the shape evolves.
+
+Once v1 is validated (2+ releases, 2+ consumers), we may unify into a single file (see #103 option A). Until then, both files exist side-by-side.
+
+## File locations
+
+| File | Purpose |
+| --- | --- |
+| `packages/core/metadata/api-enrichment.json` | **Source of truth** — curated per-symbol metadata, hand-edited. Not shipped. |
+| `packages/core/dist/public-api-annotated.json` | **Build output** — version-stamped, drift-validated manifest. Shipped in the npm tarball. |
+| `packages/core/scripts/generate-api-metadata.mjs` | Generator — reads `metadata/api-enrichment.json` + `dist/public-api.json` + `package.json`, writes the build output. |
+
+Consumers import from the package exports map:
+
+```ts
+import annotated from "@whisq/core/public-api-annotated.json" with { type: "json" };
+```
+
+## Top-level shape
+
+```ts
+interface EnrichedManifest {
+  /** npm package version the manifest was generated for, e.g. "0.1.0-alpha.9". */
+  version: string;
+  /** Incremented on breaking changes to this schema. v1 as of this PR. */
+  schemaVersion: 1;
+  /** One entry per documented symbol. Ordered alphabetically by `name`. */
+  symbols: SymbolEntry[];
+}
+```
+
+## `SymbolEntry` shape
+
+```ts
+interface SymbolEntry {
+  /** The exported name. MUST appear in public-api.json (drift-validated). */
+  name: string;
+  /** What kind of declaration this is. */
+  kind: "function" | "class" | "type" | "interface" | "const" | "namespace";
+  /** The canonical TypeScript signature as a single string. */
+  signature: string;
+  /**
+   * One-sentence description. Complete sentence, not fragment. Leads with the verb
+   * for functions ("Create a reactive value.", "Compose two bind results.").
+   */
+  summary: string;
+  /**
+   * Zero-or-more known misuse patterns. Each is a complete sentence describing
+   * what goes wrong and how to avoid it. Keep to one-liners when possible; escape
+   * hatches and long explanations belong in the full docs, not here.
+   */
+  gotchas: string[];
+  /**
+   * Zero-or-more idiomatic examples. Code strings (no markdown fences). The
+   * consumer decides how to present them (Markdown code block, plain text, …).
+   */
+  examples: string[];
+  /** First version the symbol was exported. Used by the consumer for "since" hints. */
+  since: string;
+  /** Other symbol names the reader is likely to want next. Drift-validated. */
+  seeAlso: string[];
+  /**
+   * Coarse-grained topic grouping for consumers that organise docs by topic
+   * rather than by symbol. Aligns with the MCP server's `ApiTopic` enum where
+   * possible ("signals" | "elements" | "components" | "routing" | …).
+   */
+  topic: string;
+}
+```
+
+## Drift guards
+
+The generator MUST enforce, and fail the build with a non-zero exit code, if any of:
+
+1. A `symbols[*].name` that isn't in `public-api.json`'s `exports[]` list.
+2. A `seeAlso[*]` reference that isn't in `public-api.json`'s `exports[]` list.
+3. A missing required field on a `SymbolEntry`.
+
+This guarantees the enriched manifest can't reference ghosts or lag behind the names-only list.
+
+## Worked example — `signal()`
+
+The source-of-truth entry (hand-edited in `metadata/api-enrichment.json`):
+
+```json
+{
+  "name": "signal",
+  "kind": "function",
+  "signature": "signal<T>(initial: T): Signal<T>",
+  "summary": "Create a reactive value that tracks reads and notifies on writes.",
+  "gotchas": [
+    "Mutating an array or object in place (e.g. items.value.push(x)) does not trigger updates — use items.value = [...items.value, x] so the identity changes.",
+    "Passing a signal as an element child (e.g. div(count.value)) captures the value once. Wrap in a function (e.g. () => count.value) for reactive rendering.",
+    "peek() reads without tracking — do not use it inside a computed/effect expecting reactivity."
+  ],
+  "examples": [
+    "const count = signal(0);\ncount.value = 5;\ncount.update(n => n + 1);\ncount.peek();"
+  ],
+  "since": "0.1.0-alpha.1",
+  "seeAlso": ["computed", "effect", "batch"],
+  "topic": "signals"
+}
+```
+
+After the generator runs, that entry appears inside the top-level `symbols` array of `dist/public-api-annotated.json`, with the package's current `version` and `schemaVersion: 1` stamped in.
+
+## Evolution rules
+
+- **Additive changes** (new optional fields on `SymbolEntry`, new topics) do not bump `schemaVersion`.
+- **Breaking changes** (removing a field, renaming a field, changing a field's type) bump `schemaVersion` to `2`. Consumers guard on the number.
+- **The `topic` grouping is conventional, not enforced** — new topics can be added freely. The MCP server's `ApiTopic` enum is the de-facto registry.
+
+## Open items for v2+
+
+Tracked on #103 (umbrella):
+
+- Stability annotations (`experimental` | `stable` | `deprecated`) once Whisq reaches `0.1.0`.
+- Parameter-level documentation (`params[]`) for functions with complex options objects.
+- Unification with `public-api.json` (option A from #103) once schema is stable.
+- TSDoc auto-extraction as a secondary source, with curated enrichment filling gaps.

--- a/packages/core/metadata/api-enrichment.json
+++ b/packages/core/metadata/api-enrichment.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "symbols": [
+    {
+      "name": "signal",
+      "kind": "function",
+      "signature": "signal<T>(initial: T): Signal<T>",
+      "summary": "Create a reactive value that tracks reads and notifies on writes.",
+      "gotchas": [
+        "Mutating an array or object in place (e.g. items.value.push(x)) does not trigger updates — use items.value = [...items.value, x] so the identity changes.",
+        "Passing a signal as an element child (e.g. div(count.value)) captures the value once. Wrap in a function (e.g. () => count.value) for reactive rendering.",
+        "peek() reads without tracking — do not use it inside a computed/effect expecting reactivity."
+      ],
+      "examples": [
+        "const count = signal(0);\ncount.value;            // read (tracked)\ncount.value = 5;        // write (notifies)\ncount.update(n => n + 1);\ncount.peek();           // read (NOT tracked)"
+      ],
+      "since": "0.1.0-alpha.1",
+      "seeAlso": ["computed", "effect", "batch"],
+      "topic": "signals"
+    },
+    {
+      "name": "computed",
+      "kind": "function",
+      "signature": "computed<T>(fn: () => T): ReadonlySignal<T>",
+      "summary": "Derive a reactive value from other signals; re-runs lazily when its dependencies change.",
+      "gotchas": [
+        "The returned signal is read-only — you cannot write doubled.value = x. Attempting to coerces at the type level; at runtime the setter is absent.",
+        "Dependency tracking is dynamic — an unread branch of an if/else does not create a dependency. Structure the function so reactivity follows the actual read path."
+      ],
+      "examples": [
+        "const count = signal(0);\nconst doubled = computed(() => count.value * 2);\n// doubled.value re-reads when count.value changes"
+      ],
+      "since": "0.1.0-alpha.1",
+      "seeAlso": ["signal", "effect", "batch"],
+      "topic": "signals"
+    },
+    {
+      "name": "effect",
+      "kind": "function",
+      "signature": "effect(fn: () => void | (() => void)): () => void",
+      "summary": "Run a side effect that re-executes when any signal it reads changes.",
+      "gotchas": [
+        "Return a cleanup function from the effect body if you need to tear down subscriptions, timers, or event listeners — it runs before each re-execution and on final disposal.",
+        "Calling the dispose function is the only way to stop an effect. Component effects wired via onMount/onCleanup handle this automatically; standalone effects are the caller's responsibility."
+      ],
+      "examples": [
+        "const dispose = effect(() => {\n  console.log(count.value);\n  return () => console.log('cleanup');\n});\ndispose(); // stop receiving updates"
+      ],
+      "since": "0.1.0-alpha.1",
+      "seeAlso": ["signal", "computed", "batch"],
+      "topic": "signals"
+    },
+    {
+      "name": "batch",
+      "kind": "function",
+      "signature": "batch(fn: () => void): void",
+      "summary": "Group multiple signal writes so dependent effects and computeds re-run only once afterward.",
+      "gotchas": [
+        "batch() is synchronous — await inside the callback defeats the batching (writes after the await land outside the batch).",
+        "Throwing inside batch() still flushes pending effects before the error propagates so the UI doesn't get stranded in an inconsistent state."
+      ],
+      "examples": [
+        "batch(() => {\n  x.value = 1;\n  y.value = 2;\n});\n// one update cycle, not two"
+      ],
+      "since": "0.1.0-alpha.1",
+      "seeAlso": ["signal", "computed", "effect"],
+      "topic": "signals"
+    }
+  ]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,14 +26,15 @@
     "./ids": {
       "types": "./dist/ids.d.ts",
       "import": "./dist/ids.js"
-    }
+    },
+    "./public-api-annotated.json": "./dist/public-api-annotated.json"
   },
   "files": [
     "dist",
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node scripts/generate-public-api.mjs",
+    "build": "tsc -p tsconfig.build.json && node scripts/generate-public-api.mjs && node scripts/generate-api-metadata.mjs",
     "dev": "tsc --watch -p tsconfig.build.json",
     "test": "vitest run --passWithNoTests",
     "size": "size-limit",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/core",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "The AI-native JavaScript framework that senses what you mean — reactive signals, templates, and components",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/scripts/generate-api-metadata.mjs
+++ b/packages/core/scripts/generate-api-metadata.mjs
@@ -1,0 +1,204 @@
+// ============================================================================
+// Whisq Core — Enriched API metadata generator (WHISQ-138)
+//
+// Reads metadata/api-enrichment.json (curated source of truth) and merges it
+// with the current package version + the names-only export list from
+// dist/public-api.json. Writes dist/public-api-annotated.json — the first
+// consumer-facing artefact of the schema defined in
+// packages/core/docs/api-metadata-schema.md.
+//
+// Drift guards (non-zero exit on failure):
+//   1. Every symbols[*].name must be in public-api.json's exports[].
+//   2. Every seeAlso[*] reference must be in public-api.json's exports[].
+//   3. Every SymbolEntry must have all required fields with matching types.
+//
+// Pure validation / assembly logic is exported so the (future) test file can
+// exercise it without touching the filesystem. The CLI block at the bottom
+// handles IO; everything above it is deterministic data-in / data-out.
+// ============================================================================
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const REQUIRED_SYMBOL_FIELDS = [
+  "name",
+  "kind",
+  "signature",
+  "summary",
+  "gotchas",
+  "examples",
+  "since",
+  "seeAlso",
+  "topic",
+];
+
+const VALID_KINDS = new Set([
+  "function",
+  "class",
+  "type",
+  "interface",
+  "const",
+  "namespace",
+]);
+
+/**
+ * Validate a single SymbolEntry against the schema. Returns an array of
+ * human-readable error strings; empty array means the entry is valid.
+ */
+export function validateSymbolEntry(entry, exportNames) {
+  const errs = [];
+  if (typeof entry !== "object" || entry === null) {
+    return [`entry is not an object`];
+  }
+
+  for (const field of REQUIRED_SYMBOL_FIELDS) {
+    if (!(field in entry)) {
+      errs.push(`missing required field: "${field}"`);
+    }
+  }
+  if (errs.length > 0) return errs;
+
+  if (typeof entry.name !== "string" || entry.name.length === 0) {
+    errs.push(`name must be a non-empty string`);
+  }
+  if (!VALID_KINDS.has(entry.kind)) {
+    errs.push(
+      `kind "${entry.kind}" is not one of ${[...VALID_KINDS].join(" | ")}`,
+    );
+  }
+  for (const strField of ["signature", "summary", "since", "topic"]) {
+    if (typeof entry[strField] !== "string" || entry[strField].length === 0) {
+      errs.push(`${strField} must be a non-empty string`);
+    }
+  }
+  for (const arrField of ["gotchas", "examples", "seeAlso"]) {
+    if (!Array.isArray(entry[arrField])) {
+      errs.push(`${arrField} must be an array`);
+    } else if (entry[arrField].some((s) => typeof s !== "string")) {
+      errs.push(`${arrField} must contain only strings`);
+    }
+  }
+
+  if (errs.length > 0) return errs;
+
+  if (!exportNames.has(entry.name)) {
+    errs.push(
+      `name "${entry.name}" is not in public-api.json exports — drift`,
+    );
+  }
+  for (const ref of entry.seeAlso) {
+    if (!exportNames.has(ref)) {
+      errs.push(
+        `seeAlso reference "${ref}" (from ${entry.name}) is not in public-api.json exports — drift`,
+      );
+    }
+  }
+
+  return errs;
+}
+
+/**
+ * Build the annotated manifest. Returns `{ ok: true, manifest }` on success
+ * or `{ ok: false, errors }` when any drift / schema violation is found.
+ */
+export function buildAnnotatedManifest({ version, exports, enrichment }) {
+  const exportNames = new Set(exports);
+  const errors = [];
+
+  if (!enrichment || typeof enrichment !== "object") {
+    return { ok: false, errors: ["enrichment payload is missing or not an object"] };
+  }
+  if (enrichment.schemaVersion !== 1) {
+    errors.push(
+      `enrichment.schemaVersion must be 1 (got ${JSON.stringify(enrichment.schemaVersion)})`,
+    );
+  }
+  if (!Array.isArray(enrichment.symbols)) {
+    return {
+      ok: false,
+      errors: [...errors, "enrichment.symbols must be an array"],
+    };
+  }
+
+  const seenNames = new Set();
+  for (const entry of enrichment.symbols) {
+    const entryErrs = validateSymbolEntry(entry, exportNames);
+    if (entryErrs.length > 0) {
+      const label = typeof entry?.name === "string" ? entry.name : "<unknown>";
+      for (const err of entryErrs) {
+        errors.push(`[${label}] ${err}`);
+      }
+      continue;
+    }
+    if (seenNames.has(entry.name)) {
+      errors.push(`[${entry.name}] duplicate symbol entry`);
+    }
+    seenNames.add(entry.name);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const symbols = [...enrichment.symbols].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  return {
+    ok: true,
+    manifest: {
+      version,
+      schemaVersion: 1,
+      symbols,
+    },
+  };
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+const isDirectRun =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url === `file:///${process.argv[1].replace(/\\/g, "/")}`;
+
+if (isDirectRun) {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const pkgRoot = resolve(__dirname, "..");
+
+  const pkg = JSON.parse(
+    readFileSync(resolve(pkgRoot, "package.json"), "utf8"),
+  );
+
+  const publicApiPath = resolve(pkgRoot, "dist/public-api.json");
+  if (!existsSync(publicApiPath)) {
+    console.error(
+      `[generate-api-metadata] ${publicApiPath} not found — run generate-public-api.mjs first.`,
+    );
+    process.exit(1);
+  }
+  const publicApi = JSON.parse(readFileSync(publicApiPath, "utf8"));
+
+  const enrichmentPath = resolve(pkgRoot, "metadata/api-enrichment.json");
+  const enrichment = JSON.parse(readFileSync(enrichmentPath, "utf8"));
+
+  const result = buildAnnotatedManifest({
+    version: pkg.version,
+    exports: publicApi.exports,
+    enrichment,
+  });
+
+  if (!result.ok) {
+    console.error("[generate-api-metadata] validation failed:");
+    for (const err of result.errors) {
+      console.error(`  - ${err}`);
+    }
+    process.exit(1);
+  }
+
+  const outPath = resolve(pkgRoot, "dist/public-api-annotated.json");
+  writeFileSync(outPath, JSON.stringify(result.manifest, null, 2) + "\n");
+
+  console.log(
+    `Wrote ${outPath}: ${result.manifest.symbols.length} symbols, version ${result.manifest.version} (schemaVersion ${result.manifest.schemaVersion})`,
+  );
+}

--- a/packages/core/scripts/resolve-latest-api.mjs
+++ b/packages/core/scripts/resolve-latest-api.mjs
@@ -1,0 +1,155 @@
+// ============================================================================
+// Whisq Core — Authoritative "latest API manifest" URL resolver (WHISQ-140)
+//
+// The CDN-backed `unpkg.com/@whisq/core@latest/dist/public-api.json` URL can
+// lag the npm registry by minutes to hours after each publish. During that
+// window, AI tools that resolve "the latest Whisq" through the CDN silently
+// get the *previous* version's manifest — even though `npm view @whisq/core
+// version` reports the current one. The v0.1.0-alpha.9 Codex feedback was
+// written against a stale alpha.8 manifest before the reviewer noticed.
+//
+// This script eliminates the lag window: it hits the npm registry API first
+// (authoritative, low-latency), reads the current `version`, and prints the
+// pinned-version CDN URL that cannot serve stale content. AI scaffolders and
+// docs generators that want "the latest API surface" should chain the two:
+//
+//   CORE_VERSION=$(node packages/core/scripts/resolve-latest-api.mjs --version)
+//   curl -sSL "$(node packages/core/scripts/resolve-latest-api.mjs --url)"
+//
+// or the convenience one-shot:
+//
+//   curl -sSL "$(node packages/core/scripts/resolve-latest-api.mjs --url)" \
+//     | jq .
+//
+// Pure URL-building and version-parsing logic is exported so the unit test
+// exercises them without network I/O.
+// ============================================================================
+
+const REGISTRY_URL = "https://registry.npmjs.org/@whisq/core/latest";
+const DEFAULT_PACKAGE = "@whisq/core";
+
+/**
+ * Build the pinned unpkg URL for the `public-api.json` (names-only) manifest
+ * at a specific version. The `@${version}` pin means unpkg serves the exact
+ * tarball — never a cached "@latest" alias.
+ */
+export function pinnedPublicApiUrl(version, packageName = DEFAULT_PACKAGE) {
+  assertNonEmptyString(version, "version");
+  assertNonEmptyString(packageName, "packageName");
+  return `https://unpkg.com/${packageName}@${encodeURIComponent(version)}/dist/public-api.json`;
+}
+
+/**
+ * Build the pinned unpkg URL for the enriched `public-api-annotated.json`
+ * manifest (shipped since WHISQ-138) at a specific version.
+ */
+export function pinnedAnnotatedApiUrl(version, packageName = DEFAULT_PACKAGE) {
+  assertNonEmptyString(version, "version");
+  assertNonEmptyString(packageName, "packageName");
+  return `https://unpkg.com/${packageName}@${encodeURIComponent(version)}/dist/public-api-annotated.json`;
+}
+
+/**
+ * Validate and extract the `version` field from the npm registry's
+ * `/:pkg/latest` payload. Returns the parsed semver string or throws with
+ * a context-rich error the CLI surfaces verbatim.
+ */
+export function extractVersion(registryPayload) {
+  if (registryPayload === null || typeof registryPayload !== "object") {
+    throw new TypeError(
+      "registry payload is not an object — expected { version, ... }",
+    );
+  }
+  const version = registryPayload.version;
+  if (typeof version !== "string" || version.length === 0) {
+    throw new TypeError(
+      `registry payload is missing a string "version" field (got ${JSON.stringify(version)})`,
+    );
+  }
+  return version;
+}
+
+function assertNonEmptyString(value, name) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${name} must be a non-empty string`);
+  }
+}
+
+/**
+ * Resolve the current `@whisq/core` version via the npm registry. Caller
+ * supplies a fetch implementation — in the CLI that's the global `fetch`;
+ * tests pass a stub.
+ */
+export async function resolveLatestVersion({
+  fetch: fetchImpl = globalThis.fetch,
+  registryUrl = REGISTRY_URL,
+} = {}) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error(
+      "no fetch implementation — pass { fetch } or run on Node 18+ with global fetch",
+    );
+  }
+  const response = await fetchImpl(registryUrl);
+  if (!response || !response.ok) {
+    const status = response ? response.status : "no response";
+    throw new Error(
+      `npm registry ${registryUrl} returned ${status} — cannot resolve @whisq/core version`,
+    );
+  }
+  const payload = await response.json();
+  return extractVersion(payload);
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+const isDirectRun =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url === `file:///${process.argv[1].replace(/\\/g, "/")}`;
+
+if (isDirectRun) {
+  const args = process.argv.slice(2);
+  const mode = args[0] ?? "--url";
+
+  try {
+    const version = await resolveLatestVersion();
+    switch (mode) {
+      case "--version":
+        process.stdout.write(`${version}\n`);
+        break;
+      case "--url":
+        process.stdout.write(`${pinnedPublicApiUrl(version)}\n`);
+        break;
+      case "--annotated-url":
+        process.stdout.write(`${pinnedAnnotatedApiUrl(version)}\n`);
+        break;
+      case "--help":
+      case "-h":
+        process.stdout.write(
+          [
+            "resolve-latest-api — resolve @whisq/core latest via npm registry",
+            "",
+            "Usage: node packages/core/scripts/resolve-latest-api.mjs [--url | --annotated-url | --version | --help]",
+            "",
+            "  --url             Pinned URL for dist/public-api.json (default).",
+            "  --annotated-url   Pinned URL for dist/public-api-annotated.json.",
+            "  --version         Just the version string (e.g. 0.1.0-alpha.9).",
+            "  --help, -h        Print this help.",
+            "",
+            "The pinned URLs are immune to the unpkg @latest CDN-lag window — the",
+            "@${version} suffix targets the exact tarball on the registry.",
+          ].join("\n") + "\n",
+        );
+        break;
+      default:
+        process.stderr.write(
+          `resolve-latest-api: unknown option "${mode}" — run with --help\n`,
+        );
+        process.exit(2);
+    }
+  } catch (err) {
+    process.stderr.write(
+      `resolve-latest-api: ${(err && err.message) || err}\n`,
+    );
+    process.exit(1);
+  }
+}

--- a/packages/core/src/__tests__/compose.test.ts
+++ b/packages/core/src/__tests__/compose.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { signal } from "../reactive.js";
+import { input, mount } from "../elements.js";
+import { bind } from "../bind.js";
+import { bindField } from "../bindField.js";
+import { bindPath } from "../bindPath.js";
+import { compose } from "../compose.js";
+import { WHISQ_BIND_SOURCES } from "../bind-sentinel.js";
+
+let container: HTMLElement;
+let dispose: () => void;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (dispose) dispose();
+  container.remove();
+});
+
+describe("compose() — text bind", () => {
+  it("runs both bind's oninput and the user handler on input events", () => {
+    const name = signal("");
+    const track = vi.fn();
+    dispose = mount(
+      input({ ...compose(bind(name), { oninput: track }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "grace";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(name.value).toBe("grace");
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls bind's handler before the user's handler (bind first)", () => {
+    const name = signal("ada");
+    const order: string[] = [];
+    const track = vi.fn((e: Event) => {
+      order.push(`user:${name.value}:${(e.target as HTMLInputElement).value}`);
+    });
+    // bind writes to name before user reads it, so user sees the post-write value.
+    dispose = mount(
+      input({ ...compose(bind(name), { oninput: track }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "grace";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(order).toEqual(["user:grace:grace"]);
+  });
+
+  it("works regardless of spread order of compose result (order-independent goal)", () => {
+    const name = signal("");
+    const track = vi.fn();
+    dispose = mount(
+      input({
+        placeholder: "typed before",
+        ...compose(bind(name), { oninput: track }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "x";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(name.value).toBe("x");
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(el.placeholder).toBe("typed before");
+  });
+});
+
+describe("compose() — checkbox / radio bind", () => {
+  it("composes onchange for checkbox bind", () => {
+    const agreed = signal(false);
+    const track = vi.fn();
+    dispose = mount(
+      input({
+        type: "checkbox",
+        ...compose(bind(agreed, { as: "checkbox" }), { onchange: track }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(agreed.value).toBe(true);
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  it("composes onchange for radio bind", () => {
+    const role = signal<"admin" | "user">("user");
+    const track = vi.fn();
+    dispose = mount(
+      input({
+        type: "radio",
+        name: "role",
+        ...compose(bind(role, { as: "radio", value: "admin" }), {
+          onchange: track,
+        }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(role.value).toBe("admin");
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("compose() — bindField / bindPath", () => {
+  it("composes with bindField over a keyed row", () => {
+    interface Todo {
+      id: string;
+      text: string;
+      done: boolean;
+    }
+    const todos = signal<Todo[]>([{ id: "a", text: "write", done: false }]);
+    const track = vi.fn();
+    const row = () => todos.value[0]!;
+    dispose = mount(
+      input({
+        type: "checkbox",
+        ...compose(bindField(todos, row, "done", { as: "checkbox" }), {
+          onchange: track,
+        }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.checked = true;
+    el.dispatchEvent(new Event("change"));
+    expect(todos.value[0]!.done).toBe(true);
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  it("composes with bindPath over a nested field", () => {
+    interface User {
+      profile: { name: string };
+    }
+    const user = signal<User>({ profile: { name: "" } });
+    const track = vi.fn();
+    dispose = mount(
+      input({
+        ...compose(bindPath(user, ["profile", "name"]), { oninput: track }),
+      }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.value = "grace";
+    el.dispatchEvent(new InputEvent("input"));
+    expect(user.value.profile.name).toBe("grace");
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("compose() — prop merging semantics", () => {
+  it("lets extras overwrite non-handler props (normal spread semantics)", () => {
+    const name = signal("");
+    const merged = compose(bind(name), {
+      placeholder: "from extras",
+    } as Record<string, unknown>);
+    expect((merged as Record<string, unknown>).placeholder).toBe("from extras");
+  });
+
+  it("passes through new handler keys from extras with no bind counterpart", () => {
+    const name = signal("");
+    const onFocus = vi.fn();
+    dispose = mount(
+      input({ ...compose(bind(name), { onfocus: onFocus }) }),
+      container,
+    );
+    const el = container.querySelector("input") as HTMLInputElement;
+    el.dispatchEvent(new Event("focus"));
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("compose() — sentinel integration", () => {
+  it("does NOT emit the spread-overwrite dev warning on a compose result", () => {
+    const name = signal("");
+    const track = vi.fn();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    dispose = mount(
+      input({ ...compose(bind(name), { oninput: track }) }),
+      container,
+    );
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("still warns if the compose result is then overwritten (direction-1 on compose output)", () => {
+    const name = signal("");
+    const track = vi.fn();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    dispose = mount(
+      input({
+        ...compose(bind(name), { oninput: track }),
+        oninput: () => {
+          /* overwrites the composed handler */
+        },
+      }),
+      container,
+    );
+    expect(warn).toHaveBeenCalled();
+    const message = warn.mock.calls[0]?.[0];
+    expect(String(message)).toMatch(/duplicate handler|bind\(\)/i);
+    warn.mockRestore();
+  });
+
+  it("re-tags the sentinel to reflect the composed handler", () => {
+    const name = signal("");
+    const track = vi.fn();
+    const composed = compose(bind(name), { oninput: track }) as Record<
+      string,
+      unknown
+    > & { [k: symbol]: unknown };
+    const sources = composed[WHISQ_BIND_SOURCES] as
+      | Record<string, unknown>
+      | undefined;
+    expect(sources).toBeDefined();
+    expect(sources!.oninput).toBe(composed.oninput);
+  });
+});

--- a/packages/core/src/__tests__/generate-api-metadata.test.ts
+++ b/packages/core/src/__tests__/generate-api-metadata.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error — .mjs build script exports plain JS; typechecker can't see types.
+import {
+  validateSymbolEntry,
+  buildAnnotatedManifest,
+} from "../../scripts/generate-api-metadata.mjs";
+
+const exportNames = new Set([
+  "signal",
+  "computed",
+  "effect",
+  "batch",
+  "div",
+]);
+
+function validEntry(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    name: "signal",
+    kind: "function",
+    signature: "signal<T>(initial: T): Signal<T>",
+    summary: "Create a reactive value.",
+    gotchas: [],
+    examples: [],
+    since: "0.1.0-alpha.1",
+    seeAlso: ["computed", "effect"],
+    topic: "signals",
+    ...overrides,
+  };
+}
+
+describe("validateSymbolEntry", () => {
+  it("accepts a well-formed entry with no errors", () => {
+    const errs = validateSymbolEntry(validEntry(), exportNames);
+    expect(errs).toEqual([]);
+  });
+
+  it("reports missing required fields", () => {
+    const errs = validateSymbolEntry({ name: "signal" }, exportNames);
+    expect(errs.some((e: string) => e.includes("kind"))).toBe(true);
+    expect(errs.some((e: string) => e.includes("signature"))).toBe(true);
+    expect(errs.some((e: string) => e.includes("summary"))).toBe(true);
+  });
+
+  it("rejects unknown kinds", () => {
+    const errs = validateSymbolEntry(
+      validEntry({ kind: "widget" }),
+      exportNames,
+    );
+    expect(errs.some((e: string) => e.includes("kind"))).toBe(true);
+  });
+
+  it("rejects arrays that contain non-strings", () => {
+    const errs = validateSymbolEntry(
+      validEntry({ gotchas: ["ok", 42] }),
+      exportNames,
+    );
+    expect(errs.some((e: string) => e.includes("gotchas"))).toBe(true);
+  });
+
+  it("fails drift when name is not a known export", () => {
+    const errs = validateSymbolEntry(
+      validEntry({ name: "doesNotExist" }),
+      exportNames,
+    );
+    expect(errs.some((e: string) => e.includes("drift"))).toBe(true);
+  });
+
+  it("fails drift when a seeAlso reference is not a known export", () => {
+    const errs = validateSymbolEntry(
+      validEntry({ seeAlso: ["signal", "ghostSymbol"] }),
+      exportNames,
+    );
+    expect(errs.some((e: string) => e.includes("ghostSymbol"))).toBe(true);
+    expect(errs.some((e: string) => e.includes("drift"))).toBe(true);
+  });
+});
+
+describe("buildAnnotatedManifest", () => {
+  it("returns ok + stamps version + sorts symbols alphabetically", () => {
+    const result = buildAnnotatedManifest({
+      version: "9.9.9",
+      exports: [...exportNames],
+      enrichment: {
+        schemaVersion: 1,
+        symbols: [validEntry({ name: "effect" }), validEntry({ name: "batch" })],
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.manifest.version).toBe("9.9.9");
+    expect(result.manifest.schemaVersion).toBe(1);
+    expect(result.manifest.symbols.map((s: { name: string }) => s.name)).toEqual([
+      "batch",
+      "effect",
+    ]);
+  });
+
+  it("aggregates per-entry validation errors and labels them", () => {
+    const result = buildAnnotatedManifest({
+      version: "1.0.0",
+      exports: [...exportNames],
+      enrichment: {
+        schemaVersion: 1,
+        symbols: [
+          validEntry({ name: "nope" }), // drift
+          validEntry({ kind: "widget" }), // invalid kind
+        ],
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e: string) => e.startsWith("[nope]"))).toBe(true);
+    expect(result.errors.some((e: string) => e.startsWith("[signal]"))).toBe(true);
+  });
+
+  it("rejects a wrong schemaVersion at the top level", () => {
+    const result = buildAnnotatedManifest({
+      version: "1.0.0",
+      exports: [...exportNames],
+      enrichment: { schemaVersion: 999, symbols: [validEntry()] },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e: string) => e.includes("schemaVersion"))).toBe(
+      true,
+    );
+  });
+
+  it("flags duplicate symbol entries", () => {
+    const result = buildAnnotatedManifest({
+      version: "1.0.0",
+      exports: [...exportNames],
+      enrichment: {
+        schemaVersion: 1,
+        symbols: [validEntry({ name: "signal" }), validEntry({ name: "signal" })],
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e: string) => e.includes("duplicate"))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/core/src/__tests__/ids.test.ts
+++ b/packages/core/src/__tests__/ids.test.ts
@@ -74,3 +74,62 @@ describe("randomId() — fallback path (crypto.randomUUID unavailable)", () => {
     }
   });
 });
+
+describe("randomId({ prefix })", () => {
+  it("prepends the prefix to the UUID with no separator", () => {
+    const id = randomId({ prefix: "todo_" });
+    expect(id.startsWith("todo_")).toBe(true);
+    expect(id.slice("todo_".length)).toMatch(V4_UUID_SHAPE);
+  });
+
+  it("empty prefix is a no-op (same shape as zero-arg call)", () => {
+    expect(randomId({ prefix: "" })).toMatch(V4_UUID_SHAPE);
+  });
+});
+
+describe("randomId({ rng })", () => {
+  it("produces deterministic output when rng is deterministic", () => {
+    const seeded = () => 0.5;
+    const a = randomId({ rng: seeded });
+    const b = randomId({ rng: seeded });
+    expect(a).toBe(b);
+    expect(a).toMatch(V4_UUID_SHAPE);
+  });
+
+  it("bypasses crypto.randomUUID when rng is supplied (the whole point)", () => {
+    const cryptoSpy = vi.spyOn(crypto, "randomUUID");
+    try {
+      const rng = () => 0.25;
+      randomId({ rng });
+      expect(cryptoSpy).not.toHaveBeenCalled();
+    } finally {
+      cryptoSpy.mockRestore();
+    }
+  });
+
+  it("respects both prefix and rng together", () => {
+    const id = randomId({ prefix: "t-", rng: () => 0 });
+    expect(id).toBe("t-00000000-0000-4000-8000-000000000000");
+  });
+
+  it("degenerate () => 0 rng produces the all-zero UUID (sanity / shape check)", () => {
+    expect(randomId({ rng: () => 0 })).toBe(
+      "00000000-0000-4000-8000-000000000000",
+    );
+  });
+
+  it("different rng functions may yield different sequences across calls", () => {
+    let i = 0;
+    const stepping = () => {
+      // feed 0, 1/16, 2/16, ... — each call advances, so successive calls differ
+      const n = (i % 16) / 16;
+      i += 1;
+      return n;
+    };
+    const a = randomId({ rng: stepping });
+    const b = randomId({ rng: stepping });
+    expect(a).not.toBe(b);
+    expect(a).toMatch(V4_UUID_SHAPE);
+    expect(b).toMatch(V4_UUID_SHAPE);
+  });
+});

--- a/packages/core/src/__tests__/persistence.test.ts
+++ b/packages/core/src/__tests__/persistence.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { effect } from "../reactive.js";
 // Imported from the internal path. Public import is `@whisq/core/persistence`
 // (see packages/core/package.json exports).
-import { persistedSignal } from "../persistence.js";
+import { persistedSignal, createStorageNamespace } from "../persistence.js";
 
 beforeEach(() => {
   window.localStorage.clear();
@@ -264,5 +264,68 @@ describe("persistedSignal() — onSchemaFailure callback", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+});
+
+describe("createStorageNamespace()", () => {
+  it("writes under the '<prefix>:<key>' storage slot", () => {
+    const ns = createStorageNamespace("whisq-todo-app");
+    const todos = ns.persistedSignal<string[]>("todos", []);
+    todos.value = ["walk dog"];
+    expect(window.localStorage.getItem("whisq-todo-app:todos")).toBe(
+      '["walk dog"]',
+    );
+    // the un-prefixed key must NOT be touched
+    expect(window.localStorage.getItem("todos")).toBeNull();
+  });
+
+  it("reads from the prefixed slot on init", () => {
+    window.localStorage.setItem("app-a:count", "7");
+    const ns = createStorageNamespace("app-a");
+    const count = ns.persistedSignal("count", 0);
+    expect(count.value).toBe(7);
+  });
+
+  it("keeps two namespaces from colliding on the same key", () => {
+    const a = createStorageNamespace("app-a");
+    const b = createStorageNamespace("app-b");
+    const ca = a.persistedSignal("settings", { theme: "light" });
+    const cb = b.persistedSignal("settings", { theme: "dark" });
+    ca.value = { theme: "light" };
+    cb.value = { theme: "dark" };
+    expect(window.localStorage.getItem("app-a:settings")).toBe(
+      '{"theme":"light"}',
+    );
+    expect(window.localStorage.getItem("app-b:settings")).toBe(
+      '{"theme":"dark"}',
+    );
+  });
+
+  it("passes options (storage: 'session', schema, onSchemaFailure) through to persistedSignal", () => {
+    const ns = createStorageNamespace("ns-pass");
+    const onSchemaFailure = vi.fn();
+    const s = ns.persistedSignal("flag", false, {
+      storage: "session",
+      schema: (raw) => raw as boolean,
+      onSchemaFailure,
+    });
+    s.value = true;
+    expect(window.sessionStorage.getItem("ns-pass:flag")).toBe("true");
+    expect(window.localStorage.getItem("ns-pass:flag")).toBeNull();
+    expect(onSchemaFailure).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty or whitespace-only prefix", () => {
+    expect(() => createStorageNamespace("")).toThrow(TypeError);
+    expect(() => createStorageNamespace("   ")).toThrow(TypeError);
+  });
+
+  it("rejects a non-string prefix", () => {
+    expect(() =>
+      createStorageNamespace(undefined as unknown as string),
+    ).toThrow(TypeError);
+    expect(() =>
+      createStorageNamespace(null as unknown as string),
+    ).toThrow(TypeError);
   });
 });

--- a/packages/core/src/__tests__/resolve-latest-api.test.ts
+++ b/packages/core/src/__tests__/resolve-latest-api.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+// @ts-expect-error — plain .mjs tooling script; no .d.ts emitted.
+import {
+  pinnedPublicApiUrl,
+  pinnedAnnotatedApiUrl,
+  extractVersion,
+  resolveLatestVersion,
+} from "../../scripts/resolve-latest-api.mjs";
+
+describe("pinnedPublicApiUrl", () => {
+  it("targets the exact version's tarball on unpkg", () => {
+    expect(pinnedPublicApiUrl("0.1.0-alpha.9")).toBe(
+      "https://unpkg.com/@whisq/core@0.1.0-alpha.9/dist/public-api.json",
+    );
+  });
+
+  it("percent-encodes versions that contain characters (defensive; semver rarely does)", () => {
+    expect(pinnedPublicApiUrl("0.2.0-rc.1+build.42")).toBe(
+      "https://unpkg.com/@whisq/core@0.2.0-rc.1%2Bbuild.42/dist/public-api.json",
+    );
+  });
+
+  it("accepts a custom package name", () => {
+    expect(pinnedPublicApiUrl("1.0.0", "@whisq/other")).toBe(
+      "https://unpkg.com/@whisq/other@1.0.0/dist/public-api.json",
+    );
+  });
+
+  it("rejects an empty version", () => {
+    expect(() => pinnedPublicApiUrl("")).toThrow(TypeError);
+  });
+});
+
+describe("pinnedAnnotatedApiUrl", () => {
+  it("targets the enriched manifest file at the pinned version", () => {
+    expect(pinnedAnnotatedApiUrl("0.1.0-alpha.9")).toBe(
+      "https://unpkg.com/@whisq/core@0.1.0-alpha.9/dist/public-api-annotated.json",
+    );
+  });
+});
+
+describe("extractVersion", () => {
+  it("returns the version string from a well-formed registry payload", () => {
+    expect(extractVersion({ version: "0.1.0-alpha.9", name: "@whisq/core" }))
+      .toBe("0.1.0-alpha.9");
+  });
+
+  it("throws on a non-object payload", () => {
+    expect(() => extractVersion(null)).toThrow(TypeError);
+    expect(() => extractVersion("0.1.0")).toThrow(TypeError);
+  });
+
+  it("throws when version is missing / not a string / empty", () => {
+    expect(() => extractVersion({})).toThrow(/version/);
+    expect(() => extractVersion({ version: 9 })).toThrow(/version/);
+    expect(() => extractVersion({ version: "" })).toThrow(/version/);
+  });
+});
+
+describe("resolveLatestVersion", () => {
+  it("fetches the registry URL and returns the version", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ version: "1.2.3", name: "@whisq/core" }),
+    }));
+    const version = await resolveLatestVersion({ fetch: fetchImpl });
+    expect(version).toBe("1.2.3");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/@whisq/core/latest",
+    );
+  });
+
+  it("honours a custom registryUrl (useful for mocking)", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ version: "2.0.0" }),
+    }));
+    await resolveLatestVersion({
+      fetch: fetchImpl,
+      registryUrl: "https://example.test/@whisq%2Fcore/latest",
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://example.test/@whisq%2Fcore/latest",
+    );
+  });
+
+  it("throws a context-rich error on non-2xx responses", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    }));
+    await expect(
+      resolveLatestVersion({ fetch: fetchImpl }),
+    ).rejects.toThrow(/503/);
+  });
+
+  it("throws when no fetch implementation is available", async () => {
+    await expect(
+      // @ts-expect-error — intentionally passing a non-function
+      resolveLatestVersion({ fetch: null }),
+    ).rejects.toThrow(/fetch/i);
+  });
+});

--- a/packages/core/src/__tests__/subpath-stubs.test.ts
+++ b/packages/core/src/__tests__/subpath-stubs.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  partition,
+  signalMap,
+  signalSet,
+  randomId,
+  persistedSignal,
+  bindPath,
+} from "../index.js";
+
+describe("sub-path stubs on @whisq/core main entry", () => {
+  const cases: Array<{
+    name: string;
+    stub: unknown;
+    subpath: string;
+    slug: string;
+  }> = [
+    { name: "partition", stub: partition, subpath: "collections", slug: "partition" },
+    { name: "signalMap", stub: signalMap, subpath: "collections", slug: "signalmap" },
+    { name: "signalSet", stub: signalSet, subpath: "collections", slug: "signalset" },
+    { name: "randomId", stub: randomId, subpath: "ids", slug: "randomid" },
+    { name: "persistedSignal", stub: persistedSignal, subpath: "persistence", slug: "persistedsignal" },
+    { name: "bindPath", stub: bindPath, subpath: "forms", slug: "bindpath" },
+  ];
+
+  for (const { name, stub, subpath, slug } of cases) {
+    describe(`"${name}" stub`, () => {
+      it("is callable (a function, not undefined)", () => {
+        expect(typeof stub).toBe("function");
+      });
+
+      it("throws an Error when invoked", () => {
+        expect(() => (stub as () => unknown)()).toThrow(Error);
+      });
+
+      it(`points to the @whisq/core/${subpath} sub-path in the error message`, () => {
+        try {
+          (stub as () => unknown)();
+        } catch (err) {
+          expect(err).toBeInstanceOf(Error);
+          expect((err as Error).message).toContain(`@whisq/core/${subpath}`);
+          expect((err as Error).message).toContain(name);
+          expect((err as Error).message).toContain(
+            `https://whisq.dev/api/${slug}/`,
+          );
+          return;
+        }
+        throw new Error("stub did not throw");
+      });
+    });
+  }
+
+  it("sub-path imports still resolve the real implementations (not the stubs)", async () => {
+    const collections = await import("../collections.js");
+    const ids = await import("../ids.js");
+    const persistence = await import("../persistence.js");
+    const forms = await import("../forms.js");
+
+    expect(typeof collections.partition).toBe("function");
+    expect(typeof collections.signalMap).toBe("function");
+    expect(typeof collections.signalSet).toBe("function");
+    expect(typeof ids.randomId).toBe("function");
+    expect(typeof persistence.persistedSignal).toBe("function");
+    expect(typeof forms.bindPath).toBe("function");
+
+    // sanity: the sub-path randomId returns a real v4-shaped string, not a thrown error
+    expect(ids.randomId()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("sub-path stub is distinct from the real implementation (main-path stub ≠ sub-path impl)", async () => {
+    const ids = await import("../ids.js");
+    expect(randomId).not.toBe(ids.randomId);
+  });
+});

--- a/packages/core/src/bind-sentinel.ts
+++ b/packages/core/src/bind-sentinel.ts
@@ -23,9 +23,9 @@
 // after spread). It cannot catch direction-2 (user handler first, then
 // spread bind on top) — the user's original handler is gone without a
 // trace by the time props reach the element builder. The recommended
-// convention is to spread bind/bindField/bindPath LAST; a future
-// `compose(bind(sig), { oninput: fn })` helper could cover both shapes
-// but isn't part of this change.
+// convention is to spread bind/bindField/bindPath LAST; `compose()`
+// (WHISQ-132) is the order-independent escape hatch when you deliberately
+// want to augment a bind result with extra handlers.
 // ============================================================================
 
 /**

--- a/packages/core/src/compose.ts
+++ b/packages/core/src/compose.ts
@@ -1,0 +1,88 @@
+// ============================================================================
+// Whisq Core — compose() helper for bind family
+//
+// bind() / bindField() / bindPath() return prop objects that the caller
+// spreads into an element factory. JS object spread is last-key-wins, so a
+// user-supplied event handler placed next to the bind spread either silently
+// clobbers bind (direction-1, dev-warned) or is itself silently clobbered
+// (direction-2, undetectable after the fact).
+//
+// compose(bindResult, extras) merges both sides explicitly and produces a
+// single prop object where any shared handler key chains both handlers —
+// bind first, then the user handler. Non-handler keys follow normal spread
+// semantics: extras win. The returned object carries a fresh bind-sentinel
+// whose "declared" handler is the composed chain, so a later overwrite on
+// the compose result still trips the same dev warning.
+// ============================================================================
+
+import { tagBindResult } from "./bind-sentinel.js";
+
+type EventHandler = (event: Event) => void;
+
+/**
+ * Merge a bind result with extra props, chaining event handlers that appear
+ * on both sides. For keys that match both a bind handler and a user handler,
+ * the returned handler calls bind's first and the user's second — so by the
+ * time the user handler runs, the signal has already been updated.
+ *
+ * ```ts
+ * import { bind, compose, input } from "@whisq/core";
+ *
+ * const draft = signal("");
+ * input({
+ *   ...compose(bind(draft), {
+ *     oninput: (e) => track(e),           // fires after bind writes draft
+ *     onfocus: () => analytics.focus(),   // bind has no onfocus — attaches
+ *   }),
+ * });
+ * ```
+ *
+ * Unlike the "spread bind last" convention, `compose()` is order-independent:
+ * `input({ ...compose(bind(s), { oninput: fn }) })` behaves the same whether
+ * the compose spread appears first, last, or in the middle of the props
+ * object, because both handlers are already merged inside a single handler
+ * function before the element factory sees them.
+ *
+ * Works for `bind()`, `bindField()`, and `bindPath()` — any helper that
+ * returns a bind-sentinel-tagged prop object.
+ *
+ * Non-handler keys (`value`, `checked`, `placeholder`, `class`, …) follow
+ * normal object-spread semantics: the extras' value overwrites bind's if
+ * present. In practice you won't overlap on those because bind's non-handler
+ * props are the ones bind needs to drive the input — override them at your
+ * own risk.
+ */
+export function compose<T extends object, E extends Record<string, unknown>>(
+  bindResult: T,
+  extras: E,
+): T & E {
+  const out: Record<string, unknown> = { ...bindResult } as Record<
+    string,
+    unknown
+  >;
+
+  for (const key of Object.keys(extras)) {
+    const extraValue = extras[key];
+    const existing = out[key];
+    if (
+      key.startsWith("on") &&
+      typeof existing === "function" &&
+      typeof extraValue === "function"
+    ) {
+      const bindHandler = existing as EventHandler;
+      const userHandler = extraValue as EventHandler;
+      out[key] = (event: Event): void => {
+        bindHandler(event);
+        userHandler(event);
+      };
+    } else {
+      out[key] = extraValue;
+    }
+  }
+
+  // Re-tag so the element-builder sentinel sees the composed handler as the
+  // "declared" one. That way `...compose(bind(s), { oninput: fn })` never
+  // triggers a false-positive dev warning, but a later overwrite on the
+  // compose result ({ ...compose(...), oninput: other }) still trips it.
+  return tagBindResult(out) as T & E;
+}

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -12,41 +12,78 @@
 // ============================================================================
 
 /**
+ * Options for {@link randomId}.
+ *
+ * Both fields are optional; omitting both preserves the zero-arg behaviour.
+ */
+export interface RandomIdOptions {
+  /**
+   * String prepended to the UUID. No separator is inserted — pass
+   * `"todo_"` or `"item-"` if you want one. Handy for making `each({ key })`
+   * values self-describing (e.g. `todo_01K1…`).
+   */
+  prefix?: string;
+  /**
+   * Override the source of randomness. When supplied, `crypto.randomUUID()`
+   * is bypassed entirely and the fallback synthesis runs with this function
+   * in place of `Math.random`. The primary use-case is **deterministic ids
+   * for snapshot tests**: pass a seeded PRNG to get reproducible output.
+   *
+   * The function must return a value in `[0, 1)` (same contract as
+   * `Math.random`). A degenerate `() => 0` returns an all-zero UUID.
+   */
+  rng?: () => number;
+}
+
+/**
  * Generate a UUID-v4-shaped random identifier.
  *
  * ```ts
  * import { randomId } from "@whisq/core/ids";
  *
  * const todo = { id: randomId(), text, done: false };
+ * const scoped = randomId({ prefix: "todo_" });      // "todo_01K1..."
+ * const seeded = randomId({ rng: seedrandom(42) });  // deterministic
  * ```
  *
- * Prefers `crypto.randomUUID()` when the platform provides it (all modern
- * browsers; Node 19+; Deno; Bun). Otherwise falls back to a `Math.random`
- * synthesis — same v4 shape (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` where
- * `y ∈ {8, 9, a, b}`), but with weaker entropy. Good enough for UI row
+ * Without options, prefers `crypto.randomUUID()` when the platform provides
+ * it (all modern browsers; Node 19+; Deno; Bun). Otherwise falls back to a
+ * `Math.random` synthesis — same v4 shape (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`
+ * where `y ∈ {8, 9, a, b}`), but with weaker entropy. Good enough for UI row
  * ids and keyed-`each` keys; not for tokens, secrets, or deduplication
  * across independent clients.
+ *
+ * When `options.rng` is supplied, the native path is skipped regardless of
+ * platform so the same code yields the same id in every environment — the
+ * point is testability, not randomness.
  */
-export function randomId(): string {
+export function randomId(options?: RandomIdOptions): string {
+  const prefix = options?.prefix ?? "";
+  const rng = options?.rng;
+
+  if (rng) {
+    return prefix + fallbackUuid(rng);
+  }
+
   if (
     typeof crypto !== "undefined" &&
     typeof crypto.randomUUID === "function"
   ) {
-    return crypto.randomUUID();
+    return prefix + crypto.randomUUID();
   }
-  return fallbackUuid();
+  return prefix + fallbackUuid();
 }
 
-function fallbackUuid(): string {
+function fallbackUuid(rng: () => number = Math.random): string {
   // Compose 32 hex digits, then splice in the v4 version (4) and variant
   // (8/9/a/b) bits at positions 12 and 16. Output shape matches RFC 4122 v4.
   const hex = (digits: number): string => {
     let out = "";
     for (let i = 0; i < digits; i++) {
-      out += Math.floor(Math.random() * 16).toString(16);
+      out += Math.floor(rng() * 16).toString(16);
     }
     return out;
   };
-  const variant = ((Math.random() * 4) | 0) + 8; // 8..11 → 8,9,a,b
+  const variant = ((rng() * 4) | 0) + 8; // 8..11 → 8,9,a,b
   return `${hex(8)}-${hex(4)}-4${hex(3)}-${variant.toString(16)}${hex(3)}-${hex(12)}`;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -141,3 +141,20 @@ export { compose } from "./compose.js";
 
 // bindPath() for nested-object paths lives at `@whisq/core/forms` — kept off
 // the top-level bundle so apps that don't need deep binding pay no size cost.
+
+// Sub-path guard stubs — these re-exports throw with a friendly message
+// pointing to the correct sub-path when called. They exist purely so a
+// misfiled `import { partition } from "@whisq/core"` compiles and throws
+// at call-time with an actionable error instead of the bundler's generic
+// "not exported" noise. Each stub is a no-side-effect `export function`,
+// so `sideEffects: false` + standard unused-export elimination drops them
+// to zero bytes in bundles that don't import them. Verified by
+// `pnpm -C packages/core bench:shake`.
+export {
+  partition,
+  signalMap,
+  signalSet,
+  randomId,
+  persistedSignal,
+  bindPath,
+} from "./subpath-stubs.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -137,6 +137,7 @@ export type {
 } from "./bind.js";
 export { bindField } from "./bindField.js";
 export type { BindFieldOptions } from "./bindField.js";
+export { compose } from "./compose.js";
 
 // bindPath() for nested-object paths lives at `@whisq/core/forms` — kept off
 // the top-level bundle so apps that don't need deep binding pay no size cost.

--- a/packages/core/src/persistence.ts
+++ b/packages/core/src/persistence.ts
@@ -145,3 +145,59 @@ export function persistedSignal<T>(
 
   return sig;
 }
+
+/**
+ * A namespaced persistence surface — exposes a `persistedSignal` that
+ * prepends a fixed prefix to every storage key, joined by `":"`.
+ */
+export interface StorageNamespace {
+  /**
+   * Like {@link persistedSignal}, but the storage key is transparently
+   * rewritten to `${prefix}:${key}`. The underlying storage behaviour is
+   * unchanged — SSR-safe, schema-validated, quota-safe.
+   */
+  persistedSignal<T>(
+    key: string,
+    initial: T,
+    options?: PersistedSignalOptions<T>,
+  ): Signal<T>;
+}
+
+/**
+ * Create a key-prefixed view over `persistedSignal` so several apps on the
+ * same origin can coexist without stomping on each other's storage slots.
+ *
+ * ```ts
+ * import { createStorageNamespace } from "@whisq/core/persistence";
+ *
+ * const app = createStorageNamespace("whisq-todo-app");
+ * export const todos = app.persistedSignal<Todo[]>("todos", []);
+ * //                                                ^ actual key: "whisq-todo-app:todos"
+ * export const settings = app.persistedSignal<Settings>("settings", DEFAULTS);
+ * ```
+ *
+ * Two namespaces with distinct prefixes never collide; within one namespace,
+ * keys follow the usual `persistedSignal` shape. The helper is a
+ * compositional thin wrapper — calling `app.persistedSignal(k, v, opts)` is
+ * exactly equivalent to `persistedSignal(\`${prefix}:${k}\`, v, opts)`.
+ *
+ * Empty or whitespace prefixes are rejected — they defeat the purpose and
+ * most often indicate the caller forgot to interpolate an app name.
+ */
+export function createStorageNamespace(prefix: string): StorageNamespace {
+  if (typeof prefix !== "string" || prefix.trim().length === 0) {
+    throw new TypeError(
+      "createStorageNamespace: prefix must be a non-empty string",
+    );
+  }
+
+  return {
+    persistedSignal<T>(
+      key: string,
+      initial: T,
+      options?: PersistedSignalOptions<T>,
+    ): Signal<T> {
+      return persistedSignal<T>(`${prefix}:${key}`, initial, options);
+    },
+  };
+}

--- a/packages/core/src/subpath-stubs.ts
+++ b/packages/core/src/subpath-stubs.ts
@@ -1,0 +1,89 @@
+// ============================================================================
+// Whisq Core — Sub-path import guard stubs
+//
+// The main `@whisq/core` entry is deliberately small — persistence, id
+// generation, reactive collections, and nested-path forms live behind
+// sub-path exports (`@whisq/core/persistence`, `/ids`, `/collections`,
+// `/forms`) so an app that doesn't use them pays no bundle cost.
+//
+// The downside of that split: a user (or AI) writing
+//   import { partition } from "@whisq/core";
+// gets the generic bundler error ("partition is not exported") with no
+// hint that the symbol exists — it's just on another path. This module
+// re-exports those sub-path names as runtime stubs from the main entry.
+// Importing one silently compiles; calling it throws with a message that
+// names the correct sub-path and links to the docs page. Zero behavioural
+// impact on callers who import correctly from the sub-path.
+//
+// Bundle impact: `@whisq/core` has `sideEffects: false`, so any stub the
+// user didn't actually import is dropped by the bundler's unused-export
+// elimination. In practice: if `import { signal } from "@whisq/core"` is
+// all the user wrote, none of these stubs appear in the output bundle.
+// The `bench:shake` script verifies this on every release.
+// ============================================================================
+
+function subpathError(
+  name: string,
+  subpath: string,
+  slug: string,
+): Error {
+  return new Error(
+    `[whisq] "${name}" is not exported from "@whisq/core". ` +
+      `Import it from "@whisq/core/${subpath}" instead. ` +
+      `See https://whisq.dev/api/${slug}/`,
+  );
+}
+
+/**
+ * @deprecated Import `partition` from `@whisq/core/collections` instead.
+ * Calling this re-export at runtime throws with the correct sub-path.
+ * See https://whisq.dev/api/partition/
+ */
+export function partition(..._args: unknown[]): never {
+  throw subpathError("partition", "collections", "partition");
+}
+
+/**
+ * @deprecated Import `signalMap` from `@whisq/core/collections` instead.
+ * Calling this re-export at runtime throws with the correct sub-path.
+ * See https://whisq.dev/api/signalmap/
+ */
+export function signalMap(..._args: unknown[]): never {
+  throw subpathError("signalMap", "collections", "signalmap");
+}
+
+/**
+ * @deprecated Import `signalSet` from `@whisq/core/collections` instead.
+ * Calling this re-export at runtime throws with the correct sub-path.
+ * See https://whisq.dev/api/signalset/
+ */
+export function signalSet(..._args: unknown[]): never {
+  throw subpathError("signalSet", "collections", "signalset");
+}
+
+/**
+ * @deprecated Import `randomId` from `@whisq/core/ids` instead.
+ * Calling this re-export at runtime throws with the correct sub-path.
+ * See https://whisq.dev/api/randomid/
+ */
+export function randomId(..._args: unknown[]): never {
+  throw subpathError("randomId", "ids", "randomid");
+}
+
+/**
+ * @deprecated Import `persistedSignal` from `@whisq/core/persistence` instead.
+ * Calling this re-export at runtime throws with the correct sub-path.
+ * See https://whisq.dev/api/persistedsignal/
+ */
+export function persistedSignal(..._args: unknown[]): never {
+  throw subpathError("persistedSignal", "persistence", "persistedsignal");
+}
+
+/**
+ * @deprecated Import `bindPath` from `@whisq/core/forms` instead.
+ * Calling this re-export at runtime throws with the correct sub-path.
+ * See https://whisq.dev/api/bindpath/
+ */
+export function bindPath(..._args: unknown[]): never {
+  throw subpathError("bindPath", "forms", "bindpath");
+}

--- a/packages/create-whisq/CHANGELOG.md
+++ b/packages/create-whisq/CHANGELOG.md
@@ -1,5 +1,7 @@
 # create-whisq
 
+## 0.1.0-alpha.10
+
 ## 0.1.0-alpha.9
 
 ## 0.1.0-alpha.8

--- a/packages/create-whisq/CHANGELOG.md
+++ b/packages/create-whisq/CHANGELOG.md
@@ -1,5 +1,7 @@
 # create-whisq
 
+## 0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ### Minor Changes

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/package.json
+++ b/packages/create-whisq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-whisq",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "Scaffold a new Whisq project",
   "type": "module",
   "bin": {

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.8",
-    "@whisq/router": "^0.1.0-alpha.8"
+    "@whisq/core": "^0.1.0-alpha.9",
+    "@whisq/router": "^0.1.0-alpha.9"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/full-app/package.json.tmpl
+++ b/packages/create-whisq/src/templates/full-app/package.json.tmpl
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.9",
-    "@whisq/router": "^0.1.0-alpha.9"
+    "@whisq/core": "^0.1.0-alpha.10",
+    "@whisq/router": "^0.1.0-alpha.10"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.8"
+    "@whisq/core": "^0.1.0-alpha.9"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/minimal/package.json.tmpl
+++ b/packages/create-whisq/src/templates/minimal/package.json.tmpl
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.9"
+    "@whisq/core": "^0.1.0-alpha.10"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.8",
-    "@whisq/ssr": "^0.1.0-alpha.8"
+    "@whisq/core": "^0.1.0-alpha.9",
+    "@whisq/ssr": "^0.1.0-alpha.9"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/ssr/package.json.tmpl
+++ b/packages/create-whisq/src/templates/ssr/package.json.tmpl
@@ -10,8 +10,8 @@
     "serve": "node dist/server/index.js"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.9",
-    "@whisq/ssr": "^0.1.0-alpha.9"
+    "@whisq/core": "^0.1.0-alpha.10",
+    "@whisq/ssr": "^0.1.0-alpha.10"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.9",
-    "@whisq/router": "^0.1.0-alpha.9"
+    "@whisq/core": "^0.1.0-alpha.10",
+    "@whisq/router": "^0.1.0-alpha.10"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.9",
+    "@whisq/vite-plugin": "^0.1.0-alpha.10",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
+++ b/packages/create-whisq/src/templates/vite-plugin/package.json.tmpl
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@whisq/core": "^0.1.0-alpha.8",
-    "@whisq/router": "^0.1.0-alpha.8"
+    "@whisq/core": "^0.1.0-alpha.9",
+    "@whisq/router": "^0.1.0-alpha.9"
   },
   "devDependencies": {
-    "@whisq/vite-plugin": "^0.1.0-alpha.8",
+    "@whisq/vite-plugin": "^0.1.0-alpha.9",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/devtools
 
+## 0.1.0-alpha.10
+
+### Patch Changes
+
+- Updated dependencies [987fde7]
+- Updated dependencies [fe295e0]
+- Updated dependencies [94caac8]
+- Updated dependencies [310dd97]
+  - @whisq/core@0.1.0-alpha.10
+
 ## 0.1.0-alpha.9
 
 ### Patch Changes

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/devtools
 
+## 0.1.0-alpha.9
+
+### Patch Changes
+
+- Updated dependencies [defc7eb]
+- Updated dependencies [c8f2bec]
+- Updated dependencies [e6d59c4]
+- Updated dependencies [75d2d8e]
+  - @whisq/core@0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ### Patch Changes

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/devtools",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "DevTools runtime hook for Whisq — signal inspection, component tree, effect tracking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/mcp-server
 
+## 0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ## 0.1.0-alpha.7

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,41 @@
 # @whisq/mcp-server
 
+## 0.1.0-alpha.10
+
+### Minor Changes
+
+- fe295e0: **Spike:** first slice of the enriched `public-api.json` from #103 — ships a drift-validated per-symbol metadata manifest, populates it for the `signals` topic, and wires the MCP server's `signals` docs to consume it.
+
+  ### `@whisq/core`
+  - New artefact: `dist/public-api-annotated.json`. Schema spec at `packages/core/docs/api-metadata-schema.md`. Current shape — `{ version, schemaVersion: 1, symbols: SymbolEntry[] }` — is frozen behind `schemaVersion` so consumers can guard against breaking changes.
+  - New exports-map entry: `"@whisq/core/public-api-annotated.json"` — the public path consumers import from.
+  - Hand-curated source of truth at `packages/core/metadata/api-enrichment.json`. The build step runs `scripts/generate-api-metadata.mjs` after `generate-public-api.mjs` and fails with a non-zero exit if:
+    - a `symbols[*].name` is not in `public-api.json` exports (drift),
+    - a `seeAlso[*]` reference is not in `public-api.json` exports (drift),
+    - any required field on a `SymbolEntry` is missing or wrong type,
+    - a duplicate symbol entry appears.
+  - Populated for one topic this release: `signals` (`signal`, `computed`, `effect`, `batch`). The names-only `public-api.json` is unchanged — this is a sibling file, not a replacement. See #103 for the path to unification.
+
+  ### `@whisq/mcp-server`
+  - New `@whisq/core` workspace dependency (was previously untyped docs; now consumes the annotated manifest).
+  - `api-docs.ts` `signals` topic is generated from the enriched manifest at build time — no more hand-written drift. The other topics (`elements`, `components`, `routing`, …) remain hand-written until the schema stabilises; migrating them is a follow-up tracked against #103.
+  - Load-bearing phrases consumers grep for (`signal(`, `computed(`, `.value`, `peek()`, `batch(() =>`) are locked in by a new regression test block.
+
+  ### Out of scope (follow-ups)
+  - CI drift check between `public-api.json` and `public-api-annotated.json` (all existing exports must have enrichment) — follow-up once the other topics migrate.
+  - Migrating the remaining MCP topics — mechanical once this spike's shape is validated across a release cycle.
+  - Unifying the two manifests into one — option A in #103; gated on 1–2 releases of stable schema.
+
+  Closes #138.
+
+### Patch Changes
+
+- Updated dependencies [987fde7]
+- Updated dependencies [fe295e0]
+- Updated dependencies [94caac8]
+- Updated dependencies [310dd97]
+  - @whisq/core@0.1.0-alpha.10
+
 ## 0.1.0-alpha.9
 
 ## 0.1.0-alpha.8

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/mcp-server",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "MCP server for Whisq — AI tool integrations for component scaffolding and code validation",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -35,6 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@whisq/core": "workspace:*",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/packages/mcp-server/src/__tests__/api-docs.test.ts
+++ b/packages/mcp-server/src/__tests__/api-docs.test.ts
@@ -15,6 +15,52 @@ describe("queryApi", () => {
     expect(result.content).toContain("computed(");
   });
 
+  describe("signals topic — load-bearing phrases after migration to enriched manifest (WHISQ-138)", () => {
+    // The signals topic is now generated from the @whisq/core enriched
+    // manifest rather than hand-written. These assertions pin the phrases
+    // consumers have depended on so a metadata edit can't silently drop them.
+    const content = queryApi("signals").content;
+
+    it("keeps the top-level '# Signals' heading", () => {
+      expect(content).toMatch(/^# Signals/);
+    });
+
+    it("covers the four core reactive primitives in their signature form", () => {
+      for (const snippet of [
+        "signal<T>(initial: T)",
+        "computed<T>(fn: () => T)",
+        "effect(fn:",
+        "batch(fn:",
+      ]) {
+        expect(content).toContain(snippet);
+      }
+    });
+
+    it("keeps the canonical usage phrases that API consumers grep for", () => {
+      for (const phrase of [
+        ".value",
+        "peek()",
+        "count.update",
+        "computed(() =>",
+        "batch(() =>",
+      ]) {
+        expect(content).toContain(phrase);
+      }
+    });
+
+    it("surfaces the array-mutation and stale-child gotchas (the two top signal footguns)", () => {
+      expect(content).toMatch(/items\.value\.push.*does not trigger/i);
+      expect(content).toMatch(/captures the value once/i);
+    });
+
+    it("links related primitives via See also", () => {
+      expect(content).toContain("**See also:**");
+      expect(content).toContain("computed");
+      expect(content).toContain("effect");
+      expect(content).toContain("batch");
+    });
+  });
+
   it("returns elements docs", () => {
     const result = queryApi("elements");
     expect(result.content).toContain("div(");

--- a/packages/mcp-server/src/tools/api-docs.ts
+++ b/packages/mcp-server/src/tools/api-docs.ts
@@ -1,7 +1,15 @@
 /**
  * Query Whisq API reference by topic. Returns structured documentation
  * that AI tools can use to generate accurate code.
+ *
+ * Topics are mostly hand-written below. The `signals` topic is generated
+ * from the enriched manifest shipped by @whisq/core (see WHISQ-138):
+ * `@whisq/core/public-api-annotated.json` is the drift-validated source of
+ * truth. The other topics remain hand-written for now — migrating them is
+ * tracked against #103.
  */
+
+import annotatedManifest from "@whisq/core/public-api-annotated.json" with { type: "json" };
 
 export type ApiTopic =
   | "signals"
@@ -19,6 +27,72 @@ export type ApiTopic =
 export interface ApiDocResult {
   topic: string;
   content: string;
+}
+
+interface EnrichedSymbol {
+  name: string;
+  kind: string;
+  signature: string;
+  summary: string;
+  gotchas: string[];
+  examples: string[];
+  since: string;
+  seeAlso: string[];
+  topic: string;
+}
+
+interface EnrichedManifest {
+  version: string;
+  schemaVersion: number;
+  symbols: EnrichedSymbol[];
+}
+
+const MANIFEST = annotatedManifest as EnrichedManifest;
+
+const TOPIC_TITLES: Record<ApiTopic, string> = {
+  overview: "Whisq API Overview",
+  signals: "Signals",
+  elements: "Elements",
+  components: "Components",
+  routing: "Routing (@whisq/router)",
+  styling: "Styling",
+  forms: "Forms",
+  lists: "Lists",
+  async: "Async Data",
+  ssr: "SSR (@whisq/ssr)",
+  testing: "Testing (@whisq/testing)",
+};
+
+function renderSymbol(symbol: EnrichedSymbol): string {
+  const parts: string[] = [];
+  parts.push(`## ${symbol.signature}`);
+  parts.push("");
+  parts.push(symbol.summary);
+  for (const example of symbol.examples) {
+    parts.push("");
+    parts.push("```ts");
+    parts.push(example);
+    parts.push("```");
+  }
+  if (symbol.gotchas.length > 0) {
+    parts.push("");
+    parts.push("**Gotchas:**");
+    for (const gotcha of symbol.gotchas) {
+      parts.push(`- ${gotcha}`);
+    }
+  }
+  if (symbol.seeAlso.length > 0) {
+    parts.push("");
+    parts.push(`**See also:** ${symbol.seeAlso.join(", ")}`);
+  }
+  return parts.join("\n");
+}
+
+function renderTopicFromManifest(topic: ApiTopic): string {
+  const title = TOPIC_TITLES[topic];
+  const symbols = MANIFEST.symbols.filter((s) => s.topic === topic);
+  const sections = symbols.map((s) => renderSymbol(s));
+  return [`# ${title}`, "", ...sections].join("\n");
 }
 
 const DOCS: Record<ApiTopic, string> = {
@@ -40,40 +114,7 @@ Whisq is an AI-native JavaScript/TypeScript framework. No JSX, no build step.
 import { signal, computed, effect, batch, div, span, button, component, mount } from "@whisq/core";
 \`\`\``,
 
-  signals: `# Signals
-
-## signal(initialValue)
-Create a reactive value.
-\`\`\`ts
-const count = signal(0);
-count.value;           // read (triggers tracking)
-count.value = 5;       // write (triggers updates)
-count.update(n => n + 1); // update via function
-count.peek();          // read WITHOUT tracking
-\`\`\`
-
-## computed(fn)
-Derived value that auto-updates when dependencies change.
-\`\`\`ts
-const doubled = computed(() => count.value * 2);
-\`\`\`
-
-## effect(fn)
-Side effect that re-runs when dependencies change.
-\`\`\`ts
-const dispose = effect(() => console.log(count.value));
-dispose(); // cleanup
-\`\`\`
-
-## batch(fn)
-Batch multiple signal updates into one notification.
-\`\`\`ts
-batch(() => { x.value = 1; y.value = 2; }); // one update cycle
-\`\`\`
-
-## Anti-patterns
-- items.value.push(x) — won't trigger. Use: items.value = [...items.value, x]
-- count.value as child — wrap in function: () => count.value`,
+  signals: renderTopicFromManifest("signals"),
 
   elements: `# Elements
 

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/router
 
+## 0.1.0-alpha.10
+
+### Patch Changes
+
+- Updated dependencies [987fde7]
+- Updated dependencies [fe295e0]
+- Updated dependencies [94caac8]
+- Updated dependencies [310dd97]
+  - @whisq/core@0.1.0-alpha.10
+
 ## 0.1.0-alpha.9
 
 ### Patch Changes

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/router
 
+## 0.1.0-alpha.9
+
+### Patch Changes
+
+- Updated dependencies [defc7eb]
+- Updated dependencies [c8f2bec]
+- Updated dependencies [e6d59c4]
+- Updated dependencies [75d2d8e]
+  - @whisq/core@0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ### Patch Changes

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/router",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "Signal-based router for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,42 @@
 # @whisq/sandbox
 
+## 0.1.0-alpha.9
+
+### Minor Changes
+
+- 308304d: Add `mountSandboxed()` — render AI-generated (or otherwise untrusted) Whisq source into an isolated iframe on the current page. Complements the existing `createSandbox()` primitive (which evaluates code and returns a value) by covering the rendering-isolation use case that ArrowJS's WASM sandbox is known for — without the WASM cost.
+
+  ```ts
+  import { mountSandboxed } from "@whisq/sandbox";
+
+  const handle = mountSandboxed({
+    source: `
+      import { div, signal } from "@whisq/core";
+      const n = signal(0);
+      setInterval(() => (n.value += 1), 1000);
+      document.body.append(div(() => String(n.value)).el);
+      window.__whisqPost({ type: "ready" });
+    `,
+    container: document.getElementById("agent-output")!,
+    importMap: { "@whisq/core": "https://esm.sh/@whisq/core@latest" },
+    onMessage: (msg) => console.log("from sandbox:", msg),
+  });
+
+  handle.postMessage({ type: "shutdown" });
+  handle.dispose();
+  ```
+
+  Isolation is standards-only:
+  - `<iframe sandbox="allow-scripts">` — unique origin; no same-origin access, no forms, no popups, no top-navigation.
+  - `<meta http-equiv="Content-Security-Policy">` in the iframe's srcdoc — default policy is `default-src 'none'` with `script-src` allowing inline + origins from your `importMap`; override via `cspDirectives`.
+  - `srcdoc` rather than `src=` — no network navigation; the iframe is a blank document we write into.
+  - `__whisq`-tagged postMessage bridge — other frames can't spoof messages into the parent's `onMessage` callback. Parent-to-iframe messages arrive as a `whisq:parent` `CustomEvent` on the iframe-side `window`.
+  - `</script>` and HTML comment closers inside the user source are escaped to prevent srcdoc injection.
+
+  API shape is deliberately scaffolded so future `isolation: "worker"` / `isolation: "wasm"` backends can land without a breaking change.
+
+  Closes WHISQ-118.
+
 ## 0.1.0-alpha.8
 
 ## 0.1.0-alpha.7

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/sandbox
 
+## 0.1.0-alpha.10
+
 ## 0.1.0-alpha.9
 
 ### Minor Changes

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/sandbox",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Sandboxed code execution for Whisq — isolated environment with configurable limits",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/ssr
 
+## 0.1.0-alpha.9
+
+### Patch Changes
+
+- Updated dependencies [defc7eb]
+- Updated dependencies [c8f2bec]
+- Updated dependencies [e6d59c4]
+- Updated dependencies [75d2d8e]
+  - @whisq/core@0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ### Patch Changes

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/ssr
 
+## 0.1.0-alpha.10
+
+### Patch Changes
+
+- Updated dependencies [987fde7]
+- Updated dependencies [fe295e0]
+- Updated dependencies [94caac8]
+- Updated dependencies [310dd97]
+  - @whisq/core@0.1.0-alpha.10
+
 ## 0.1.0-alpha.9
 
 ### Patch Changes

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/ssr",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Server-side rendering for Whisq applications",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/testing
 
+## 0.1.0-alpha.10
+
+### Patch Changes
+
+- Updated dependencies [987fde7]
+- Updated dependencies [fe295e0]
+- Updated dependencies [94caac8]
+- Updated dependencies [310dd97]
+  - @whisq/core@0.1.0-alpha.10
+
 ## 0.1.0-alpha.9
 
 ### Patch Changes

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @whisq/testing
 
+## 0.1.0-alpha.9
+
+### Patch Changes
+
+- Updated dependencies [defc7eb]
+- Updated dependencies [c8f2bec]
+- Updated dependencies [e6d59c4]
+- Updated dependencies [75d2d8e]
+  - @whisq/core@0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/testing",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Testing utilities for Whisq components — render, screen queries, fireEvent",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/vite-plugin
 
+## 0.1.0-alpha.9
+
 ## 0.1.0-alpha.8
 
 ## 0.1.0-alpha.7

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @whisq/vite-plugin
 
+## 0.1.0-alpha.10
+
 ## 0.1.0-alpha.9
 
 ## 0.1.0-alpha.8

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whisq/vite-plugin",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Vite plugin for Whisq — file-based routing, HMR, and optimized builds",
   "type": "module",
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
+      '@whisq/core':
+        specifier: workspace:*
+        version: link:../core
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -2805,14 +2808,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
-
   '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -3910,7 +3905,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
Release PR for **v0.1.0-alpha.10**.

Reopened from the user account because the original bot-opened PR (#144) didn't trigger CI — GitHub Actions anti-recursion means PRs authored by `app/whisq-bot` don't fire the `CI` workflow. Closing+reopening doesn't flip the author; a fresh PR does.

## What's shipping

Four `@whisq/core: minor` changesets — rolls the `fixed` group (all `@whisq/*` + `create-whisq`) from `0.1.0-alpha.9` to `0.1.0-alpha.10`:

- **compose-bind-helper** (#132) — `compose(bindResult, extras)` for order-independent `bind()` / `bindField()` / `bindPath()` handler composition.
- **subpath-friendly-errors** (#133) — runtime stubs on `@whisq/core` main entry for 6 sub-path-only symbols (`partition`, `signalMap`, `signalSet`, `randomId`, `persistedSignal`, `bindPath`).
- **small-utility-helpers-omnibus** (#134) — `createStorageNamespace(prefix)` on `@whisq/core/persistence`; `randomId({ prefix, rng })` on `@whisq/core/ids`.
- **enriched-api-metadata-spike** (#138) — first slice of the `public-api-annotated.json` manifest (signals topic), schema at `packages/core/docs/api-metadata-schema.md`, MCP server signals topic now generated from the manifest.

## Also merged (intentionally no changeset — `skip-changeset`)

- **#142 (WHISQ-140)** — `packages/core/scripts/resolve-latest-api.mjs` resolver + post-publish `unpkg @latest` CDN-propagation check in `release.yml` (warn-only). Root-cause fix for the CDN-lag footgun surfaced in Codex alpha.9 feedback. Will run for the first time on this release.
- **#143 (WHISQ-141)** — `examples/template-todo` filter UI (all/active/done). Completes the Codex "complete todo example" ask.

## Release pipeline (automated)

Merging this PR into `main` triggers `.github/workflows/release.yml`:
1. Re-runs build + test as a safety net
2. `pnpm run release` publishes all bumped packages to npm (with provenance)
3. Creates per-package git tags + GitHub Releases
4. New warn-only step (from #142): fetches `unpkg.com/@whisq/core@latest/dist/public-api.json` post-publish and emits a `::warning::` annotation if the CDN is still serving alpha.9 during the propagation window. Won't fail the release.
5. Opens a follow-up PR to back-merge `main` → `develop`

See each package's `CHANGELOG.md` (in the diff) for full per-package release notes.

## Verification

- [x] `pnpm build` locally on the release branch — 9 tasks green
- [x] `pnpm test` locally on the release branch — 18 tasks / 634 tests green
- [x] `node scripts/check-versions.mjs` — 9 packages + 4 templates + 1 example aligned at `0.1.0-alpha.10`
- [x] All four feature branches passed CI before merging to develop
- [ ] CI on this PR (once user-authored: audit, build, lint, test, typecheck, version-consistency, license-check, CodeQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)